### PR TITLE
Return tidspunkt from deling endpoints

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/OppfolgingsplanResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/OppfolgingsplanResponse.kt
@@ -27,3 +27,11 @@ data class CreateOppfolgingsplanRequest(
     val content: FormSnapshot,
     val evalueringsdato: LocalDate,
 )
+
+data class DelMedLegeResponse(
+    val deltMedLegeTidspunkt: Instant,
+)
+
+data class DelMedVeilederResponse(
+    val deltMedVeilederTidspunkt: Instant,
+)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
@@ -171,10 +171,14 @@ class OppfolgingsplanService(
     suspend fun updateDelingAvPlanMedVeileder(
         uuid: UUID,
         journalpostId: String,
-    ) {
+    ): Instant {
+        val deltMedVeilederTidspunkt = Instant.now()
+
         withContext(Dispatchers.IO) {
-            database.updateDelingAvPlanMedVeileder(uuid, Instant.now(), journalpostId)
+            database.updateDelingAvPlanMedVeileder(uuid, deltMedVeilederTidspunkt, journalpostId)
         }
+
+        return deltMedVeilederTidspunkt;
     }
 
     suspend fun getAktivplanForSykmeldt(sykmeldt: Sykmeldt): PersistedOppfolgingsplan? {

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.ktor.client.call.body
@@ -52,6 +53,8 @@ import no.nav.syfo.oppfolgingsplan.db.findAllOppfolgingsplanerBy
 import no.nav.syfo.oppfolgingsplan.db.findOppfolgingsplanUtkastBy
 import no.nav.syfo.oppfolgingsplan.db.upsertOppfolgingsplanUtkast
 import no.nav.syfo.oppfolgingsplan.dto.ArbeidsgiverOppfolgingsplanOverviewResponse
+import no.nav.syfo.oppfolgingsplan.dto.DelMedLegeResponse
+import no.nav.syfo.oppfolgingsplan.dto.DelMedVeilederResponse
 import no.nav.syfo.oppfolgingsplan.dto.OppfolgingsplanResponse
 import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
 import no.nav.syfo.pdfgen.PdfGenService
@@ -586,6 +589,10 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
             }
             // Assert
             response.status shouldBe HttpStatusCode.OK
+
+            val responseBody = response.body<DelMedLegeResponse>()
+            responseBody.deltMedLegeTidspunkt.shouldNotBeNull()
+
             val plan = testDb.findAllOppfolgingsplanerBy("12345678901", "orgnummer").first { it.uuid == uuid }
             plan.skalDelesMedLege shouldBe true
             plan.deltMedLegeTidspunkt shouldNotBe null
@@ -703,10 +710,15 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
             }
             // Assert
             response.status shouldBe HttpStatusCode.OK
+
+            val responseBody = response.body<DelMedVeilederResponse>()
+            responseBody.deltMedVeilederTidspunkt.shouldNotBeNull()
+
             val plan = testDb.findAllOppfolgingsplanerBy("12345678901", "orgnummer").first { it.uuid == uuid }
             plan.skalDelesMedVeileder shouldBe true
             plan.deltMedVeilederTidspunkt shouldNotBe null
             plan.journalpostId shouldBe randomJournalpostId
+
             coVerify(exactly = 1) {
                 dokarkivServiceMock.arkiverOppfolgingsplan(any(), any())
             }


### PR DESCRIPTION
Return deltMedLegeTidspunkt og deltMedVeilederTidspunkt from deling endpoints

So that frontend can show correct tidspunkt without having to do another get request.

Henger sammen med https://github.com/navikt/syfo-oppfolgingsplan-frontend/pull/541.