### PR TITLE
fix(verify): add merge_group trigger for merge queue compatibility

### DIFF
--- a/.github/workflows/hovmester-verify.yml
+++ b/.github/workflows/hovmester-verify.yml
@@ -3,10 +3,11 @@ name: Verify and merge hovmester sync
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+  merge_group:
 
 jobs:
   verify-hovmester-sync:
-    if: github.head_ref == 'hovmester-sync' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'merge_group' || (github.head_ref == 'hovmester-sync' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
## Problem

`pull_request_target` does not fire in merge queue context, causing `verify-hovmester-sync` to show as **Expected — Waiting for status to be reported** and blocking auto-merge of hovmester sync PRs.

## Fix

Add `merge_group` trigger to `hovmester-verify.yml`. When the PR enters the merge queue:
- Verification already happened on `pull_request_target` (scope check + auto-approve)
- `merge_group` event fires → job condition doesn't match → job skips → GitHub reports neutral/success
- Merge queue gets the green light

The `if` condition is updated to: `github.event_name == 'merge_group' || (existing conditions)`