### PR TITLE
feat(aareg): integrate AREG v2 for stillingstittel and stillingsprosent

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,6 +88,7 @@ dependencies {
     testImplementation("io.insert-koin:koin-test:$koinVersion")
     testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
     testImplementation("io.kotest.extensions:kotest-extensions-koin:1.3.0")
+    testImplementation("org.wiremock:wiremock:3.13.1")
     testImplementation("org.testcontainers:testcontainers:$testcontainersVersion")
     testImplementation("org.testcontainers:postgresql:$testcontainersVersion")
 }

--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -85,7 +85,7 @@ spec:
       external:
         - host: dokarkiv.dev-fss-pub.nais.io
         - host: pdl-api.dev-fss-pub.nais.io
-        - host: aareg-services-nais-q2.dev-fss-pub.nais.io
+        - host: aareg-services-q2.dev-fss-pub.nais.io
   kafka:
     pool: nav-dev
   valkey:
@@ -115,7 +115,7 @@ spec:
     - name: PDL_SCOPE
       value: dev-fss.pdl.pdl-api
     - name: AAREG_BASE_URL
-      value: https://aareg-services-nais-q2.dev-fss-pub.nais.io
+      value: https://aareg-services-q2.dev-fss-pub.nais.io
     - name: AAREG_SCOPE
       value: dev-fss.arbeidsforhold.aareg-services-nais
     - name: SYFOMODIAPERSON_CLIENT_ID

--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -85,6 +85,7 @@ spec:
       external:
         - host: dokarkiv.dev-fss-pub.nais.io
         - host: pdl-api.dev-fss-pub.nais.io
+        - host: aareg-services-nais-q2.dev-fss-pub.nais.io
   kafka:
     pool: nav-dev
   valkey:
@@ -113,6 +114,10 @@ spec:
       value: https://pdl-api.dev-fss-pub.nais.io/graphql
     - name: PDL_SCOPE
       value: dev-fss.pdl.pdl-api
+    - name: AAREG_BASE_URL
+      value: https://aareg-services-nais-q2.dev-fss-pub.nais.io
+    - name: AAREG_SCOPE
+      value: dev-fss.arbeidsforhold.aareg-services-nais
     - name: SYFOMODIAPERSON_CLIENT_ID
       value: dev-gcp:teamsykefravr:syfomodiaperson
     - name: SYFO_OPPFOLGINGSPLAN_FRONTEND_CLIENT_ID

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -81,6 +81,7 @@ spec:
       external:
         - host: dokarkiv.prod-fss-pub.nais.io
         - host: pdl-api.prod-fss-pub.nais.io
+        - host: aareg-services-nais.prod-fss-pub.nais.io
   kafka:
     pool: nav-prod
   valkey:
@@ -109,6 +110,10 @@ spec:
       value: https://pdl-api.prod-fss-pub.nais.io/graphql
     - name: PDL_SCOPE
       value: prod-fss.pdl.pdl-api
+    - name: AAREG_BASE_URL
+      value: https://aareg-services-nais.prod-fss-pub.nais.io
+    - name: AAREG_SCOPE
+      value: prod-fss.arbeidsforhold.aareg-services-nais
     - name: SYFOMODIAPERSON_CLIENT_ID
       value: prod-gcp:teamsykefravr:syfomodiaperson
     - name: SYFO_OPPFOLGINGSPLAN_FRONTEND_CLIENT_ID

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -81,7 +81,7 @@ spec:
       external:
         - host: dokarkiv.prod-fss-pub.nais.io
         - host: pdl-api.prod-fss-pub.nais.io
-        - host: aareg-services-nais.prod-fss-pub.nais.io
+        - host: aareg-services.prod-fss-pub.nais.io
   kafka:
     pool: nav-prod
   valkey:
@@ -111,7 +111,7 @@ spec:
     - name: PDL_SCOPE
       value: prod-fss.pdl.pdl-api
     - name: AAREG_BASE_URL
-      value: https://aareg-services-nais.prod-fss-pub.nais.io
+      value: https://aareg-services.prod-fss-pub.nais.io
     - name: AAREG_SCOPE
       value: prod-fss.arbeidsforhold.aareg-services-nais
     - name: SYFOMODIAPERSON_CLIENT_ID

--- a/src/main/kotlin/no/nav/syfo/aareg/AaregModels.kt
+++ b/src/main/kotlin/no/nav/syfo/aareg/AaregModels.kt
@@ -1,0 +1,41 @@
+package no.nav.syfo.aareg
+
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class Arbeidsforhold(
+    val arbeidssted: Arbeidssted,
+    val ansettelsesperiode: Periode,
+    val ansettelsesdetaljer: List<Ansettelsesdetaljer> = emptyList(),
+)
+
+data class Ansettelsesdetaljer(
+    val rapporteringsmaaneder: Periode,
+    val yrke: Kodeverksentitet? = null,
+    val avtaltStillingsprosent: BigDecimal? = null,
+)
+
+data class Kodeverksentitet(
+    val kode: String? = null,
+    val beskrivelse: String? = null,
+)
+
+data class Arbeidssted(
+    val identer: List<Ident> = emptyList(),
+)
+
+data class Ident(
+    val type: String,
+    val ident: String,
+)
+
+data class Periode(
+    val fra: LocalDate? = null,
+    val til: LocalDate? = null,
+    val sluttdato: LocalDate? = null,
+)
+
+data class Stillingsinformasjon(
+    val stillingstittel: String? = null,
+    val stillingsprosent: BigDecimal? = null,
+)

--- a/src/main/kotlin/no/nav/syfo/aareg/AaregModels.kt
+++ b/src/main/kotlin/no/nav/syfo/aareg/AaregModels.kt
@@ -2,15 +2,16 @@ package no.nav.syfo.aareg
 
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.time.YearMonth
 
 data class Arbeidsforhold(
     val arbeidssted: Arbeidssted,
-    val ansettelsesperiode: Periode,
+    val ansettelsesperiode: Ansettelsesperiode,
     val ansettelsesdetaljer: List<Ansettelsesdetaljer> = emptyList(),
 )
 
 data class Ansettelsesdetaljer(
-    val rapporteringsmaaneder: Periode,
+    val rapporteringsmaaneder: Rapporteringsperiode,
     val yrke: Kodeverksentitet? = null,
     val avtaltStillingsprosent: BigDecimal? = null,
 )
@@ -29,10 +30,14 @@ data class Ident(
     val ident: String,
 )
 
-data class Periode(
-    val fra: LocalDate? = null,
-    val til: LocalDate? = null,
+data class Ansettelsesperiode(
+    val startdato: LocalDate? = null,
     val sluttdato: LocalDate? = null,
+)
+
+data class Rapporteringsperiode(
+    val fra: YearMonth? = null,
+    val til: YearMonth? = null,
 )
 
 data class Stillingsinformasjon(

--- a/src/main/kotlin/no/nav/syfo/aareg/AaregService.kt
+++ b/src/main/kotlin/no/nav/syfo/aareg/AaregService.kt
@@ -1,0 +1,50 @@
+package no.nav.syfo.aareg
+
+import no.nav.syfo.aareg.client.IAaregClient
+import no.nav.syfo.util.logger
+
+class AaregService(
+    private val aaregClient: IAaregClient,
+) {
+    private val logger = logger()
+
+    suspend fun getStillingsinformasjon(
+        fnr: String,
+        virksomhetsnummer: String,
+    ): Stillingsinformasjon? {
+        val arbeidsforhold = aaregClient.getArbeidsforhold(fnr)
+
+        val matchendeArbeidsforhold = arbeidsforhold
+            .asSequence()
+            .filter { arbeidsforhold ->
+                arbeidsforhold.arbeidssted.identer.any { ident ->
+                    ident.type == ORGANISASJONSNUMMER && ident.ident == virksomhetsnummer
+                }
+            }
+            .filter { arbeidsforhold ->
+                arbeidsforhold.ansettelsesperiode.sluttdato == null
+            }
+            .mapNotNull { arbeidsforhold ->
+                arbeidsforhold.ansettelsesdetaljer
+                    .firstOrNull { detalj -> detalj.rapporteringsmaaneder.til == null }
+            }
+            .toList()
+
+        if (matchendeArbeidsforhold.size > 1) {
+            logger.warn(
+                "Fant flere matchende arbeidsforhold i Aareg for virksomhetsnummer $virksomhetsnummer, bruker første treff",
+            )
+        }
+
+        return matchendeArbeidsforhold.firstOrNull()?.let { detalj ->
+            Stillingsinformasjon(
+                stillingstittel = detalj.yrke?.beskrivelse,
+                stillingsprosent = detalj.avtaltStillingsprosent,
+            )
+        }
+    }
+
+    private companion object {
+        const val ORGANISASJONSNUMMER = "ORGANISASJONSNUMMER"
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/aareg/AaregService.kt
+++ b/src/main/kotlin/no/nav/syfo/aareg/AaregService.kt
@@ -38,7 +38,7 @@ class AaregService(
 
         return matchendeDetaljer.firstOrNull()?.let { detalj ->
             Stillingsinformasjon(
-                stillingstittel = detalj.yrke?.beskrivelse,
+                stillingstittel = detalj.yrke?.beskrivelse?.takeIf { it.isNotBlank() },
                 stillingsprosent = detalj.avtaltStillingsprosent,
             )
         }

--- a/src/main/kotlin/no/nav/syfo/aareg/AaregService.kt
+++ b/src/main/kotlin/no/nav/syfo/aareg/AaregService.kt
@@ -14,7 +14,7 @@ class AaregService(
     ): Stillingsinformasjon? {
         val arbeidsforhold = aaregClient.getArbeidsforhold(fnr)
 
-        val matchendeArbeidsforhold = arbeidsforhold
+        val matchendeDetaljer = arbeidsforhold
             .asSequence()
             .filter { arbeidsforhold ->
                 arbeidsforhold.arbeidssted.identer.any { ident ->
@@ -30,13 +30,13 @@ class AaregService(
             }
             .toList()
 
-        if (matchendeArbeidsforhold.size > 1) {
+        if (matchendeDetaljer.size > 1) {
             logger.warn(
-                "Fant flere matchende arbeidsforhold i Aareg, bruker første treff",
+                "Fant flere matchende ansettelsesdetaljer i Aareg, bruker første treff",
             )
         }
 
-        return matchendeArbeidsforhold.firstOrNull()?.let { detalj ->
+        return matchendeDetaljer.firstOrNull()?.let { detalj ->
             Stillingsinformasjon(
                 stillingstittel = detalj.yrke?.beskrivelse,
                 stillingsprosent = detalj.avtaltStillingsprosent,

--- a/src/main/kotlin/no/nav/syfo/aareg/AaregService.kt
+++ b/src/main/kotlin/no/nav/syfo/aareg/AaregService.kt
@@ -32,7 +32,7 @@ class AaregService(
 
         if (matchendeArbeidsforhold.size > 1) {
             logger.warn(
-                "Fant flere matchende arbeidsforhold i Aareg for virksomhetsnummer $virksomhetsnummer, bruker første treff",
+                "Fant flere matchende arbeidsforhold i Aareg, bruker første treff",
             )
         }
 

--- a/src/main/kotlin/no/nav/syfo/aareg/client/AaregClient.kt
+++ b/src/main/kotlin/no/nav/syfo/aareg/client/AaregClient.kt
@@ -1,0 +1,45 @@
+package no.nav.syfo.aareg.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import no.nav.syfo.aareg.Arbeidsforhold
+import no.nav.syfo.texas.client.TexasHttpClient
+
+interface IAaregClient {
+    suspend fun getArbeidsforhold(fnr: String): List<Arbeidsforhold>
+}
+
+class AaregClient(
+    private val httpClient: HttpClient,
+    private val aaregBaseUrl: String,
+    private val texasHttpClient: TexasHttpClient,
+    private val scope: String,
+) : IAaregClient {
+    override suspend fun getArbeidsforhold(fnr: String): List<Arbeidsforhold> {
+        val token = texasHttpClient.systemToken(
+            IDENTITY_PROVIDER,
+            TexasHttpClient.getTarget(scope),
+        ).accessToken
+
+        return httpClient
+            .get("$aaregBaseUrl$ARBEIDSFORHOLD_PATH") {
+                header(HttpHeaders.Authorization, "Bearer $token")
+                header(NAV_PERSONIDENT_HEADER, fnr)
+                url {
+                    parameters.append("regelverk", "A_ORDNINGEN")
+                    parameters.append("arbeidsforholdstatus", "AKTIV,FREMTIDIG")
+                    parameters.append("sporingsinformasjon", "false")
+                }
+            }
+            .body()
+    }
+
+    companion object {
+        const val ARBEIDSFORHOLD_PATH = "/api/v2/arbeidstaker/arbeidsforhold"
+        const val NAV_PERSONIDENT_HEADER = "Nav-Personident"
+        const val IDENTITY_PROVIDER = "azuread"
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/aareg/client/FakeAaregClient.kt
+++ b/src/main/kotlin/no/nav/syfo/aareg/client/FakeAaregClient.kt
@@ -1,0 +1,42 @@
+package no.nav.syfo.aareg.client
+
+import net.datafaker.Faker
+import no.nav.syfo.aareg.Ansettelsesdetaljer
+import no.nav.syfo.aareg.Arbeidsforhold
+import no.nav.syfo.aareg.Arbeidssted
+import no.nav.syfo.aareg.Ident
+import no.nav.syfo.aareg.Kodeverksentitet
+import no.nav.syfo.aareg.Periode
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.util.Random
+
+class FakeAaregClient : IAaregClient {
+    override suspend fun getArbeidsforhold(fnr: String): List<Arbeidsforhold> {
+        val faker = Faker(Random(fnr.toLong()))
+        val stillingsprosent = BigDecimal.valueOf(faker.number().randomDouble(2, 20, 100))
+            .setScale(2, RoundingMode.HALF_UP)
+
+        return listOf(
+            Arbeidsforhold(
+                arbeidssted = Arbeidssted(
+                    identer = listOf(
+                        Ident(type = "ORGANISASJONSNUMMER", ident = "orgnummer"),
+                        Ident(type = "ORGANISASJONSNUMMER", ident = "123456789"),
+                    ),
+                ),
+                ansettelsesperiode = Periode(sluttdato = null),
+                ansettelsesdetaljer = listOf(
+                    Ansettelsesdetaljer(
+                        rapporteringsmaaneder = Periode(til = null),
+                        yrke = Kodeverksentitet(
+                            kode = faker.job().field(),
+                            beskrivelse = faker.job().title(),
+                        ),
+                        avtaltStillingsprosent = stillingsprosent,
+                    ),
+                ),
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/aareg/client/FakeAaregClient.kt
+++ b/src/main/kotlin/no/nav/syfo/aareg/client/FakeAaregClient.kt
@@ -2,11 +2,12 @@ package no.nav.syfo.aareg.client
 
 import net.datafaker.Faker
 import no.nav.syfo.aareg.Ansettelsesdetaljer
+import no.nav.syfo.aareg.Ansettelsesperiode
 import no.nav.syfo.aareg.Arbeidsforhold
 import no.nav.syfo.aareg.Arbeidssted
 import no.nav.syfo.aareg.Ident
 import no.nav.syfo.aareg.Kodeverksentitet
-import no.nav.syfo.aareg.Periode
+import no.nav.syfo.aareg.Rapporteringsperiode
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.util.Random
@@ -25,10 +26,10 @@ class FakeAaregClient : IAaregClient {
                         Ident(type = "ORGANISASJONSNUMMER", ident = "123456789"),
                     ),
                 ),
-                ansettelsesperiode = Periode(sluttdato = null),
+                ansettelsesperiode = Ansettelsesperiode(sluttdato = null),
                 ansettelsesdetaljer = listOf(
                     Ansettelsesdetaljer(
-                        rapporteringsmaaneder = Periode(til = null),
+                        rapporteringsmaaneder = Rapporteringsperiode(til = null),
                         yrke = Kodeverksentitet(
                             kode = faker.job().field(),
                             beskrivelse = faker.job().title(),

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -19,6 +19,8 @@ interface Environment {
     val pdfGenUrl: String
     val isDialogmeldingBaseUrl: String
     val isTilgangskontrollBaseUrl: String
+    val aaregBaseUrl: String
+    val aaregScope: String
     val pdlBaseUrl: String
     val pdlScope: String
     val kafka: KafkaEnv
@@ -61,6 +63,8 @@ data class NaisEnvironment(
     override val dokumentportenScope: String = getEnvVar("DOKUMENTPORTEN_SCOPE"),
     override val isDialogmeldingBaseUrl: String = getEnvVar("ISDIALOGMELDING_BASE_URL"),
     override val isTilgangskontrollBaseUrl: String = getEnvVar("ISTILGANGSKONTROLL_URL"),
+    override val aaregBaseUrl: String = getEnvVar("AAREG_BASE_URL"),
+    override val aaregScope: String = getEnvVar("AAREG_SCOPE"),
     override val pdlBaseUrl: String = getEnvVar("PDL_BASE_URL"),
     override val pdlScope: String = getEnvVar("PDL_SCOPE"),
     override val kafka: KafkaEnv = KafkaEnv.createFromEnvVars(),
@@ -109,6 +113,8 @@ data class LocalEnvironment(
     override val dokumentportenScope: String = "dokumentporten",
     override val isDialogmeldingBaseUrl: String = "https://isdialogmelding.intern.dev.nav.no",
     override val isTilgangskontrollBaseUrl: String = "https://istilgangskontroll.intern.dev.nav.no",
+    override val aaregBaseUrl: String = "https://aareg-services-nais-q2.dev-fss-pub.nais.io",
+    override val aaregScope: String = "dev-fss.arbeidsforhold.aareg-services-nais",
     override val pdfGenUrl: String = "http://localhost:9091",
     override val pdlBaseUrl: String = "https://pdl-api.dev.intern.nav.no",
     override val pdlScope: String = "pdl",

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
@@ -8,6 +8,7 @@ import no.nav.syfo.oppfolgingsplan.dto.CreateOppfolgingsplanRequest
 import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.FormSnapshot
 import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.jsonToFormSnapshot
 import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.toJsonString
+import java.math.BigDecimal
 import java.sql.Date
 import java.sql.ResultSet
 import java.sql.Timestamp
@@ -20,6 +21,8 @@ fun DatabaseInterface.persistOppfolgingsplanAndDeleteUtkast(
     narmesteLederFnr: String,
     sykmeldt: Sykmeldt,
     createOppfolgingsplanRequest: CreateOppfolgingsplanRequest,
+    stillingstittel: String?,
+    stillingsprosent: BigDecimal?,
 ): UUID {
     val insertStatement = """
         INSERT INTO oppfolgingsplan (
@@ -29,13 +32,15 @@ fun DatabaseInterface.persistOppfolgingsplanAndDeleteUtkast(
             narmeste_leder_fnr,
             organisasjonsnummer,
             organisasjonsnavn,
+            stillingstittel,
+            stillingsprosent,
             content,
             evalueringsdato,
             skal_deles_med_lege,
             skal_deles_med_veileder,
             utkast_created_at,
             created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
         RETURNING uuid
     """.trimIndent()
 
@@ -63,14 +68,16 @@ fun DatabaseInterface.persistOppfolgingsplanAndDeleteUtkast(
             it.setString(4, narmesteLederFnr)
             it.setString(5, sykmeldt.orgnummer)
             it.setString(6, sykmeldt.getOrganizationName())
-            it.setObject(7, createOppfolgingsplanRequest.content.toJsonString(), Types.OTHER)
-            it.setDate(8, Date.valueOf(createOppfolgingsplanRequest.evalueringsdato.toString()))
-            it.setBoolean(9, false)
-            it.setBoolean(10, false)
+            it.setString(7, stillingstittel)
+            it.setBigDecimal(8, stillingsprosent)
+            it.setObject(9, createOppfolgingsplanRequest.content.toJsonString(), Types.OTHER)
+            it.setDate(10, Date.valueOf(createOppfolgingsplanRequest.evalueringsdato.toString()))
+            it.setBoolean(11, false)
+            it.setBoolean(12, false)
             if (utkastCreatedAt != null) {
-                it.setTimestamp(11, Timestamp.from(utkastCreatedAt))
+                it.setTimestamp(13, Timestamp.from(utkastCreatedAt))
             } else {
-                it.setNull(11, Types.TIMESTAMP)
+                it.setNull(13, Types.TIMESTAMP)
             }
             val resultSet = it.executeQuery()
             resultSet.next()
@@ -350,6 +357,8 @@ fun ResultSet.mapToOppfolgingsplan(): PersistedOppfolgingsplan = PersistedOppfol
     narmesteLederFullName = this.getString("narmeste_leder_full_name"),
     organisasjonsnummer = this.getString("organisasjonsnummer"),
     organisasjonsnavn = this.getString("organisasjonsnavn"),
+    stillingstittel = this.getString("stillingstittel"),
+    stillingsprosent = this.getBigDecimal("stillingsprosent"),
     content = FormSnapshot.jsonToFormSnapshot(getString("content")),
     evalueringsdato = LocalDate.parse(this.getString("evalueringsdato")),
     skalDelesMedLege = this.getBoolean("skal_deles_med_lege"),

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/domain/PersistedOppfolgingsplan.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/domain/PersistedOppfolgingsplan.kt
@@ -7,6 +7,7 @@ import no.nav.syfo.oppfolgingsplan.dto.OppfolgingsplanResponse
 import no.nav.syfo.oppfolgingsplan.dto.OppfolgingsplanResponseData
 import no.nav.syfo.oppfolgingsplan.dto.SykmeldtOppfolgingsplanOverviewResponse
 import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.FormSnapshot
+import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
@@ -20,6 +21,8 @@ data class PersistedOppfolgingsplan(
     val narmesteLederFullName: String?,
     val organisasjonsnummer: String,
     val organisasjonsnavn: String?,
+    val stillingstittel: String? = null,
+    val stillingsprosent: BigDecimal? = null,
     val content: FormSnapshot,
     val evalueringsdato: LocalDate,
     val skalDelesMedLege: Boolean,
@@ -38,6 +41,8 @@ fun PersistedOppfolgingsplan.toOppfolgingsplanMetadata(): OppfolgingsplanMetadat
     deltMedLegeTidspunkt = deltMedLegeTidspunkt,
     deltMedVeilederTidspunkt = deltMedVeilederTidspunkt,
     ferdigstiltTidspunkt = createdAt,
+    stillingstittel = stillingstittel,
+    stillingsprosent = stillingsprosent,
     organization = OrganizationDetails(
         orgNumber = organisasjonsnummer,
         orgName = organisasjonsnavn,
@@ -61,6 +66,8 @@ fun PersistedOppfolgingsplan.toResponse(canEditPlan: Boolean): OppfolgingsplanRe
         deltMedLegeTidspunkt = deltMedLegeTidspunkt,
         deltMedVeilederTidspunkt = deltMedVeilederTidspunkt,
         ferdigstiltTidspunkt = createdAt,
+        stillingstittel = stillingstittel,
+        stillingsprosent = stillingsprosent,
     ),
 )
 

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/ArbeidsgiverOppfolgingsplanOverviewResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/ArbeidsgiverOppfolgingsplanOverviewResponse.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.oppfolgingsplan.dto
 
 import no.nav.syfo.oppfolgingsplan.domain.EmployeeDetails
 import no.nav.syfo.oppfolgingsplan.domain.OrganizationDetails
+import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
@@ -22,6 +23,8 @@ data class OppfolgingsplanMetadata(
     val deltMedLegeTidspunkt: Instant? = null,
     val deltMedVeilederTidspunkt: Instant? = null,
     val ferdigstiltTidspunkt: Instant,
+    val stillingstittel: String? = null,
+    val stillingsprosent: BigDecimal? = null,
     val organization: OrganizationDetails,
 )
 

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/OppfolgingsplanResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/OppfolgingsplanResponse.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.oppfolgingsplan.dto
 import no.nav.syfo.oppfolgingsplan.domain.EmployeeDetails
 import no.nav.syfo.oppfolgingsplan.domain.OrganizationDetails
 import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.FormSnapshot
+import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
@@ -14,6 +15,8 @@ data class OppfolgingsplanResponseData(
     val deltMedLegeTidspunkt: Instant? = null,
     val deltMedVeilederTidspunkt: Instant? = null,
     val ferdigstiltTidspunkt: Instant,
+    val stillingstittel: String? = null,
+    val stillingsprosent: BigDecimal? = null,
 )
 
 data class OppfolgingsplanResponse(

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
@@ -67,7 +67,7 @@ class OppfolgingsplanService(
             )
         } catch (e: Exception) {
             logger.warn(
-                "Kunne ikke hente stillingsinformasjon fra Aareg for virksomhetsnummer ${sykmeldt.orgnummer}",
+                "Kunne ikke hente stillingsinformasjon fra Aareg",
                 e,
             )
             null

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.oppfolgingsplan.service
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import no.nav.syfo.aareg.AaregService
@@ -65,6 +66,8 @@ class OppfolgingsplanService(
                 fnr = sykmeldt.fnr,
                 virksomhetsnummer = sykmeldt.orgnummer,
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             logger.warn(
                 "Kunne ikke hente stillingsinformasjon fra Aareg",
@@ -87,6 +90,8 @@ class OppfolgingsplanService(
             withContext(Dispatchers.IO) {
                 produceOppfolgingsplanCreatedVarsel(sykmeldt)
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             logger.error("Error when producing kafka message", e)
         }

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.oppfolgingsplan.service
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import no.nav.syfo.aareg.AaregService
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.application.exception.ApiErrorException
 import no.nav.syfo.application.exception.PlanNotFoundException
@@ -50,6 +51,7 @@ class OppfolgingsplanService(
     private val database: DatabaseInterface,
     private val esyfovarselProducer: EsyfovarselProducer,
     private val pdlService: PdlService,
+    private val aaregService: AaregService,
 ) {
     private val logger = logger()
 
@@ -58,8 +60,27 @@ class OppfolgingsplanService(
         sykmeldt: Sykmeldt,
         createOppfolgingsplanRequest: CreateOppfolgingsplanRequest,
     ): UUID {
+        val stillingsinformasjon = try {
+            aaregService.getStillingsinformasjon(
+                fnr = sykmeldt.fnr,
+                virksomhetsnummer = sykmeldt.orgnummer,
+            )
+        } catch (e: Exception) {
+            logger.warn(
+                "Kunne ikke hente stillingsinformasjon fra Aareg for virksomhetsnummer ${sykmeldt.orgnummer}",
+                e,
+            )
+            null
+        }
+
         val uuid = withContext(Dispatchers.IO) {
-            database.persistOppfolgingsplanAndDeleteUtkast(narmesteLederFnr, sykmeldt, createOppfolgingsplanRequest)
+            database.persistOppfolgingsplanAndDeleteUtkast(
+                narmesteLederFnr = narmesteLederFnr,
+                sykmeldt = sykmeldt,
+                createOppfolgingsplanRequest = createOppfolgingsplanRequest,
+                stillingstittel = stillingsinformasjon?.stillingstittel,
+                stillingsprosent = stillingsinformasjon?.stillingsprosent,
+            )
         }
 
         try {

--- a/src/main/kotlin/no/nav/syfo/pdfgen/PdfGenService.kt
+++ b/src/main/kotlin/no/nav/syfo/pdfgen/PdfGenService.kt
@@ -49,6 +49,8 @@ fun PersistedOppfolgingsplan.toOppfolgingsplanPdfV1(): OppfolgingsplanPdfV1 {
             // dine-sykmeldte-backend even though all rows in the database currently have a value
             organisasjonsnavn = this.organisasjonsnavn ?: throw RuntimeException("Organisasjonsnavn is null"),
             organisasjonsnummer = this.organisasjonsnummer,
+            stillingstittel = this.stillingstittel,
+            stillingsprosent = this.stillingsprosent?.toPlainString(),
             narmesteLederName = this.narmesteLederFullName ?: throw RuntimeException("NarmesteLederName is null"),
             sections = content.sections.map { section ->
                 Section(

--- a/src/main/kotlin/no/nav/syfo/pdfgen/client/OppfolgingsplanPdfV1.kt
+++ b/src/main/kotlin/no/nav/syfo/pdfgen/client/OppfolgingsplanPdfV1.kt
@@ -12,6 +12,8 @@ data class Oppfolgingsplan(
     val sykmeldtFnr: String,
     val organisasjonsnavn: String,
     val organisasjonsnummer: String,
+    val stillingstittel: String? = null,
+    val stillingsprosent: String? = null,
     val narmesteLederName: String,
     val sections: List<Section>,
 )

--- a/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
@@ -2,6 +2,10 @@ package no.nav.syfo.plugins
 
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
+import no.nav.syfo.aareg.AaregService
+import no.nav.syfo.aareg.client.AaregClient
+import no.nav.syfo.aareg.client.FakeAaregClient
+import no.nav.syfo.aareg.client.IAaregClient
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.Environment
 import no.nav.syfo.application.LocalEnvironment
@@ -78,6 +82,18 @@ private fun clientsModule() = module {
     single { httpClientDefault() }
     single { PdfGenClient(get(), env().pdfGenUrl) }
     single { TexasHttpClient(get(), env().texas) }
+    single<IAaregClient> {
+        if (isLocalEnv()) {
+            FakeAaregClient()
+        } else {
+            AaregClient(
+                httpClient = get(),
+                aaregBaseUrl = env().aaregBaseUrl,
+                texasHttpClient = get(),
+                scope = env().aaregScope,
+            )
+        }
+    }
     single {
         if (isLocalEnv()) {
             FakeDokarkivClient()
@@ -182,7 +198,8 @@ private fun servicesModule() = module {
     single { IsTilgangskontrollService(get()) }
     single { LeaderElection(get(), env().electorPath) }
     single { PdlService(get()) }
-    single { OppfolgingsplanService(database = get(), esyfovarselProducer = get(), get()) }
+    single { AaregService(get()) }
+    single { OppfolgingsplanService(database = get(), esyfovarselProducer = get(), pdlService = get(), aaregService = get()) }
     single { PdfGenService(get(), get()) }
     single { SendOppfolgingsplanTask(get(), get()) }
 }

--- a/src/main/resources/db/migration/V12__add_stilling_columns.sql
+++ b/src/main/resources/db/migration/V12__add_stilling_columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE oppfolgingsplan
+    ADD COLUMN stillingstittel VARCHAR,
+    ADD COLUMN stillingsprosent DECIMAL(5,2);

--- a/src/main/resources/openapi/arbeidsgiver.yaml
+++ b/src/main/resources/openapi/arbeidsgiver.yaml
@@ -611,6 +611,12 @@ components:
         ferdigstiltTidspunkt:
           type: string
           format: date-time
+        stillingstittel:
+          type: string
+          nullable: true
+        stillingsprosent:
+          type: number
+          nullable: true
 
     OppfolgingsplanUtkastResponse:
       type: object
@@ -668,6 +674,12 @@ components:
         ferdigstiltTidspunkt:
           type: string
           format: date-time
+        stillingstittel:
+          type: string
+          nullable: true
+        stillingsprosent:
+          type: number
+          nullable: true
 
     UtkastMetadata:
       type: object

--- a/src/main/resources/openapi/sykmeldt.yaml
+++ b/src/main/resources/openapi/sykmeldt.yaml
@@ -298,6 +298,12 @@ components:
         ferdigstiltTidspunkt:
           type: string
           format: date-time
+        stillingstittel:
+          type: string
+          nullable: true
+        stillingsprosent:
+          type: number
+          nullable: true
 
     OppfolgingsplanMetadata:
       type: object
@@ -323,6 +329,12 @@ components:
         ferdigstiltTidspunkt:
           type: string
           format: date-time
+        stillingstittel:
+          type: string
+          nullable: true
+        stillingsprosent:
+          type: number
+          nullable: true
 
     OrganizationDetails:
       type: object

--- a/src/test/kotlin/no/nav/syfo/TestDb.kt
+++ b/src/test/kotlin/no/nav/syfo/TestDb.kt
@@ -107,12 +107,16 @@ fun DatabaseInterface.persistOppfolgingsplan(
             narmeste_leder_id,
             narmeste_leder_fnr,
             organisasjonsnummer,
+            organisasjonsnavn,
+            narmeste_leder_full_name,
+            stillingstittel,
+            stillingsprosent,
             content,
             evalueringsdato,
             skal_deles_med_lege,
             skal_deles_med_veileder,
             created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
         RETURNING uuid
     """.trimIndent()
 
@@ -123,10 +127,14 @@ fun DatabaseInterface.persistOppfolgingsplan(
             it.setString(3, persistedOppfolgingsplan.narmesteLederId)
             it.setString(4, persistedOppfolgingsplan.narmesteLederFnr)
             it.setString(5, persistedOppfolgingsplan.organisasjonsnummer)
-            it.setObject(6, persistedOppfolgingsplan.content.toJsonString(), Types.OTHER)
-            it.setDate(7, Date.valueOf(persistedOppfolgingsplan.evalueringsdato.toString()))
-            it.setBoolean(8, persistedOppfolgingsplan.skalDelesMedLege)
-            it.setBoolean(9, persistedOppfolgingsplan.skalDelesMedVeileder)
+            it.setString(6, persistedOppfolgingsplan.organisasjonsnavn)
+            it.setString(7, persistedOppfolgingsplan.narmesteLederFullName)
+            it.setString(8, persistedOppfolgingsplan.stillingstittel)
+            it.setBigDecimal(9, persistedOppfolgingsplan.stillingsprosent)
+            it.setObject(10, persistedOppfolgingsplan.content.toJsonString(), Types.OTHER)
+            it.setDate(11, Date.valueOf(persistedOppfolgingsplan.evalueringsdato.toString()))
+            it.setBoolean(12, persistedOppfolgingsplan.skalDelesMedLege)
+            it.setBoolean(13, persistedOppfolgingsplan.skalDelesMedVeileder)
             val resultSet = it.executeQuery()
             connection.commit()
             resultSet.next()

--- a/src/test/kotlin/no/nav/syfo/TestUtils.kt
+++ b/src/test/kotlin/no/nav/syfo/TestUtils.kt
@@ -26,6 +26,7 @@ import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.TextFieldSnapshot
 import no.nav.syfo.texas.client.TexasHttpClient
 import no.nav.syfo.texas.client.TexasIntrospectionResponse
 import no.nav.syfo.texas.client.TexasResponse
+import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
@@ -60,6 +61,8 @@ fun defaultPersistedOppfolgingsplan() = PersistedOppfolgingsplan(
     narmesteLederFullName = "Narmesteleder",
     organisasjonsnummer = "orgnummer",
     organisasjonsnavn = "Test AS",
+    stillingstittel = "Systemutvikler",
+    stillingsprosent = BigDecimal("100.00"),
     content = defaultFormSnapshot(),
     skalDelesMedLege = false,
     skalDelesMedVeileder = false,

--- a/src/test/kotlin/no/nav/syfo/aareg/AaregServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/aareg/AaregServiceTest.kt
@@ -8,6 +8,7 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import no.nav.syfo.aareg.client.IAaregClient
 import java.math.BigDecimal
+import java.time.YearMonth
 
 class AaregServiceTest :
     DescribeSpec({
@@ -23,10 +24,13 @@ class AaregServiceTest :
                                 Ident(type = "ORGANISASJONSNUMMER", ident = "999999999"),
                             ),
                         ),
-                        ansettelsesperiode = Periode(sluttdato = null),
+                        ansettelsesperiode = Ansettelsesperiode(sluttdato = null),
                         ansettelsesdetaljer = listOf(
                             Ansettelsesdetaljer(
-                                rapporteringsmaaneder = Periode(til = null),
+                                rapporteringsmaaneder = Rapporteringsperiode(
+                                    fra = YearMonth.of(2020, 1),
+                                    til = null,
+                                ),
                                 yrke = Kodeverksentitet(beskrivelse = "Systemutvikler"),
                                 avtaltStillingsprosent = BigDecimal("80.50"),
                             ),
@@ -49,10 +53,13 @@ class AaregServiceTest :
                                 Ident(type = "ORGANISASJONSNUMMER", ident = "111111111"),
                             ),
                         ),
-                        ansettelsesperiode = Periode(sluttdato = null),
+                        ansettelsesperiode = Ansettelsesperiode(sluttdato = null),
                         ansettelsesdetaljer = listOf(
                             Ansettelsesdetaljer(
-                                rapporteringsmaaneder = Periode(til = null),
+                                rapporteringsmaaneder = Rapporteringsperiode(
+                                    fra = YearMonth.of(2020, 1),
+                                    til = null,
+                                ),
                                 yrke = Kodeverksentitet(beskrivelse = "Sykepleier"),
                                 avtaltStillingsprosent = BigDecimal("50.00"),
                             ),
@@ -71,10 +78,13 @@ class AaregServiceTest :
                                 Ident(type = "ORGANISASJONSNUMMER", ident = "999999999"),
                             ),
                         ),
-                        ansettelsesperiode = Periode(sluttdato = null),
+                        ansettelsesperiode = Ansettelsesperiode(sluttdato = null),
                         ansettelsesdetaljer = listOf(
                             Ansettelsesdetaljer(
-                                rapporteringsmaaneder = Periode(til = null),
+                                rapporteringsmaaneder = Rapporteringsperiode(
+                                    fra = YearMonth.of(2020, 1),
+                                    til = null,
+                                ),
                                 yrke = Kodeverksentitet(beskrivelse = "Første stilling"),
                                 avtaltStillingsprosent = BigDecimal("100.00"),
                             ),
@@ -86,10 +96,13 @@ class AaregServiceTest :
                                 Ident(type = "ORGANISASJONSNUMMER", ident = "999999999"),
                             ),
                         ),
-                        ansettelsesperiode = Periode(sluttdato = null),
+                        ansettelsesperiode = Ansettelsesperiode(sluttdato = null),
                         ansettelsesdetaljer = listOf(
                             Ansettelsesdetaljer(
-                                rapporteringsmaaneder = Periode(til = null),
+                                rapporteringsmaaneder = Rapporteringsperiode(
+                                    fra = YearMonth.of(2020, 2),
+                                    til = null,
+                                ),
                                 yrke = Kodeverksentitet(beskrivelse = "Andre stilling"),
                                 avtaltStillingsprosent = BigDecimal("20.00"),
                             ),

--- a/src/test/kotlin/no/nav/syfo/aareg/AaregServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/aareg/AaregServiceTest.kt
@@ -1,0 +1,108 @@
+package no.nav.syfo.aareg
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import no.nav.syfo.aareg.client.IAaregClient
+import java.math.BigDecimal
+
+class AaregServiceTest :
+    DescribeSpec({
+        val aaregClient = mockk<IAaregClient>()
+        val service = AaregService(aaregClient)
+
+        describe("getStillingsinformasjon") {
+            it("returns stillingsinformasjon for active arbeidsforhold in matching virksomhet") {
+                coEvery { aaregClient.getArbeidsforhold("12345678901") } returns listOf(
+                    Arbeidsforhold(
+                        arbeidssted = Arbeidssted(
+                            identer = listOf(
+                                Ident(type = "ORGANISASJONSNUMMER", ident = "999999999"),
+                            ),
+                        ),
+                        ansettelsesperiode = Periode(sluttdato = null),
+                        ansettelsesdetaljer = listOf(
+                            Ansettelsesdetaljer(
+                                rapporteringsmaaneder = Periode(til = null),
+                                yrke = Kodeverksentitet(beskrivelse = "Systemutvikler"),
+                                avtaltStillingsprosent = BigDecimal("80.50"),
+                            ),
+                        ),
+                    ),
+                )
+
+                val result = service.getStillingsinformasjon("12345678901", "999999999")
+
+                result shouldNotBe null
+                result?.stillingstittel shouldBe "Systemutvikler"
+                result?.stillingsprosent shouldBe BigDecimal("80.50")
+            }
+
+            it("returns null when no arbeidsforhold matches virksomhetsnummer") {
+                coEvery { aaregClient.getArbeidsforhold("12345678901") } returns listOf(
+                    Arbeidsforhold(
+                        arbeidssted = Arbeidssted(
+                            identer = listOf(
+                                Ident(type = "ORGANISASJONSNUMMER", ident = "111111111"),
+                            ),
+                        ),
+                        ansettelsesperiode = Periode(sluttdato = null),
+                        ansettelsesdetaljer = listOf(
+                            Ansettelsesdetaljer(
+                                rapporteringsmaaneder = Periode(til = null),
+                                yrke = Kodeverksentitet(beskrivelse = "Sykepleier"),
+                                avtaltStillingsprosent = BigDecimal("50.00"),
+                            ),
+                        ),
+                    ),
+                )
+
+                service.getStillingsinformasjon("12345678901", "999999999").shouldBeNull()
+            }
+
+            it("uses first match when multiple active arbeidsforhold match virksomhetsnummer") {
+                coEvery { aaregClient.getArbeidsforhold("12345678901") } returns listOf(
+                    Arbeidsforhold(
+                        arbeidssted = Arbeidssted(
+                            identer = listOf(
+                                Ident(type = "ORGANISASJONSNUMMER", ident = "999999999"),
+                            ),
+                        ),
+                        ansettelsesperiode = Periode(sluttdato = null),
+                        ansettelsesdetaljer = listOf(
+                            Ansettelsesdetaljer(
+                                rapporteringsmaaneder = Periode(til = null),
+                                yrke = Kodeverksentitet(beskrivelse = "Første stilling"),
+                                avtaltStillingsprosent = BigDecimal("100.00"),
+                            ),
+                        ),
+                    ),
+                    Arbeidsforhold(
+                        arbeidssted = Arbeidssted(
+                            identer = listOf(
+                                Ident(type = "ORGANISASJONSNUMMER", ident = "999999999"),
+                            ),
+                        ),
+                        ansettelsesperiode = Periode(sluttdato = null),
+                        ansettelsesdetaljer = listOf(
+                            Ansettelsesdetaljer(
+                                rapporteringsmaaneder = Periode(til = null),
+                                yrke = Kodeverksentitet(beskrivelse = "Andre stilling"),
+                                avtaltStillingsprosent = BigDecimal("20.00"),
+                            ),
+                        ),
+                    ),
+                )
+
+                val result = service.getStillingsinformasjon("12345678901", "999999999")
+
+                result shouldBe Stillingsinformasjon(
+                    stillingstittel = "Første stilling",
+                    stillingsprosent = BigDecimal("100.00"),
+                )
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/aareg/AaregServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/aareg/AaregServiceTest.kt
@@ -70,6 +70,35 @@ class AaregServiceTest :
                 service.getStillingsinformasjon("12345678901", "999999999").shouldBeNull()
             }
 
+            it("returns null stillingstittel when yrke beskrivelse is blank") {
+                coEvery { aaregClient.getArbeidsforhold("12345678901") } returns listOf(
+                    Arbeidsforhold(
+                        arbeidssted = Arbeidssted(
+                            identer = listOf(
+                                Ident(type = "ORGANISASJONSNUMMER", ident = "999999999"),
+                            ),
+                        ),
+                        ansettelsesperiode = Ansettelsesperiode(sluttdato = null),
+                        ansettelsesdetaljer = listOf(
+                            Ansettelsesdetaljer(
+                                rapporteringsmaaneder = Rapporteringsperiode(
+                                    fra = YearMonth.of(2020, 1),
+                                    til = null,
+                                ),
+                                yrke = Kodeverksentitet(beskrivelse = "   "),
+                                avtaltStillingsprosent = BigDecimal("80.50"),
+                            ),
+                        ),
+                    ),
+                )
+
+                val result = service.getStillingsinformasjon("12345678901", "999999999")
+
+                result shouldNotBe null
+                result?.stillingstittel.shouldBeNull()
+                result?.stillingsprosent shouldBe BigDecimal("80.50")
+            }
+
             it("uses first match when multiple active arbeidsforhold match virksomhetsnummer") {
                 coEvery { aaregClient.getArbeidsforhold("12345678901") } returns listOf(
                     Arbeidsforhold(

--- a/src/test/kotlin/no/nav/syfo/aareg/client/AaregClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/aareg/client/AaregClientTest.kt
@@ -1,0 +1,115 @@
+package no.nav.syfo.aareg.client
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.ktor.http.HttpHeaders
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import no.nav.syfo.texas.client.TexasHttpClient
+import no.nav.syfo.texas.client.TexasResponse
+import no.nav.syfo.util.httpClientDefault
+
+class AaregClientTest :
+    DescribeSpec({
+        val texasHttpClient = mockk<TexasHttpClient>()
+        val wireMockServer = WireMockServer(options().dynamicPort())
+
+        beforeTest {
+            clearAllMocks()
+            wireMockServer.start()
+        }
+
+        afterTest {
+            wireMockServer.resetAll()
+            wireMockServer.stop()
+        }
+
+        describe("getArbeidsforhold") {
+            it("requests arbeidsforhold with system token, headers and query params") {
+                coEvery {
+                    texasHttpClient.systemToken(
+                        AaregClient.IDENTITY_PROVIDER,
+                        TexasHttpClient.getTarget("scope"),
+                    )
+                } returns TexasResponse(
+                    accessToken = "token",
+                    expiresIn = 3600,
+                    tokenType = "Bearer",
+                )
+
+                wireMockServer.stubFor(
+                    get(urlPathEqualTo(AaregClient.ARBEIDSFORHOLD_PATH))
+                        .withHeader(HttpHeaders.Authorization, equalTo("Bearer token"))
+                        .withHeader(AaregClient.NAV_PERSONIDENT_HEADER, equalTo("12345678901"))
+                        .withQueryParam("regelverk", equalTo("A_ORDNINGEN"))
+                        .withQueryParam("arbeidsforholdstatus", equalTo("AKTIV,FREMTIDIG"))
+                        .withQueryParam("sporingsinformasjon", equalTo("false"))
+                        .willReturn(
+                            aResponse()
+                                .withHeader(HttpHeaders.ContentType, "application/json")
+                                .withBody(
+                                    """
+                                    [
+                                      {
+                                        "arbeidssted": {
+                                          "identer": [
+                                            {
+                                              "type": "ORGANISASJONSNUMMER",
+                                              "ident": "999999999"
+                                            }
+                                          ]
+                                        },
+                                        "ansettelsesperiode": {
+                                          "sluttdato": null
+                                        },
+                                        "ansettelsesdetaljer": [
+                                          {
+                                            "rapporteringsmaaneder": {
+                                              "fra": "2024-01-01",
+                                              "til": null
+                                            },
+                                            "yrke": {
+                                              "kode": "2512",
+                                              "beskrivelse": "Systemutvikler"
+                                            },
+                                            "avtaltStillingsprosent": 100.00
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                    """.trimIndent(),
+                                ),
+                        ),
+                )
+
+                val client = AaregClient(
+                    httpClient = httpClientDefault(),
+                    aaregBaseUrl = wireMockServer.baseUrl(),
+                    texasHttpClient = texasHttpClient,
+                    scope = "scope",
+                )
+
+                val arbeidsforhold = client.getArbeidsforhold("12345678901")
+
+                arbeidsforhold.shouldHaveSize(1)
+                arbeidsforhold.first().arbeidssted.identer.first().ident shouldBe "999999999"
+                arbeidsforhold.first().ansettelsesdetaljer.first().yrke?.beskrivelse shouldBe "Systemutvikler"
+                arbeidsforhold.first().ansettelsesdetaljer.first().avtaltStillingsprosent.toString() shouldBe "100.00"
+                coVerify(exactly = 1) {
+                    texasHttpClient.systemToken(
+                        AaregClient.IDENTITY_PROVIDER,
+                        TexasHttpClient.getTarget("scope"),
+                    )
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/aareg/client/AaregClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/aareg/client/AaregClientTest.kt
@@ -17,6 +17,8 @@ import io.mockk.mockk
 import no.nav.syfo.texas.client.TexasHttpClient
 import no.nav.syfo.texas.client.TexasResponse
 import no.nav.syfo.util.httpClientDefault
+import java.time.LocalDate
+import java.time.YearMonth
 
 class AaregClientTest :
     DescribeSpec({
@@ -69,12 +71,13 @@ class AaregClientTest :
                                           ]
                                         },
                                         "ansettelsesperiode": {
+                                          "startdato": "2014-01-01",
                                           "sluttdato": null
                                         },
                                         "ansettelsesdetaljer": [
                                           {
                                             "rapporteringsmaaneder": {
-                                              "fra": "2024-01-01",
+                                              "fra": "2024-01",
                                               "til": null
                                             },
                                             "yrke": {
@@ -102,6 +105,8 @@ class AaregClientTest :
 
                 arbeidsforhold.shouldHaveSize(1)
                 arbeidsforhold.first().arbeidssted.identer.first().ident shouldBe "999999999"
+                arbeidsforhold.first().ansettelsesperiode.startdato shouldBe LocalDate.parse("2014-01-01")
+                arbeidsforhold.first().ansettelsesdetaljer.first().rapporteringsmaaneder.fra shouldBe YearMonth.of(2024, 1)
                 arbeidsforhold.first().ansettelsesdetaljer.first().yrke?.beskrivelse shouldBe "Systemutvikler"
                 arbeidsforhold.first().ansettelsesdetaljer.first().avtaltStillingsprosent.toString() shouldBe "100.00"
                 coVerify(exactly = 1) {

--- a/src/test/kotlin/no/nav/syfo/dokumentporten/DokumentportenServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/dokumentporten/DokumentportenServiceTest.kt
@@ -8,6 +8,7 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.spyk
 import no.nav.syfo.TestDB
+import no.nav.syfo.aareg.AaregService
 import no.nav.syfo.defaultPersistedOppfolgingsplan
 import no.nav.syfo.dokumentporten.client.FakeDokumentportenClient
 import no.nav.syfo.oppfolgingsplan.db.domain.PersistedOppfolgingsplan
@@ -29,6 +30,7 @@ class DokumentportenServiceTest :
             database = testDb,
             pdlService = mockk<PdlService>(relaxed = true),
             esyfovarselProducer = mockk<EsyfovarselProducer>(relaxed = true),
+            aaregService = mockk<AaregService>(relaxed = true),
         )
 
         beforeTest {

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
@@ -29,6 +29,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.syfo.TestDB
+import no.nav.syfo.aareg.AaregService
+import no.nav.syfo.aareg.Stillingsinformasjon
 import no.nav.syfo.application.Environment
 import no.nav.syfo.application.LocalEnvironment
 import no.nav.syfo.application.exception.ApiError
@@ -67,6 +69,7 @@ import no.nav.syfo.texas.client.TexasHttpClient
 import no.nav.syfo.texas.client.TexasIntrospectionResponse
 import no.nav.syfo.varsel.EsyfovarselProducer
 import no.nav.syfo.varsel.domain.ArbeidstakerHendelse
+import java.math.BigDecimal
 import java.time.Instant
 import java.util.UUID
 
@@ -82,6 +85,7 @@ class OppfolgingsplanApiV1Test :
         val isTilgangskontrollClientMock = mockk<IIsTilgangskontrollClient>()
         val pdfGenServiceMock = mockk<PdfGenService>()
         val pdlServiceMock = mockk<PdlService>(relaxed = true)
+        val aaregServiceMock = mockk<AaregService>()
 
         val narmestelederId = UUID.randomUUID().toString()
         val pidInnlogetBruker = "10987654321"
@@ -94,11 +98,16 @@ class OppfolgingsplanApiV1Test :
             clearAllMocks()
             TestDB.clearAllData()
             every { valkeyCacheMock.getSykmeldt(any(), any()) } returns null
+            coEvery { aaregServiceMock.getStillingsinformasjon(any(), any()) } returns Stillingsinformasjon(
+                stillingstittel = "Systemutvikler",
+                stillingsprosent = BigDecimal("100.00"),
+            )
         }
         val oppfolgingsplanService = OppfolgingsplanService(
             database = testDb,
             esyfovarselProducer = esyfovarselProducerMock,
             pdlService = pdlServiceMock,
+            aaregService = aaregServiceMock,
         )
         val environment: Environment = LocalEnvironment()
 
@@ -288,7 +297,9 @@ class OppfolgingsplanApiV1Test :
 
                     // Assert
                     response.status shouldBe HttpStatusCode.OK
-                    response.body<OppfolgingsplanResponse>()
+                    val oppfolgingsplanResponse = response.body<OppfolgingsplanResponse>()
+                    oppfolgingsplanResponse.oppfolgingsplan.stillingstittel shouldBe "Systemutvikler"
+                    oppfolgingsplanResponse.oppfolgingsplan.stillingsprosent shouldBe BigDecimal("100.00")
                 }
             }
 
@@ -373,6 +384,8 @@ class OppfolgingsplanApiV1Test :
                     response.status shouldBe HttpStatusCode.OK
                     val overview = response.body<ArbeidsgiverOppfolgingsplanOverviewResponse>().oversikt
                     overview.aktivPlan?.id shouldBe latestPlanUUID
+                    overview.aktivPlan?.stillingstittel shouldBe "Systemutvikler"
+                    overview.aktivPlan?.stillingsprosent shouldBe BigDecimal("100.00")
                     overview.tidligerePlaner.size shouldBe 1
                     overview.tidligerePlaner.first().id shouldBe firstPlanUUID
                 }
@@ -410,6 +423,8 @@ class OppfolgingsplanApiV1Test :
                     persisted.first().evalueringsdato.toString() shouldBe oppfolgingsplan.evalueringsdato.toString()
                     persisted.first().sykmeldtFullName shouldBe "Navn Sykmeldt"
                     persisted.first().organisasjonsnavn shouldBe "Test AS"
+                    persisted.first().stillingstittel shouldBe "Systemutvikler"
+                    persisted.first().stillingsprosent shouldBe BigDecimal("100.00")
                     verify(exactly = 1) {
                         esyfovarselProducerMock.sendVarselToEsyfovarsel(
                             withArg {
@@ -455,6 +470,8 @@ class OppfolgingsplanApiV1Test :
                     val persistedOppfolgingsplaner = testDb.findAllOppfolgingsplanerBy("12345678901", "orgnummer")
                     persistedOppfolgingsplaner.size shouldBe 1
                     persistedOppfolgingsplaner.first().utkastCreatedAt shouldBe existingUtkast?.createdAt
+                    persistedOppfolgingsplaner.first().stillingstittel shouldBe "Systemutvikler"
+                    persistedOppfolgingsplaner.first().stillingsprosent shouldBe BigDecimal("100.00")
 
                     val persistedUtkast = testDb.findOppfolgingsplanUtkastBy(sykmeldt.fnr, sykmeldt.orgnummer)
                     persistedUtkast shouldBe null
@@ -513,6 +530,36 @@ class OppfolgingsplanApiV1Test :
                         },
                     )
                 }
+            }
+        }
+        it("POST /oppfolgingsplaner should persist null stillingssnapshot when aareg fails") {
+            withTestApplication {
+                // Arrange
+                texasClientMock.defaultMocks(pidInnlogetBruker, clientId = environment.syfoOppfolgingsplanFrontendClientId)
+
+                dineSykmeldteHttpClientMock.defaultMocks(narmestelederId = narmestelederId)
+
+                coEvery {
+                    aaregServiceMock.getStillingsinformasjon("12345678901", "orgnummer")
+                } throws RuntimeException("boom")
+                coEvery {
+                    esyfovarselProducerMock.sendVarselToEsyfovarsel(any())
+                } returns Unit
+
+                // Act
+                val response = client.post {
+                    url("/api/v1/arbeidsgiver/$narmestelederId/oppfolgingsplaner")
+                    bearerAuth("Bearer token")
+                    contentType(ContentType.Application.Json)
+                    setBody(defaultOppfolgingsplan())
+                }
+
+                // Assert
+                response.status shouldBe HttpStatusCode.Created
+                val persistedOppfolgingsplaner = testDb.findAllOppfolgingsplanerBy("12345678901", "orgnummer")
+                persistedOppfolgingsplaner.size shouldBe 1
+                persistedOppfolgingsplaner.first().stillingstittel shouldBe null
+                persistedOppfolgingsplaner.first().stillingsprosent shouldBe null
             }
         }
         it("POST /oppfolgingsplaner/{uuid}/del-med-lege should respond with NotFound if plan does not exist") {

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanUtkastApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanUtkastApiV1Test.kt
@@ -26,6 +26,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.syfo.TestDB
+import no.nav.syfo.aareg.AaregService
 import no.nav.syfo.application.Environment
 import no.nav.syfo.application.LocalEnvironment
 import no.nav.syfo.application.valkey.ValkeyCache
@@ -73,6 +74,7 @@ class OppfolgingsplanUtkastApiV1Test :
             database = testDb,
             esyfovarselProducer = esyfovarselProducerMock,
             pdlService = pdlService,
+            aaregService = mockk<AaregService>(relaxed = true),
         )
         val narmestelederId = UUID.randomUUID().toString()
         val pidInnlogetBruker = "10987654321"

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/OppfolgingsplanApiV1Test.kt
@@ -25,6 +25,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.syfo.TestDB
+import no.nav.syfo.aareg.AaregService
 import no.nav.syfo.application.Environment
 import no.nav.syfo.application.LocalEnvironment
 import no.nav.syfo.application.valkey.ValkeyCache
@@ -72,6 +73,7 @@ class OppfolgingsplanApiV1Test :
         val isTilgangskontrollServiceMock = IsTilgangskontrollService(isTilgangskontrollClientMock)
         val pdlServiceMock = mockk<PdlService>(relaxed = true)
         val environment: Environment = LocalEnvironment()
+        val aaregServiceMock = mockk<AaregService>(relaxed = true)
 
         beforeTest {
             clearAllMocks()
@@ -104,6 +106,7 @@ class OppfolgingsplanApiV1Test :
                                 database = testDb,
                                 esyfovarselProducer = esyfovarselProducerMock,
                                 pdlService = pdlServiceMock,
+                                aaregService = aaregServiceMock,
                             ),
                             pdfGenService = pdfGenService,
                             isDialogmeldingService = IsDialogmeldingService(isDialogmeldingClientMock),

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederOppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederOppfolgingsplanApiV1Test.kt
@@ -27,6 +27,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.syfo.TestDB
+import no.nav.syfo.aareg.AaregService
 import no.nav.syfo.application.Environment
 import no.nav.syfo.application.LocalEnvironment
 import no.nav.syfo.application.valkey.ValkeyCache
@@ -101,6 +102,7 @@ class VeilederOppfolgingsplanApiV1Test :
                                 database = testDb,
                                 esyfovarselProducer = esyfovarselProducerMock,
                                 pdlService = mockk(relaxed = true),
+                                aaregService = mockk<AaregService>(relaxed = true),
                             ),
                             pdfGenService = pdfGenService,
                             isDialogmeldingService = IsDialogmeldingService(isDialogmeldingClientMock),

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/db/PersistedOppfolgingsplanTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/db/PersistedOppfolgingsplanTest.kt
@@ -58,6 +58,8 @@ class PersistedOppfolgingsplanTest :
                 pdf.oppfolgingsplan.sykmeldtFnr shouldBe plan.sykmeldtFnr
                 pdf.oppfolgingsplan.organisasjonsnavn shouldBe plan.organisasjonsnavn
                 pdf.oppfolgingsplan.organisasjonsnummer shouldBe plan.organisasjonsnummer
+                pdf.oppfolgingsplan.stillingstittel shouldBe plan.stillingstittel
+                pdf.oppfolgingsplan.stillingsprosent shouldBe plan.stillingsprosent?.toPlainString()
                 pdf.oppfolgingsplan.narmesteLederName shouldBe plan.narmesteLederFullName
 
                 // Sections

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanServiceTest.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.oppfolgingsplan.service
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
@@ -7,6 +8,7 @@ import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import no.nav.syfo.TestDB
 import no.nav.syfo.aareg.AaregService
 import no.nav.syfo.aareg.Stillingsinformasjon
@@ -154,6 +156,27 @@ class OppfolgingsplanServiceTest :
                     val persisted = service.getPersistedOppfolgingsplanByUuid(uuid)
                     persisted.stillingstittel.shouldBeNull()
                     persisted.stillingsprosent.shouldBeNull()
+                }
+
+                it("should rethrow cancellation exception from aareg") {
+                    val aaregService = mockk<AaregService>()
+                    val service = OppfolgingsplanService(
+                        database = TestDB.database,
+                        pdlService = mockk(relaxed = true),
+                        esyfovarselProducer = mockk(relaxed = true),
+                        aaregService = aaregService,
+                    )
+                    coEvery {
+                        aaregService.getStillingsinformasjon("12345678901", "orgnummer")
+                    } throws CancellationException("cancelled")
+
+                    shouldThrow<CancellationException> {
+                        service.createOppfolgingsplan(
+                            narmesteLederFnr = "10987654321",
+                            sykmeldt = defaultSykmeldt(),
+                            createOppfolgingsplanRequest = defaultOppfolgingsplan(),
+                        )
+                    }
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanServiceTest.kt
@@ -1,16 +1,22 @@
 package no.nav.syfo.oppfolgingsplan.service
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import no.nav.syfo.TestDB
+import no.nav.syfo.aareg.AaregService
+import no.nav.syfo.aareg.Stillingsinformasjon
+import no.nav.syfo.defaultOppfolgingsplan
 import no.nav.syfo.defaultPersistedOppfolgingsplan
+import no.nav.syfo.defaultSykmeldt
 import no.nav.syfo.pdl.PdlService
 import no.nav.syfo.persistOppfolgingsplan
 import no.nav.syfo.varsel.EsyfovarselProducer
+import java.math.BigDecimal
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
@@ -51,6 +57,7 @@ class OppfolgingsplanServiceTest :
                         database = TestDB.database,
                         pdlService = pdlServive,
                         esyfovarselProducer = mockk<EsyfovarselProducer>(relaxed = true),
+                        aaregService = mockk(relaxed = true),
                     )
                     coEvery { pdlServive.getNameFor(any()) } returns expectedFullname
                     val plan = defaultPersistedOppfolgingsplan().copy(
@@ -78,6 +85,7 @@ class OppfolgingsplanServiceTest :
                         database = TestDB.database,
                         pdlService = pdlServive,
                         esyfovarselProducer = mockk<EsyfovarselProducer>(relaxed = true),
+                        aaregService = mockk(relaxed = true),
                     )
                     coEvery { pdlServive.getNameFor(any()) } returns expectedFullname
                     val plan = defaultPersistedOppfolgingsplan()
@@ -91,6 +99,61 @@ class OppfolgingsplanServiceTest :
                     // Assert
                     result.narmesteLederFullName shouldBe plan.narmesteLederFullName
                     coVerify(exactly = 0) { pdlServive.getNameFor(any()) }
+                }
+            }
+            describe("createOppfolgingsplan") {
+                afterTest {
+                    TestDB.clearAllData()
+                    clearAllMocks()
+                }
+
+                it("should persist stillingssnapshot from aareg") {
+                    val aaregService = mockk<AaregService>()
+                    val service = OppfolgingsplanService(
+                        database = TestDB.database,
+                        pdlService = mockk(relaxed = true),
+                        esyfovarselProducer = mockk(relaxed = true),
+                        aaregService = aaregService,
+                    )
+                    coEvery {
+                        aaregService.getStillingsinformasjon("12345678901", "orgnummer")
+                    } returns Stillingsinformasjon(
+                        stillingstittel = "Systemutvikler",
+                        stillingsprosent = BigDecimal("80.50"),
+                    )
+
+                    val uuid = service.createOppfolgingsplan(
+                        narmesteLederFnr = "10987654321",
+                        sykmeldt = defaultSykmeldt(),
+                        createOppfolgingsplanRequest = defaultOppfolgingsplan(),
+                    )
+
+                    val persisted = service.getPersistedOppfolgingsplanByUuid(uuid)
+                    persisted.stillingstittel shouldBe "Systemutvikler"
+                    persisted.stillingsprosent shouldBe BigDecimal("80.50")
+                }
+
+                it("should persist null stillingssnapshot when aareg fails") {
+                    val aaregService = mockk<AaregService>()
+                    val service = OppfolgingsplanService(
+                        database = TestDB.database,
+                        pdlService = mockk(relaxed = true),
+                        esyfovarselProducer = mockk(relaxed = true),
+                        aaregService = aaregService,
+                    )
+                    coEvery {
+                        aaregService.getStillingsinformasjon("12345678901", "orgnummer")
+                    } throws RuntimeException("boom")
+
+                    val uuid = service.createOppfolgingsplan(
+                        narmesteLederFnr = "10987654321",
+                        sykmeldt = defaultSykmeldt(),
+                        createOppfolgingsplanRequest = defaultOppfolgingsplan(),
+                    )
+
+                    val persisted = service.getPersistedOppfolgingsplanByUuid(uuid)
+                    persisted.stillingstittel.shouldBeNull()
+                    persisted.stillingsprosent.shouldBeNull()
                 }
             }
         }


### PR DESCRIPTION
## Beskrivelse

Integrerer AREG v2 (Aa-registeret) for å hente **stillingstittel** og **stillingsprosent** ved ferdigstilling av oppfølgingsplaner. Informasjonen snapshotes i databasen og inkluderes i PDF-generering og API-responser.

### Hovedfunksjonalitet
- Ny AREG-klient (`AaregClient`) med Azure AD M2M system-token mot `aareg-services-nais`
- Filtreringslogikk (`AaregService`) som matcher arbeidsforhold på virksomhetsnummer, aktiv periode og gjeldende ansettelsesdetaljer
- Best-effort: AREG-feil blokkerer ikke planopprettelse — stillingsinformasjon settes til null
- Flyway-migrering med nullable kolonner (`stillingstittel`, `stillingsprosent`)

### Tekniske valg
- Bruker AREG v2 REST API (internt, Azure AD M2M) — ikke GraphQL (som krever Maskinporten)
- Separate modelltyper for `Ansettelsesperiode` (LocalDate) og `Rapporteringsperiode` (YearMonth) — matcher AREG v2 OpenAPI-spec
- CancellationException kastes videre i alle coroutine catch-blokker

## Endringer

- `aareg/AaregModels.kt`: AREG v2 response-modeller
- `aareg/AaregService.kt`: Filtreringslogikk for stillingsinformasjon
- `aareg/client/AaregClient.kt`: HTTP-klient med system-token
- `aareg/client/FakeAaregClient.kt`: Fake for lokal utvikling
- `oppfolgingsplan/service/OppfolgingsplanService.kt`: AREG-kall ved ferdigstilling
- `oppfolgingsplan/db/OppfolgingsplanDAO.kt`: INSERT/SELECT med stilling-kolonner
- `oppfolgingsplan/db/domain/PersistedOppfolgingsplan.kt`: Domene + mappings
- `oppfolgingsplan/dto/`: Stilling i API-responser
- `pdfgen/`: Stilling i PDF-modell
- `nais/nais-{dev,prod}.yaml`: Outbound access + env vars
- `openapi/`: Oppdatert OpenAPI-spec
- `db/migration/V12__add_stilling_columns.sql`: Flyway-migrering
- Tester: AaregServiceTest, AaregClientTest (WireMock), OppfolgingsplanServiceTest

## Issue

Closes #257
Del av epic: #253

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

## Inspeksjonslogg

| Runde | Inspektør | Dom |
|---|---|---|
| 1 (full impl) | inspektør-claude (Opus) | 😐 — 0 blockers, 3 warnings |
| 2 (full impl) | inspektør-claude + inspektør-gpt | 😐 → 🔴 YearMonth-blocker funnet |
| 3 (etter fix) | inspektør-claude (Opus) | 😊 — 0 blockers, 0 warnings |