### PR TITLE
Fix for Flyway

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,7 +112,7 @@ tasks {
 
     shadowJar {
         filesMatching("META-INF/services/**") {
-            duplicatesStrategy = DuplicatesStrategy.INCLUDE
+            duplicatesStrategy = DuplicatesStrategy.WARN
         }
         mergeServiceFiles()
         archiveFileName.set("app.jar")


### PR DESCRIPTION
## Solves the Flyway 11.14 problem with location.

Allow any duplicate service providers found during build, and merge them. 