### PR TITLE
store when utkast was created

### DIFF
--- a/src/main/resources/db/migration/V6__add_colum_utkast_created_at.sql
+++ b/src/main/resources/db/migration/V6__add_colum_utkast_created_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oppfolgingsplan
+    ADD COLUMN utkast_created_at TIMESTAMPTZ;

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
@@ -346,6 +346,8 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
                     createUtkastRequest = defaultUtkast()
                 )
 
+                val existingUtkast = testDb.findOppfolgingsplanUtkastBy(sykmeldt.fnr, sykmeldt.orgnummer)
+
                 val oppfolgingsplan = defaultOppfolgingsplan()
 
                 // Act
@@ -360,8 +362,9 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
                 response.status shouldBe HttpStatusCode.Created
                 val persistedOppfolgingsplaner = testDb.findAllOppfolgingsplanerBy("12345678901", "orgnummer")
                 persistedOppfolgingsplaner.size shouldBe 1
+                persistedOppfolgingsplaner.first().utkastCreatedAt shouldBe existingUtkast?.createdAt
 
-                val persistedUtkast = testDb.findOppfolgingsplanUtkastBy("12345678901", "orgnummer")
+                val persistedUtkast = testDb.findOppfolgingsplanUtkastBy(sykmeldt.fnr, sykmeldt.orgnummer)
                 persistedUtkast shouldBe null
                 verify(exactly = 1) {
                     esyfovarselProducerMock.sendVarselToEsyfovarsel(withArg {


### PR DESCRIPTION
Målet med denne PR'n er å gjøre det mulig for Datafortellinger å finne ut hvor lang tid det har gått siden en oppfølgingplan ble påbegynt, til den er ferdigstilt. Dette kan nå gjøres ved å sammenligne `utkast_created_at` med `created_at` i tabellen `oppfolgingsplan`