### PR TITLE
only cache sykmeldt if aktivSykmelding

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/valkey/ValkeyCache.kt
+++ b/src/main/kotlin/no/nav/syfo/application/valkey/ValkeyCache.kt
@@ -73,7 +73,7 @@ class ValkeyCache(
     }
 
     companion object {
-        const val CACHE_TTL_SECONDS = 3600L
+        const val CACHE_TTL_SECONDS = 900L // 15 minutes
         const val DINE_SYKMELDTE_CACHE_KEY_PREFIX = "dinesykmeldte"
     }
 }

--- a/src/main/kotlin/no/nav/syfo/dinesykmeldte/DineSykmeldteService.kt
+++ b/src/main/kotlin/no/nav/syfo/dinesykmeldte/DineSykmeldteService.kt
@@ -27,7 +27,9 @@ class DineSykmeldteService(
         COUNT_CACHE_MISS_DINE_SYKMELDTE.increment()
         return try {
             val sykmeldt = dineSykmeldteHttpClient.getSykmeldtForNarmesteLederId(narmestelederId, accessToken)
-            valkeyCache.putSykmeldt(lederFnr, narmestelederId, sykmeldt)
+            if (sykmeldt.aktivSykmelding == true) {
+                valkeyCache.putSykmeldt(lederFnr, narmestelederId, sykmeldt)
+            }
             return sykmeldt
         } catch (clientRequestException: ClientRequestException) {
             when (clientRequestException.response.status) {


### PR DESCRIPTION
Vi trenger egentlig ikke cache sykmeldt hvis personen ikke er aktivt sykmeldt, siden arbeidsgiver da ikke kommer til å skrive en plan. Skrur også ned ttl.