### PR TITLE
feat: hard-delete utkast etter 4 måneder

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Swagger UI er tilgjengelig på:
 
 OpenAPI-spesifikasjonene finnes i `src/main/resources/openapi/`.
 
+## Utkast-cleanup
+
+- Oppfølgingsplanutkast hard-slettes av en bakgrunnstask én gang i døgnet når utkastet er eldre enn 4 måneder.
+- Slettingen kjøres i batcher for å redusere låsetid i databasen.
+- API-responsene for utkast eksponerer `utkastUtloperDato` i UTC. Feltet er informativt og er en best-effort-beregning basert på `updated_at`.
+
 ## Docker compose
 
 ### Størrelse på containerplattform

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ OpenAPI-spesifikasjonene finnes i `src/main/resources/openapi/`.
 
 ## Utkast-cleanup
 
-- Oppfølgingsplanutkast hard-slettes av en bakgrunnstask én gang i døgnet når utkastet er eldre enn 4 måneder.
-- Slettingen kjøres i batcher for å redusere låsetid i databasen.
-- API-responsene for utkast eksponerer `utkastUtloperDato` i UTC. Feltet er informativt og er en best-effort-beregning basert på `updated_at`.
+- Oppfølgingsplanutkast hard-slettes av en daglig bakgrunnstask (`CleanupUtkastTask`) når utkastet er eldre enn 4 måneder.
+- Begge bakgrunnstaskene (`CleanupUtkastTask` og `SendOppfolgingsplanTask`) bruker `RecurringTask`-baseklassen med leader election, feilhåndtering og graceful shutdown.
+- API-responsene for utkast eksponerer `utkastUtloperDato` (Europe/Oslo). Feltet er informativt og beregnes fra `updated_at`.
 
 ## Docker compose
 

--- a/src/main/kotlin/no/nav/syfo/application/task/RecurringTask.kt
+++ b/src/main/kotlin/no/nav/syfo/application/task/RecurringTask.kt
@@ -1,0 +1,39 @@
+package no.nav.syfo.application.task
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import no.nav.syfo.application.leaderelection.LeaderElection
+import no.nav.syfo.util.logger
+import kotlin.time.Duration
+
+abstract class RecurringTask(
+    name: String,
+    private val interval: Duration,
+    private val leaderElection: LeaderElection,
+) {
+    protected val log = logger(name)
+    protected val taskName: String = name
+
+    abstract suspend fun execute()
+
+    suspend fun runTask() = coroutineScope {
+        try {
+            while (isActive) {
+                try {
+                    if (leaderElection.isLeader()) {
+                        execute()
+                    }
+                } catch (ex: CancellationException) {
+                    throw ex
+                } catch (ex: Exception) {
+                    log.error("Error while executing $taskName", ex)
+                }
+                delay(interval)
+            }
+        } catch (_: CancellationException) {
+            log.info("$taskName stopped gracefully")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/dokumentporten/SendOppfolgingsplanTask.kt
+++ b/src/main/kotlin/no/nav/syfo/dokumentporten/SendOppfolgingsplanTask.kt
@@ -1,27 +1,20 @@
 package no.nav.syfo.dokumentporten
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
+
 import no.nav.syfo.application.leaderelection.LeaderElection
-import no.nav.syfo.util.logger
+import no.nav.syfo.application.task.RecurringTask
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 
 class SendOppfolgingsplanTask(
-    private val leaderElection: LeaderElection,
+    leaderElection: LeaderElection,
     private val dokumentportenService: DokumentportenService,
+    interval: Duration = 5.minutes,
+) : RecurringTask(
+    name = SendOppfolgingsplanTask::class.qualifiedName!!,
+    interval = interval,
+    leaderElection = leaderElection,
 ) {
-    private val logger = logger()
-    suspend fun runTask() = coroutineScope {
-        try {
-            while (isActive) {
-                if (leaderElection.isLeader()) {
-                    dokumentportenService.findAndSendOppfolgingsplaner()
-                }
-                // Sleep for a while before checking again
-                delay(5 * 60 * 1000) // 5 minutes
-            }
-        } catch (ex: CancellationException) {
-            logger.info("cancelled delete data job", ex)
-        }
+    override suspend fun execute() {
+        dokumentportenService.findAndSendOppfolgingsplaner()
     }
 }

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/OppfolginsplanAPiMetrics.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/OppfolginsplanAPiMetrics.kt
@@ -8,6 +8,7 @@ const val OPPFOLGINGSPLAN_CREATED = "${METRICS_NS}_oppfolgingsplan_created"
 const val OPPFOLGINGSPLAN_SHARED_WITH_GP = "${METRICS_NS}_oppfolgingsplan_shared_with_gp"
 const val OPPFOLGINGSPLAN_SHARED_WITH_NAV = "${METRICS_NS}_oppfolgingsplan_shared_with_nav"
 const val OPPFOLGINGSPLAN_DRAFT_MANUALLY_DELETED = "${METRICS_NS}_oppfolgingsplan_draft_manually_deleted"
+const val OPPFOLGINGSPLAN_DRAFT_AUTO_DELETED = "${METRICS_NS}_oppfolgingsplan_draft_auto_deleted"
 
 val COUNT_OPPFOLGINGSPLAN_CREATED: Counter = Counter.builder(OPPFOLGINGSPLAN_CREATED)
     .description("Counts the number of created oppfolgingsplans")
@@ -20,4 +21,7 @@ val COUNT_OPPFOLGINGSPLAN_SHARED_WITH_NAV: Counter = Counter.builder(OPPFOLGINGS
     .register(METRICS_REGISTRY)
 val COUNT_OPPFOLGINGSPLAN_DRAFT_MANUALLY_DELETED: Counter = Counter.builder(OPPFOLGINGSPLAN_DRAFT_MANUALLY_DELETED)
     .description("Counts the number of drafts oppfolgingsplan manually deleted")
+    .register(METRICS_REGISTRY)
+val COUNT_OPPFOLGINGSPLAN_DRAFT_AUTO_DELETED: Counter = Counter.builder(OPPFOLGINGSPLAN_DRAFT_AUTO_DELETED)
+    .description("Counts the number of expired oppfolgingsplan drafts automatically deleted")
     .register(METRICS_REGISTRY)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanUtkastDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanUtkastDAO.kt
@@ -84,38 +84,22 @@ fun DatabaseInterface.deleteOppfolgingsplanUtkast(
 }
 
 fun DatabaseInterface.deleteExpiredOppfolgingsplanUtkast(
-    retentionMonths: Int,
+    retentionCutoff: Instant,
     limit: Int,
 ): Int = executeDeleteExpiredOppfolgingsplanUtkast(
     statement = """
         DELETE FROM oppfolgingsplan_utkast
-        WHERE uuid IN (
-            SELECT uuid FROM oppfolgingsplan_utkast
-            WHERE updated_at < NOW() - make_interval(months => ?)
-            ORDER BY updated_at
-            LIMIT ?
+        WHERE ctid = ANY(
+            ARRAY(
+                SELECT ctid FROM oppfolgingsplan_utkast
+                WHERE updated_at < ?
+                ORDER BY updated_at
+                LIMIT ?
+            )
         )
     """.trimIndent(),
 ) { preparedStatement ->
-    preparedStatement.setInt(1, retentionMonths)
-    preparedStatement.setInt(2, limit)
-}
-
-fun DatabaseInterface.deleteExpiredOppfolgingsplanUtkastUpdatedBefore(
-    updatedBefore: Instant,
-    limit: Int,
-): Int = executeDeleteExpiredOppfolgingsplanUtkast(
-    statement = """
-        DELETE FROM oppfolgingsplan_utkast
-        WHERE uuid IN (
-            SELECT uuid FROM oppfolgingsplan_utkast
-            WHERE updated_at < ?
-            ORDER BY updated_at
-            LIMIT ?
-        )
-    """.trimIndent(),
-) { preparedStatement ->
-    preparedStatement.setTimestamp(1, Timestamp.from(updatedBefore))
+    preparedStatement.setTimestamp(1, Timestamp.from(retentionCutoff))
     preparedStatement.setInt(2, limit)
 }
 

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanUtkastDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanUtkastDAO.kt
@@ -85,22 +85,20 @@ fun DatabaseInterface.deleteOppfolgingsplanUtkast(
 
 fun DatabaseInterface.deleteExpiredOppfolgingsplanUtkast(
     retentionCutoff: Instant,
-    limit: Int,
-): Int = executeDeleteExpiredOppfolgingsplanUtkast(
-    statement = """
+): Int {
+    val statement = """
         DELETE FROM oppfolgingsplan_utkast
-        WHERE ctid = ANY(
-            ARRAY(
-                SELECT ctid FROM oppfolgingsplan_utkast
-                WHERE updated_at < ?
-                ORDER BY updated_at
-                LIMIT ?
-            )
-        )
-    """.trimIndent(),
-) { preparedStatement ->
-    preparedStatement.setTimestamp(1, Timestamp.from(retentionCutoff))
-    preparedStatement.setInt(2, limit)
+        WHERE updated_at < ?
+    """.trimIndent()
+
+    connection.use { connection ->
+        connection.prepareStatement(statement).use { preparedStatement ->
+            preparedStatement.setTimestamp(1, Timestamp.from(retentionCutoff))
+            val deletedRows = preparedStatement.executeUpdate()
+            connection.commit()
+            return deletedRows
+        }
+    }
 }
 
 fun DatabaseInterface.findOppfolgingsplanUtkastBy(
@@ -129,19 +127,7 @@ fun DatabaseInterface.findOppfolgingsplanUtkastBy(
     }
 }
 
-private fun DatabaseInterface.executeDeleteExpiredOppfolgingsplanUtkast(
-    statement: String,
-    setParameters: (java.sql.PreparedStatement) -> Unit,
-): Int {
-    connection.use { connection ->
-        connection.prepareStatement(statement).use { preparedStatement ->
-            setParameters(preparedStatement)
-            val deletedRows = preparedStatement.executeUpdate()
-            connection.commit()
-            return deletedRows
-        }
-    }
-}
+
 
 fun ResultSet.toOppfolgingsplanUtkastDTO(): PersistedOppfolgingsplanUtkast = PersistedOppfolgingsplanUtkast(
     uuid = getObject("uuid") as UUID,

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanUtkastDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanUtkastDAO.kt
@@ -7,6 +7,7 @@ import no.nav.syfo.oppfolgingsplan.db.domain.PersistedOppfolgingsplanUtkast
 import no.nav.syfo.oppfolgingsplan.dto.LagreUtkastRequest
 import no.nav.syfo.util.configuredJacksonMapper
 import java.sql.ResultSet
+import java.sql.Timestamp
 import java.sql.Types
 import java.time.Instant
 import java.util.UUID
@@ -82,6 +83,42 @@ fun DatabaseInterface.deleteOppfolgingsplanUtkast(
     }
 }
 
+fun DatabaseInterface.deleteExpiredOppfolgingsplanUtkast(
+    retentionMonths: Int,
+    limit: Int,
+): Int = executeDeleteExpiredOppfolgingsplanUtkast(
+    statement = """
+        DELETE FROM oppfolgingsplan_utkast
+        WHERE uuid IN (
+            SELECT uuid FROM oppfolgingsplan_utkast
+            WHERE updated_at < NOW() - make_interval(months => ?)
+            ORDER BY updated_at
+            LIMIT ?
+        )
+    """.trimIndent(),
+) { preparedStatement ->
+    preparedStatement.setInt(1, retentionMonths)
+    preparedStatement.setInt(2, limit)
+}
+
+fun DatabaseInterface.deleteExpiredOppfolgingsplanUtkastUpdatedBefore(
+    updatedBefore: Instant,
+    limit: Int,
+): Int = executeDeleteExpiredOppfolgingsplanUtkast(
+    statement = """
+        DELETE FROM oppfolgingsplan_utkast
+        WHERE uuid IN (
+            SELECT uuid FROM oppfolgingsplan_utkast
+            WHERE updated_at < ?
+            ORDER BY updated_at
+            LIMIT ?
+        )
+    """.trimIndent(),
+) { preparedStatement ->
+    preparedStatement.setTimestamp(1, Timestamp.from(updatedBefore))
+    preparedStatement.setInt(2, limit)
+}
+
 fun DatabaseInterface.findOppfolgingsplanUtkastBy(
     sykmeldtFnr: String,
     organisasjonsnummer: String,
@@ -104,6 +141,20 @@ fun DatabaseInterface.findOppfolgingsplanUtkastBy(
             } else {
                 null
             }
+        }
+    }
+}
+
+private fun DatabaseInterface.executeDeleteExpiredOppfolgingsplanUtkast(
+    statement: String,
+    setParameters: (java.sql.PreparedStatement) -> Unit,
+): Int {
+    connection.use { connection ->
+        connection.prepareStatement(statement).use { preparedStatement ->
+            setParameters(preparedStatement)
+            val deletedRows = preparedStatement.executeUpdate()
+            connection.commit()
+            return deletedRows
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/domain/PersistedOppfolgingsplanUtkast.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/domain/PersistedOppfolgingsplanUtkast.kt
@@ -9,7 +9,7 @@ import no.nav.syfo.oppfolgingsplan.dto.UtkastMetadata
 import no.nav.syfo.oppfolgingsplan.dto.UtkastResponseData
 import no.nav.syfo.oppfolgingsplan.service.OPPFOLGINGSPLAN_UTKAST_RETENTION_MONTHS
 import java.time.Instant
-import java.time.ZoneOffset
+import java.time.ZoneId
 import java.util.UUID
 
 data class PersistedOppfolgingsplanUtkast(
@@ -28,7 +28,7 @@ fun PersistedOppfolgingsplanUtkast.toUtkastMetadata(): UtkastMetadata = UtkastMe
     utkastUtloperDato = utkastUtloperDato(),
 )
 
-fun PersistedOppfolgingsplanUtkast.utkastUtloperDato(): Instant = updatedAt.atZone(ZoneOffset.UTC)
+fun PersistedOppfolgingsplanUtkast.utkastUtloperDato(): Instant = updatedAt.atZone(ZoneId.of("Europe/Oslo"))
     .plusMonths(OPPFOLGINGSPLAN_UTKAST_RETENTION_MONTHS.toLong())
     .toInstant()
 

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/domain/PersistedOppfolgingsplanUtkast.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/domain/PersistedOppfolgingsplanUtkast.kt
@@ -7,7 +7,9 @@ import no.nav.syfo.oppfolgingsplan.domain.OrganizationDetails
 import no.nav.syfo.oppfolgingsplan.dto.OppfolgingsplanUtkastResponse
 import no.nav.syfo.oppfolgingsplan.dto.UtkastMetadata
 import no.nav.syfo.oppfolgingsplan.dto.UtkastResponseData
+import no.nav.syfo.oppfolgingsplan.service.OPPFOLGINGSPLAN_UTKAST_RETENTION_MONTHS
 import java.time.Instant
+import java.time.ZoneOffset
 import java.util.UUID
 
 data class PersistedOppfolgingsplanUtkast(
@@ -23,7 +25,12 @@ data class PersistedOppfolgingsplanUtkast(
 
 fun PersistedOppfolgingsplanUtkast.toUtkastMetadata(): UtkastMetadata = UtkastMetadata(
     sistLagretTidspunkt = updatedAt,
+    utkastUtloperDato = utkastUtloperDato(),
 )
+
+fun PersistedOppfolgingsplanUtkast.utkastUtloperDato(): Instant = updatedAt.atZone(ZoneOffset.UTC)
+    .plusMonths(OPPFOLGINGSPLAN_UTKAST_RETENTION_MONTHS.toLong())
+    .toInstant()
 
 fun PersistedOppfolgingsplanUtkast?.toResponse(sykmeldt: Sykmeldt): OppfolgingsplanUtkastResponse = OppfolgingsplanUtkastResponse(
     userHasEditAccess = sykmeldt.aktivSykmelding == true,
@@ -39,6 +46,7 @@ fun PersistedOppfolgingsplanUtkast?.toResponse(sykmeldt: Sykmeldt): Oppfolgingsp
         UtkastResponseData(
             content = it.content,
             sistLagretTidspunkt = it.updatedAt,
+            utkastUtloperDato = it.utkastUtloperDato(),
         )
     },
 )

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/ArbeidsgiverOppfolgingsplanOverviewResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/ArbeidsgiverOppfolgingsplanOverviewResponse.kt
@@ -9,6 +9,7 @@ import java.util.UUID
 
 data class UtkastMetadata(
     val sistLagretTidspunkt: Instant,
+    val utkastUtloperDato: Instant,
 )
 
 data class OversiktResponseData(

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/OppfolgingsplanUtkastResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/OppfolgingsplanUtkastResponse.kt
@@ -7,6 +7,7 @@ import java.time.Instant
 data class UtkastResponseData(
     val content: Map<String, String?>,
     val sistLagretTidspunkt: Instant,
+    val utkastUtloperDato: Instant,
 )
 
 data class OppfolgingsplanUtkastResponse(

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
@@ -41,7 +41,7 @@ import no.nav.syfo.varsel.EsyfovarselProducer
 import no.nav.syfo.varsel.domain.ArbeidstakerHendelse
 import no.nav.syfo.varsel.domain.HendelseType
 import java.time.Instant
-import java.time.ZoneOffset
+import java.time.ZoneId
 import java.util.UUID
 
 const val OPPFOLGINGSPLAN_UTKAST_RETENTION_MONTHS = 4
@@ -140,7 +140,7 @@ class OppfolgingsplanService(
         batchSize: Int = DEFAULT_UTKAST_CLEANUP_BATCH_SIZE,
     ): Int = deleteExpiredOppfolgingsplanUtkast(
         retentionCutoff = Instant.now()
-            .atZone(ZoneOffset.UTC)
+            .atZone(ZoneId.of("Europe/Oslo"))
             .minusMonths(retentionMonths.toLong())
             .toInstant(),
         batchSize = batchSize,

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
@@ -11,7 +11,6 @@ import no.nav.syfo.dinesykmeldte.client.Sykmeldt
 import no.nav.syfo.dinesykmeldte.client.getOrganizationName
 import no.nav.syfo.oppfolgingsplan.api.v1.veileder.OppfolgingsplanVeileder
 import no.nav.syfo.oppfolgingsplan.db.deleteExpiredOppfolgingsplanUtkast
-import no.nav.syfo.oppfolgingsplan.db.deleteExpiredOppfolgingsplanUtkastUpdatedBefore
 import no.nav.syfo.oppfolgingsplan.db.deleteOppfolgingsplanUtkast
 import no.nav.syfo.oppfolgingsplan.db.domain.PersistedOppfolgingsplan
 import no.nav.syfo.oppfolgingsplan.db.domain.PersistedOppfolgingsplanUtkast
@@ -42,6 +41,7 @@ import no.nav.syfo.varsel.EsyfovarselProducer
 import no.nav.syfo.varsel.domain.ArbeidstakerHendelse
 import no.nav.syfo.varsel.domain.HendelseType
 import java.time.Instant
+import java.time.ZoneOffset
 import java.util.UUID
 
 const val OPPFOLGINGSPLAN_UTKAST_RETENTION_MONTHS = 4
@@ -138,20 +138,25 @@ class OppfolgingsplanService(
     suspend fun deleteExpiredOppfolgingsplanUtkast(
         retentionMonths: Int = OPPFOLGINGSPLAN_UTKAST_RETENTION_MONTHS,
         batchSize: Int = DEFAULT_UTKAST_CLEANUP_BATCH_SIZE,
-        updatedBefore: Instant? = null,
+    ): Int = deleteExpiredOppfolgingsplanUtkast(
+        retentionCutoff = Instant.now()
+            .atZone(ZoneOffset.UTC)
+            .minusMonths(retentionMonths.toLong())
+            .toInstant(),
+        batchSize = batchSize,
+    )
+
+    internal suspend fun deleteExpiredOppfolgingsplanUtkast(
+        retentionCutoff: Instant,
+        batchSize: Int,
     ): Int = withContext(Dispatchers.IO) {
         var totalDeleted = 0
         try {
             var deletedInBatch: Int
 
             do {
-                deletedInBatch = updatedBefore?.let {
-                    database.deleteExpiredOppfolgingsplanUtkastUpdatedBefore(
-                        updatedBefore = it,
-                        limit = batchSize,
-                    )
-                } ?: database.deleteExpiredOppfolgingsplanUtkast(
-                    retentionMonths = retentionMonths,
+                deletedInBatch = database.deleteExpiredOppfolgingsplanUtkast(
+                    retentionCutoff = retentionCutoff,
                     limit = batchSize,
                 )
 

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
@@ -10,6 +10,8 @@ import no.nav.syfo.application.exception.PlanNotFoundException
 import no.nav.syfo.dinesykmeldte.client.Sykmeldt
 import no.nav.syfo.dinesykmeldte.client.getOrganizationName
 import no.nav.syfo.oppfolgingsplan.api.v1.veileder.OppfolgingsplanVeileder
+import no.nav.syfo.oppfolgingsplan.db.deleteExpiredOppfolgingsplanUtkast
+import no.nav.syfo.oppfolgingsplan.db.deleteExpiredOppfolgingsplanUtkastUpdatedBefore
 import no.nav.syfo.oppfolgingsplan.db.deleteOppfolgingsplanUtkast
 import no.nav.syfo.oppfolgingsplan.db.domain.PersistedOppfolgingsplan
 import no.nav.syfo.oppfolgingsplan.db.domain.PersistedOppfolgingsplanUtkast
@@ -41,6 +43,9 @@ import no.nav.syfo.varsel.domain.ArbeidstakerHendelse
 import no.nav.syfo.varsel.domain.HendelseType
 import java.time.Instant
 import java.util.UUID
+
+const val OPPFOLGINGSPLAN_UTKAST_RETENTION_MONTHS = 4
+const val DEFAULT_UTKAST_CLEANUP_BATCH_SIZE = 100
 
 /**
  * Service for managing oppfølgingsplaner.
@@ -127,6 +132,38 @@ class OppfolgingsplanService(
 
         withContext(Dispatchers.IO) {
             database.deleteOppfolgingsplanUtkast(sykmeldt)
+        }
+    }
+
+    suspend fun deleteExpiredOppfolgingsplanUtkast(
+        retentionMonths: Int = OPPFOLGINGSPLAN_UTKAST_RETENTION_MONTHS,
+        batchSize: Int = DEFAULT_UTKAST_CLEANUP_BATCH_SIZE,
+        updatedBefore: Instant? = null,
+    ): Int = withContext(Dispatchers.IO) {
+        var totalDeleted = 0
+        try {
+            var deletedInBatch: Int
+
+            do {
+                deletedInBatch = updatedBefore?.let {
+                    database.deleteExpiredOppfolgingsplanUtkastUpdatedBefore(
+                        updatedBefore = it,
+                        limit = batchSize,
+                    )
+                } ?: database.deleteExpiredOppfolgingsplanUtkast(
+                    retentionMonths = retentionMonths,
+                    limit = batchSize,
+                )
+
+                totalDeleted += deletedInBatch
+            } while (deletedInBatch != 0)
+
+            totalDeleted
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (exception: Exception) {
+            logger.error("Cleanup failed after deleting $totalDeleted oppfolgingsplan utkast", exception)
+            throw exception
         }
     }
 

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
@@ -45,7 +45,6 @@ import java.time.ZoneId
 import java.util.UUID
 
 const val OPPFOLGINGSPLAN_UTKAST_RETENTION_MONTHS = 4
-const val DEFAULT_UTKAST_CLEANUP_BATCH_SIZE = 100
 
 /**
  * Service for managing oppfølgingsplaner.
@@ -137,38 +136,14 @@ class OppfolgingsplanService(
 
     suspend fun deleteExpiredOppfolgingsplanUtkast(
         retentionMonths: Int = OPPFOLGINGSPLAN_UTKAST_RETENTION_MONTHS,
-        batchSize: Int = DEFAULT_UTKAST_CLEANUP_BATCH_SIZE,
-    ): Int = deleteExpiredOppfolgingsplanUtkast(
-        retentionCutoff = Instant.now()
+    ): Int {
+        val retentionCutoff = Instant.now()
             .atZone(ZoneId.of("Europe/Oslo"))
             .minusMonths(retentionMonths.toLong())
-            .toInstant(),
-        batchSize = batchSize,
-    )
+            .toInstant()
 
-    internal suspend fun deleteExpiredOppfolgingsplanUtkast(
-        retentionCutoff: Instant,
-        batchSize: Int,
-    ): Int = withContext(Dispatchers.IO) {
-        var totalDeleted = 0
-        try {
-            var deletedInBatch: Int
-
-            do {
-                deletedInBatch = database.deleteExpiredOppfolgingsplanUtkast(
-                    retentionCutoff = retentionCutoff,
-                    limit = batchSize,
-                )
-
-                totalDeleted += deletedInBatch
-            } while (deletedInBatch != 0)
-
-            totalDeleted
-        } catch (exception: CancellationException) {
-            throw exception
-        } catch (exception: Exception) {
-            logger.error("Cleanup failed after deleting $totalDeleted oppfolgingsplan utkast", exception)
-            throw exception
+        return withContext(Dispatchers.IO) {
+            database.deleteExpiredOppfolgingsplanUtkast(retentionCutoff)
         }
     }
 

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/task/CleanupUtkastTask.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/task/CleanupUtkastTask.kt
@@ -1,0 +1,50 @@
+package no.nav.syfo.oppfolgingsplan.task
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import no.nav.syfo.application.leaderelection.LeaderElection
+import no.nav.syfo.oppfolgingsplan.api.v1.COUNT_OPPFOLGINGSPLAN_DRAFT_AUTO_DELETED
+import no.nav.syfo.oppfolgingsplan.service.DEFAULT_UTKAST_CLEANUP_BATCH_SIZE
+import no.nav.syfo.oppfolgingsplan.service.OPPFOLGINGSPLAN_UTKAST_RETENTION_MONTHS
+import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
+import no.nav.syfo.util.logger
+
+private const val ONE_DAY_IN_MILLIS = 24 * 60 * 60 * 1000L
+
+class CleanupUtkastTask(
+    private val leaderElection: LeaderElection,
+    private val oppfolgingsplanService: OppfolgingsplanService,
+    private val delayMillis: Long = ONE_DAY_IN_MILLIS,
+) {
+    private val logger = logger()
+
+    suspend fun runTask() = coroutineScope {
+        try {
+            while (isActive) {
+                try {
+                    if (leaderElection.isLeader()) {
+                        val deletedDrafts = oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(
+                            retentionMonths = OPPFOLGINGSPLAN_UTKAST_RETENTION_MONTHS,
+                            batchSize = DEFAULT_UTKAST_CLEANUP_BATCH_SIZE,
+                        )
+
+                        if (deletedDrafts > 0) {
+                            COUNT_OPPFOLGINGSPLAN_DRAFT_AUTO_DELETED.increment(deletedDrafts.toDouble())
+                            logger.info("Deleted $deletedDrafts expired oppfolgingsplan drafts")
+                        }
+                    }
+                } catch (exception: CancellationException) {
+                    throw exception
+                } catch (exception: Exception) {
+                    logger.error("Failed to cleanup expired oppfolgingsplan drafts", exception)
+                }
+
+                delay(delayMillis)
+            }
+        } catch (exception: CancellationException) {
+            logger.info("Cancelled cleanup utkast task", exception)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/task/CleanupUtkastTask.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/task/CleanupUtkastTask.kt
@@ -6,8 +6,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import no.nav.syfo.application.leaderelection.LeaderElection
 import no.nav.syfo.oppfolgingsplan.api.v1.COUNT_OPPFOLGINGSPLAN_DRAFT_AUTO_DELETED
-import no.nav.syfo.oppfolgingsplan.service.DEFAULT_UTKAST_CLEANUP_BATCH_SIZE
-import no.nav.syfo.oppfolgingsplan.service.OPPFOLGINGSPLAN_UTKAST_RETENTION_MONTHS
 import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
 import no.nav.syfo.util.logger
 
@@ -25,10 +23,7 @@ class CleanupUtkastTask(
             return 0
         }
 
-        val deletedDrafts = oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(
-            retentionMonths = OPPFOLGINGSPLAN_UTKAST_RETENTION_MONTHS,
-            batchSize = DEFAULT_UTKAST_CLEANUP_BATCH_SIZE,
-        )
+        val deletedDrafts = oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast()
 
         if (deletedDrafts > 0) {
             COUNT_OPPFOLGINGSPLAN_DRAFT_AUTO_DELETED.increment(deletedDrafts.toDouble())

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/task/CleanupUtkastTask.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/task/CleanupUtkastTask.kt
@@ -1,51 +1,29 @@
 package no.nav.syfo.oppfolgingsplan.task
 
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
 import no.nav.syfo.application.leaderelection.LeaderElection
+import no.nav.syfo.application.task.RecurringTask
 import no.nav.syfo.oppfolgingsplan.api.v1.COUNT_OPPFOLGINGSPLAN_DRAFT_AUTO_DELETED
 import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
-import no.nav.syfo.util.logger
-
-private const val ONE_DAY_IN_MILLIS = 24 * 60 * 60 * 1000L
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
 
 class CleanupUtkastTask(
-    private val leaderElection: LeaderElection,
+    leaderElection: LeaderElection,
     private val oppfolgingsplanService: OppfolgingsplanService,
-    private val delayMillis: Long = ONE_DAY_IN_MILLIS,
+    interval: Duration = 1.days,
+) : RecurringTask(
+    name = CleanupUtkastTask::class.qualifiedName!!,
+    interval = interval,
+    leaderElection = leaderElection,
 ) {
-    private val logger = logger()
-
-    internal suspend fun runCleanup(): Int = try {
-        if (!leaderElection.isLeader()) {
-            return 0
-        }
-
+    override suspend fun execute() {
         val deletedDrafts = oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast()
 
         if (deletedDrafts > 0) {
             COUNT_OPPFOLGINGSPLAN_DRAFT_AUTO_DELETED.increment(deletedDrafts.toDouble())
-            logger.info("Deleted $deletedDrafts expired oppfolgingsplan drafts")
-        }
-
-        deletedDrafts
-    } catch (exception: CancellationException) {
-        throw exception
-    } catch (exception: Exception) {
-        logger.error("Failed to cleanup expired oppfolgingsplan drafts", exception)
-        0
-    }
-
-    suspend fun runTask() = coroutineScope {
-        try {
-            while (isActive) {
-                runCleanup()
-                delay(delayMillis)
-            }
-        } catch (exception: CancellationException) {
-            logger.info("Cancelled cleanup utkast task", exception)
+            log.info("Deleted $deletedDrafts expired oppfolgingsplan drafts")
+        } else {
+            log.debug("No expired oppfolgingsplan drafts to delete")
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/task/CleanupUtkastTask.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/task/CleanupUtkastTask.kt
@@ -20,27 +20,33 @@ class CleanupUtkastTask(
 ) {
     private val logger = logger()
 
+    internal suspend fun runCleanup(): Int = try {
+        if (!leaderElection.isLeader()) {
+            return 0
+        }
+
+        val deletedDrafts = oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(
+            retentionMonths = OPPFOLGINGSPLAN_UTKAST_RETENTION_MONTHS,
+            batchSize = DEFAULT_UTKAST_CLEANUP_BATCH_SIZE,
+        )
+
+        if (deletedDrafts > 0) {
+            COUNT_OPPFOLGINGSPLAN_DRAFT_AUTO_DELETED.increment(deletedDrafts.toDouble())
+            logger.info("Deleted $deletedDrafts expired oppfolgingsplan drafts")
+        }
+
+        deletedDrafts
+    } catch (exception: CancellationException) {
+        throw exception
+    } catch (exception: Exception) {
+        logger.error("Failed to cleanup expired oppfolgingsplan drafts", exception)
+        0
+    }
+
     suspend fun runTask() = coroutineScope {
         try {
             while (isActive) {
-                try {
-                    if (leaderElection.isLeader()) {
-                        val deletedDrafts = oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(
-                            retentionMonths = OPPFOLGINGSPLAN_UTKAST_RETENTION_MONTHS,
-                            batchSize = DEFAULT_UTKAST_CLEANUP_BATCH_SIZE,
-                        )
-
-                        if (deletedDrafts > 0) {
-                            COUNT_OPPFOLGINGSPLAN_DRAFT_AUTO_DELETED.increment(deletedDrafts.toDouble())
-                            logger.info("Deleted $deletedDrafts expired oppfolgingsplan drafts")
-                        }
-                    }
-                } catch (exception: CancellationException) {
-                    throw exception
-                } catch (exception: Exception) {
-                    logger.error("Failed to cleanup expired oppfolgingsplan drafts", exception)
-                }
-
+                runCleanup()
                 delay(delayMillis)
             }
         } catch (exception: CancellationException) {

--- a/src/main/kotlin/no/nav/syfo/plugins/ConfigureTasks.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/ConfigureTasks.kt
@@ -4,13 +4,17 @@ import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationStopping
 import kotlinx.coroutines.launch
 import no.nav.syfo.dokumentporten.SendOppfolgingsplanTask
+import no.nav.syfo.oppfolgingsplan.task.CleanupUtkastTask
 import org.koin.ktor.ext.inject
 
 fun Application.configureBackgroundTasks() {
     val sendDialogTask by inject<SendOppfolgingsplanTask>()
+    val cleanupUtkastTask by inject<CleanupUtkastTask>()
 
     val sendDialogTaskJob = launch { sendDialogTask.runTask() }
+    val cleanupUtkastTaskJob = launch { cleanupUtkastTask.runTask() }
     monitor.subscribe(ApplicationStopping) {
         sendDialogTaskJob.cancel()
+        cleanupUtkastTaskJob.cancel()
     }
 }

--- a/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
@@ -35,6 +35,7 @@ import no.nav.syfo.istilgangskontroll.IsTilgangskontrollService
 import no.nav.syfo.istilgangskontroll.client.FakeIsTilgangskontrollClient
 import no.nav.syfo.istilgangskontroll.client.IsTilgangskontrollClient
 import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
+import no.nav.syfo.oppfolgingsplan.task.CleanupUtkastTask
 import no.nav.syfo.pdfgen.PdfGenService
 import no.nav.syfo.pdfgen.client.PdfGenClient
 import no.nav.syfo.pdl.PdlService
@@ -202,6 +203,7 @@ private fun servicesModule() = module {
     single { OppfolgingsplanService(database = get(), esyfovarselProducer = get(), pdlService = get(), aaregService = get()) }
     single { PdfGenService(get(), get()) }
     single { SendOppfolgingsplanTask(get(), get()) }
+    single { CleanupUtkastTask(get(), get()) }
 }
 
 private fun Scope.env() = get<Environment>()

--- a/src/main/resources/db/migration/V13__add_utkast_updated_at_index.sql
+++ b/src/main/resources/db/migration/V13__add_utkast_updated_at_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX oppfolgingsplan_utkast_updated_at_idx ON oppfolgingsplan_utkast (updated_at);

--- a/src/main/resources/db/migration/V13__add_utkast_updated_at_index.sql
+++ b/src/main/resources/db/migration/V13__add_utkast_updated_at_index.sql
@@ -1,1 +1,1 @@
-CREATE INDEX oppfolgingsplan_utkast_updated_at_idx ON oppfolgingsplan_utkast (updated_at);
+CREATE INDEX IF NOT EXISTS oppfolgingsplan_utkast_updated_at_idx ON oppfolgingsplan_utkast (updated_at);

--- a/src/main/resources/openapi/arbeidsgiver.yaml
+++ b/src/main/resources/openapi/arbeidsgiver.yaml
@@ -640,6 +640,7 @@ components:
       required:
         - content
         - sistLagretTidspunkt
+        - utkastUtloperDato
       properties:
         content:
           type: object
@@ -649,6 +650,10 @@ components:
         sistLagretTidspunkt:
           type: string
           format: date-time
+        utkastUtloperDato:
+          type: string
+          format: date-time
+          description: "Beregnet utløpsdato for utkastet (informativt). Utkast slettes automatisk etter denne datoen."
 
     OppfolgingsplanMetadata:
       type: object
@@ -685,10 +690,15 @@ components:
       type: object
       required:
         - sistLagretTidspunkt
+        - utkastUtloperDato
       properties:
         sistLagretTidspunkt:
           type: string
           format: date-time
+        utkastUtloperDato:
+          type: string
+          format: date-time
+          description: "Beregnet utløpsdato for utkastet (informativt). Utkast slettes automatisk etter denne datoen."
 
     OrganizationDetails:
       type: object

--- a/src/test/kotlin/no/nav/syfo/TestDb.kt
+++ b/src/test/kotlin/no/nav/syfo/TestDb.kt
@@ -222,15 +222,3 @@ fun DatabaseInterface.findOppfolgingsplanUtkastByNarmesteLederId(
     }
 }
 
-fun DatabaseInterface.countOppfolgingsplanUtkast(): Int = connection.use { connection ->
-    connection.prepareStatement(
-        """
-        SELECT COUNT(*) AS count
-        FROM oppfolgingsplan_utkast
-        """.trimIndent(),
-    ).use {
-        val resultSet = it.executeQuery()
-        resultSet.next()
-        resultSet.getInt("count")
-    }
-}

--- a/src/test/kotlin/no/nav/syfo/TestDb.kt
+++ b/src/test/kotlin/no/nav/syfo/TestDb.kt
@@ -6,6 +6,7 @@ import com.zaxxer.hikari.HikariDataSource
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.oppfolgingsplan.db.domain.PersistedOppfolgingsplan
 import no.nav.syfo.oppfolgingsplan.db.domain.PersistedOppfolgingsplanUtkast
+import no.nav.syfo.oppfolgingsplan.db.toOppfolgingsplanUtkastDTO
 import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.toJsonString
 import org.flywaydb.core.Flyway
 import org.slf4j.LoggerFactory
@@ -13,7 +14,9 @@ import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy
 import java.sql.Connection
 import java.sql.Date
+import java.sql.Timestamp
 import java.sql.Types
+import java.time.Instant
 import java.util.UUID
 
 private val objectMapper = jacksonObjectMapper()
@@ -148,6 +151,7 @@ fun DatabaseInterface.persistOppfolgingsplanUtkast(
 ) {
     val insertStatement = """
         INSERT INTO oppfolgingsplan_utkast (
+            uuid,
             sykmeldt_fnr,
             narmeste_leder_id,
             narmeste_leder_fnr,
@@ -155,7 +159,7 @@ fun DatabaseInterface.persistOppfolgingsplanUtkast(
             content,
             created_at,
             updated_at
-        ) VALUES (?, ?, ?, ?, ?, NOW(), NOW())
+        ) VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW())
         ON CONFLICT (narmeste_leder_id) DO UPDATE SET
             sykmeldt_fnr = EXCLUDED.sykmeldt_fnr,
             narmeste_leder_fnr = EXCLUDED.narmeste_leder_fnr,
@@ -166,13 +170,67 @@ fun DatabaseInterface.persistOppfolgingsplanUtkast(
 
     connection.use { connection ->
         connection.prepareStatement(insertStatement).use {
-            it.setString(1, persistedOppfolgingsplanUtkast.sykmeldtFnr)
-            it.setString(2, persistedOppfolgingsplanUtkast.narmesteLederId)
-            it.setString(3, persistedOppfolgingsplanUtkast.narmesteLederFnr)
-            it.setString(4, persistedOppfolgingsplanUtkast.organisasjonsnummer)
-            it.setObject(5, objectMapper.writeValueAsString(persistedOppfolgingsplanUtkast.content), Types.OTHER)
+            it.setObject(1, persistedOppfolgingsplanUtkast.uuid)
+            it.setString(2, persistedOppfolgingsplanUtkast.sykmeldtFnr)
+            it.setString(3, persistedOppfolgingsplanUtkast.narmesteLederId)
+            it.setString(4, persistedOppfolgingsplanUtkast.narmesteLederFnr)
+            it.setString(5, persistedOppfolgingsplanUtkast.organisasjonsnummer)
+            it.setObject(6, objectMapper.writeValueAsString(persistedOppfolgingsplanUtkast.content), Types.OTHER)
             it.executeUpdate()
         }
         connection.commit()
+    }
+}
+
+fun DatabaseInterface.setOppfolgingsplanUtkastUpdatedAt(
+    uuid: UUID,
+    updatedAt: Instant,
+) {
+    connection.use { connection ->
+        connection.prepareStatement(
+            """
+            UPDATE oppfolgingsplan_utkast
+            SET updated_at = ?
+            WHERE uuid = ?
+            """.trimIndent(),
+        ).use {
+            it.setTimestamp(1, Timestamp.from(updatedAt))
+            it.setObject(2, uuid)
+            it.executeUpdate()
+        }
+        connection.commit()
+    }
+}
+
+fun DatabaseInterface.findOppfolgingsplanUtkastByNarmesteLederId(
+    narmesteLederId: String,
+): PersistedOppfolgingsplanUtkast? = connection.use { connection ->
+    connection.prepareStatement(
+        """
+        SELECT *
+        FROM oppfolgingsplan_utkast
+        WHERE narmeste_leder_id = ?
+        """.trimIndent(),
+    ).use {
+        it.setString(1, narmesteLederId)
+        val resultSet = it.executeQuery()
+        if (resultSet.next()) {
+            resultSet.toOppfolgingsplanUtkastDTO()
+        } else {
+            null
+        }
+    }
+}
+
+fun DatabaseInterface.countOppfolgingsplanUtkast(): Int = connection.use { connection ->
+    connection.prepareStatement(
+        """
+        SELECT COUNT(*) AS count
+        FROM oppfolgingsplan_utkast
+        """.trimIndent(),
+    ).use {
+        val resultSet = it.executeQuery()
+        resultSet.next()
+        resultSet.getInt("count")
     }
 }

--- a/src/test/kotlin/no/nav/syfo/application/task/RecurringTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/application/task/RecurringTaskTest.kt
@@ -1,0 +1,111 @@
+package no.nav.syfo.application.task
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import no.nav.syfo.application.leaderelection.LeaderElection
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+
+class RecurringTaskTest :
+    DescribeSpec({
+        describe("runTask") {
+            it("should call execute when pod is leader") {
+                val leaderElection = mockk<LeaderElection>()
+                coEvery { leaderElection.isLeader() } returns true
+
+                val executeCount = AtomicInteger(0)
+                val task = object : RecurringTask("test-task", 10.milliseconds, leaderElection) {
+                    override suspend fun execute() {
+                        executeCount.incrementAndGet()
+                    }
+                }
+
+                val job = launch { task.runTask() }
+                delay(100)
+                job.cancelAndJoin()
+
+                executeCount.get() shouldBeGreaterThan 0
+            }
+
+            it("should skip execute when pod is not leader") {
+                val leaderElection = mockk<LeaderElection>()
+                coEvery { leaderElection.isLeader() } returns false
+
+                val executeCount = AtomicInteger(0)
+                val task = object : RecurringTask("test-task", 10.milliseconds, leaderElection) {
+                    override suspend fun execute() {
+                        executeCount.incrementAndGet()
+                    }
+                }
+
+                val job = launch { task.runTask() }
+                delay(100)
+                job.cancelAndJoin()
+
+                executeCount.get() shouldBe 0
+            }
+
+            it("should continue loop after exception in execute") {
+                val leaderElection = mockk<LeaderElection>()
+                coEvery { leaderElection.isLeader() } returns true
+
+                val executeCount = AtomicInteger(0)
+                val task = object : RecurringTask("test-task", 10.milliseconds, leaderElection) {
+                    override suspend fun execute() {
+                        val callNumber = executeCount.incrementAndGet()
+                        if (callNumber == 1) {
+                            throw RuntimeException("boom")
+                        }
+                    }
+                }
+
+                val job = launch { task.runTask() }
+                delay(100)
+                job.cancelAndJoin()
+
+                executeCount.get() shouldBeGreaterThan 1
+            }
+
+            it("should stop loop when execute throws CancellationException") {
+                val leaderElection = mockk<LeaderElection>()
+                coEvery { leaderElection.isLeader() } returns true
+
+                val executeCount = AtomicInteger(0)
+                val task = object : RecurringTask("test-task", 10.milliseconds, leaderElection) {
+                    override suspend fun execute() {
+                        executeCount.incrementAndGet()
+                        throw CancellationException("cancelled internally")
+                    }
+                }
+
+                val job = launch { task.runTask() }
+                delay(100)
+                job.cancelAndJoin()
+
+                executeCount.get() shouldBe 1
+            }
+
+            it("should stop gracefully when job is cancelled") {
+                val leaderElection = mockk<LeaderElection>()
+                coEvery { leaderElection.isLeader() } returns true
+
+                val task = object : RecurringTask("test-task", 10.milliseconds, leaderElection) {
+                    override suspend fun execute() {
+                        // no-op
+                    }
+                }
+
+                val job = launch { task.runTask() }
+                delay(50)
+                job.cancelAndJoin()
+                // If we reach here, the task stopped without leaking exceptions
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/db/PersistedOppfolgingsplanUtkastTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/db/PersistedOppfolgingsplanUtkastTest.kt
@@ -1,0 +1,31 @@
+package no.nav.syfo.oppfolgingsplan.db
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import no.nav.syfo.defaultPersistedOppfolgingsplanUtkast
+import no.nav.syfo.defaultSykmeldt
+import no.nav.syfo.oppfolgingsplan.db.domain.toResponse
+import no.nav.syfo.oppfolgingsplan.db.domain.toUtkastMetadata
+import no.nav.syfo.oppfolgingsplan.db.domain.utkastUtloperDato
+import java.time.Instant
+
+class PersistedOppfolgingsplanUtkastTest :
+    DescribeSpec({
+        describe("PersistedOppfolgingsplanUtkast") {
+            it("should calculate utkastUtloperDato in UTC from updatedAt") {
+                val updatedAt = Instant.parse("2025-01-15T10:30:00Z")
+                val utkast = defaultPersistedOppfolgingsplanUtkast().copy(updatedAt = updatedAt)
+
+                utkast.utkastUtloperDato() shouldBe Instant.parse("2025-05-15T10:30:00Z")
+            }
+
+            it("should expose utkastUtloperDato in metadata and response dto") {
+                val updatedAt = Instant.parse("2025-01-15T10:30:00Z")
+                val utkast = defaultPersistedOppfolgingsplanUtkast().copy(updatedAt = updatedAt)
+                val expectedExpiry = Instant.parse("2025-05-15T10:30:00Z")
+
+                utkast.toUtkastMetadata().utkastUtloperDato shouldBe expectedExpiry
+                utkast.toResponse(defaultSykmeldt()).utkast?.utkastUtloperDato shouldBe expectedExpiry
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/db/PersistedOppfolgingsplanUtkastTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/db/PersistedOppfolgingsplanUtkastTest.kt
@@ -12,17 +12,18 @@ import java.time.Instant
 class PersistedOppfolgingsplanUtkastTest :
     DescribeSpec({
         describe("PersistedOppfolgingsplanUtkast") {
-            it("should calculate utkastUtloperDato in UTC from updatedAt") {
+            it("should calculate utkastUtloperDato in Norwegian time from updatedAt") {
                 val updatedAt = Instant.parse("2025-01-15T10:30:00Z")
                 val utkast = defaultPersistedOppfolgingsplanUtkast().copy(updatedAt = updatedAt)
 
-                utkast.utkastUtloperDato() shouldBe Instant.parse("2025-05-15T10:30:00Z")
+                // 10:30 UTC = 11:30 CET → +4 months → 11:30 CEST = 09:30 UTC
+                utkast.utkastUtloperDato() shouldBe Instant.parse("2025-05-15T09:30:00Z")
             }
 
             it("should expose utkastUtloperDato in metadata and response dto") {
                 val updatedAt = Instant.parse("2025-01-15T10:30:00Z")
                 val utkast = defaultPersistedOppfolgingsplanUtkast().copy(updatedAt = updatedAt)
-                val expectedExpiry = Instant.parse("2025-05-15T10:30:00Z")
+                val expectedExpiry = Instant.parse("2025-05-15T09:30:00Z")
 
                 utkast.toUtkastMetadata().utkastUtloperDato shouldBe expectedExpiry
                 utkast.toResponse(defaultSykmeldt()).utkast?.utkastUtloperDato shouldBe expectedExpiry

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanServiceTest.kt
@@ -12,14 +12,21 @@ import kotlinx.coroutines.CancellationException
 import no.nav.syfo.TestDB
 import no.nav.syfo.aareg.AaregService
 import no.nav.syfo.aareg.Stillingsinformasjon
+import no.nav.syfo.countOppfolgingsplanUtkast
 import no.nav.syfo.defaultOppfolgingsplan
 import no.nav.syfo.defaultPersistedOppfolgingsplan
+import no.nav.syfo.defaultPersistedOppfolgingsplanUtkast
 import no.nav.syfo.defaultSykmeldt
+import no.nav.syfo.findOppfolgingsplanUtkastByNarmesteLederId
 import no.nav.syfo.pdl.PdlService
 import no.nav.syfo.persistOppfolgingsplan
+import no.nav.syfo.persistOppfolgingsplanUtkast
+import no.nav.syfo.setOppfolgingsplanUtkastUpdatedAt
 import no.nav.syfo.varsel.EsyfovarselProducer
 import java.math.BigDecimal
 import java.time.Instant
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 
 class OppfolgingsplanServiceTest :
@@ -177,6 +184,124 @@ class OppfolgingsplanServiceTest :
                             createOppfolgingsplanRequest = defaultOppfolgingsplan(),
                         )
                     }
+                }
+            }
+
+            describe("deleteExpiredOppfolgingsplanUtkast") {
+                afterTest {
+                    TestDB.clearAllData()
+                    clearAllMocks()
+                }
+
+                it("should delete drafts older than four months and keep exact cutoff and newer drafts") {
+                    val service = OppfolgingsplanService(
+                        database = TestDB.database,
+                        pdlService = mockk(relaxed = true),
+                        esyfovarselProducer = mockk(relaxed = true),
+                        aaregService = mockk(relaxed = true),
+                    )
+                    val referenceTime = ZonedDateTime.of(2025, 8, 15, 12, 0, 0, 0, ZoneOffset.UTC)
+                    val cutoff = referenceTime.minusMonths(4).toInstant()
+
+                    val expiredDraft = defaultPersistedOppfolgingsplanUtkast().copy(
+                        narmesteLederId = "leder-expired",
+                    )
+                    val exactCutoffDraft = defaultPersistedOppfolgingsplanUtkast().copy(
+                        narmesteLederId = "leder-cutoff",
+                    )
+                    val freshDraft = defaultPersistedOppfolgingsplanUtkast().copy(
+                        narmesteLederId = "leder-fresh",
+                    )
+
+                    TestDB.database.persistOppfolgingsplanUtkast(expiredDraft)
+                    TestDB.database.persistOppfolgingsplanUtkast(exactCutoffDraft)
+                    TestDB.database.persistOppfolgingsplanUtkast(freshDraft)
+
+                    TestDB.database.setOppfolgingsplanUtkastUpdatedAt(expiredDraft.uuid, cutoff.minus(1, ChronoUnit.DAYS))
+                    TestDB.database.setOppfolgingsplanUtkastUpdatedAt(exactCutoffDraft.uuid, cutoff)
+                    TestDB.database.setOppfolgingsplanUtkastUpdatedAt(
+                        freshDraft.uuid,
+                        referenceTime.minusMonths(3).minusDays(29).toInstant(),
+                    )
+
+                    val deletedDrafts = service.deleteExpiredOppfolgingsplanUtkast(
+                        batchSize = 2,
+                        updatedBefore = cutoff,
+                    )
+
+                    deletedDrafts shouldBe 1
+                    TestDB.database.findOppfolgingsplanUtkastByNarmesteLederId(expiredDraft.narmesteLederId).shouldBeNull()
+                    TestDB.database.findOppfolgingsplanUtkastByNarmesteLederId(exactCutoffDraft.narmesteLederId)
+                        ?.uuid shouldBe exactCutoffDraft.uuid
+                    TestDB.database.findOppfolgingsplanUtkastByNarmesteLederId(freshDraft.narmesteLederId)
+                        ?.uuid shouldBe freshDraft.uuid
+                }
+
+                it("should delete expired drafts in batches until no rows remain") {
+                    val service = OppfolgingsplanService(
+                        database = TestDB.database,
+                        pdlService = mockk(relaxed = true),
+                        esyfovarselProducer = mockk(relaxed = true),
+                        aaregService = mockk(relaxed = true),
+                    )
+                    val referenceTime = ZonedDateTime.of(2025, 8, 15, 12, 0, 0, 0, ZoneOffset.UTC)
+                    val cutoff = referenceTime.minusMonths(4).toInstant()
+
+                    val draftOne = defaultPersistedOppfolgingsplanUtkast().copy(narmesteLederId = "leder-batch-1")
+                    val draftTwo = defaultPersistedOppfolgingsplanUtkast().copy(narmesteLederId = "leder-batch-2")
+                    val draftThree = defaultPersistedOppfolgingsplanUtkast().copy(narmesteLederId = "leder-batch-3")
+
+                    listOf(draftOne, draftTwo, draftThree).forEach { draft ->
+                        TestDB.database.persistOppfolgingsplanUtkast(draft)
+                        TestDB.database.setOppfolgingsplanUtkastUpdatedAt(
+                            draft.uuid,
+                            cutoff.minus(2, ChronoUnit.DAYS),
+                        )
+                    }
+
+                    val deletedDrafts = service.deleteExpiredOppfolgingsplanUtkast(
+                        batchSize = 2,
+                        updatedBefore = cutoff,
+                    )
+
+                    deletedDrafts shouldBe 3
+                    TestDB.database.countOppfolgingsplanUtkast() shouldBe 0
+                }
+
+                it("should delete expired drafts using retentionMonths SQL path when updatedBefore is null") {
+                    val service = OppfolgingsplanService(
+                        database = TestDB.database,
+                        pdlService = mockk(relaxed = true),
+                        esyfovarselProducer = mockk(relaxed = true),
+                        aaregService = mockk(relaxed = true),
+                    )
+                    val expiredDraft = defaultPersistedOppfolgingsplanUtkast().copy(
+                        narmesteLederId = "leder-expired-default-path",
+                    )
+                    val freshDraft = defaultPersistedOppfolgingsplanUtkast().copy(
+                        narmesteLederId = "leder-fresh-default-path",
+                    )
+
+                    TestDB.database.persistOppfolgingsplanUtkast(expiredDraft)
+                    TestDB.database.persistOppfolgingsplanUtkast(freshDraft)
+
+                    TestDB.database.setOppfolgingsplanUtkastUpdatedAt(
+                        expiredDraft.uuid,
+                        Instant.now().minus(180, ChronoUnit.DAYS),
+                    )
+                    TestDB.database.setOppfolgingsplanUtkastUpdatedAt(
+                        freshDraft.uuid,
+                        Instant.now().minus(30, ChronoUnit.DAYS),
+                    )
+
+                    val deletedDrafts = service.deleteExpiredOppfolgingsplanUtkast(
+                        batchSize = 10,
+                    )
+
+                    deletedDrafts shouldBe 1
+                    TestDB.database.findOppfolgingsplanUtkastByNarmesteLederId(expiredDraft.narmesteLederId).shouldBeNull()
+                    TestDB.database.findOppfolgingsplanUtkastByNarmesteLederId(freshDraft.narmesteLederId)
+                        ?.uuid shouldBe freshDraft.uuid
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanServiceTest.kt
@@ -12,12 +12,12 @@ import kotlinx.coroutines.CancellationException
 import no.nav.syfo.TestDB
 import no.nav.syfo.aareg.AaregService
 import no.nav.syfo.aareg.Stillingsinformasjon
-import no.nav.syfo.countOppfolgingsplanUtkast
 import no.nav.syfo.defaultOppfolgingsplan
 import no.nav.syfo.defaultPersistedOppfolgingsplan
 import no.nav.syfo.defaultPersistedOppfolgingsplanUtkast
 import no.nav.syfo.defaultSykmeldt
 import no.nav.syfo.findOppfolgingsplanUtkastByNarmesteLederId
+import no.nav.syfo.oppfolgingsplan.db.deleteExpiredOppfolgingsplanUtkast
 import no.nav.syfo.pdl.PdlService
 import no.nav.syfo.persistOppfolgingsplan
 import no.nav.syfo.persistOppfolgingsplanUtkast
@@ -193,13 +193,7 @@ class OppfolgingsplanServiceTest :
                     clearAllMocks()
                 }
 
-                it("should delete drafts older than four months and keep exact cutoff and newer drafts") {
-                    val service = OppfolgingsplanService(
-                        database = TestDB.database,
-                        pdlService = mockk(relaxed = true),
-                        esyfovarselProducer = mockk(relaxed = true),
-                        aaregService = mockk(relaxed = true),
-                    )
+                it("should delete drafts older than cutoff and keep exact cutoff and newer drafts") {
                     val referenceTime = ZonedDateTime.of(2025, 8, 15, 12, 0, 0, 0, ZoneOffset.UTC)
                     val cutoff = referenceTime.minusMonths(4).toInstant()
 
@@ -224,9 +218,8 @@ class OppfolgingsplanServiceTest :
                         referenceTime.minusMonths(3).minusDays(29).toInstant(),
                     )
 
-                    val deletedDrafts = service.deleteExpiredOppfolgingsplanUtkast(
+                    val deletedDrafts = TestDB.database.deleteExpiredOppfolgingsplanUtkast(
                         retentionCutoff = cutoff,
-                        batchSize = 2,
                     )
 
                     deletedDrafts shouldBe 1
@@ -235,37 +228,6 @@ class OppfolgingsplanServiceTest :
                         ?.uuid shouldBe exactCutoffDraft.uuid
                     TestDB.database.findOppfolgingsplanUtkastByNarmesteLederId(freshDraft.narmesteLederId)
                         ?.uuid shouldBe freshDraft.uuid
-                }
-
-                it("should delete expired drafts in batches until no rows remain") {
-                    val service = OppfolgingsplanService(
-                        database = TestDB.database,
-                        pdlService = mockk(relaxed = true),
-                        esyfovarselProducer = mockk(relaxed = true),
-                        aaregService = mockk(relaxed = true),
-                    )
-                    val referenceTime = ZonedDateTime.of(2025, 8, 15, 12, 0, 0, 0, ZoneOffset.UTC)
-                    val cutoff = referenceTime.minusMonths(4).toInstant()
-
-                    val draftOne = defaultPersistedOppfolgingsplanUtkast().copy(narmesteLederId = "leder-batch-1")
-                    val draftTwo = defaultPersistedOppfolgingsplanUtkast().copy(narmesteLederId = "leder-batch-2")
-                    val draftThree = defaultPersistedOppfolgingsplanUtkast().copy(narmesteLederId = "leder-batch-3")
-
-                    listOf(draftOne, draftTwo, draftThree).forEach { draft ->
-                        TestDB.database.persistOppfolgingsplanUtkast(draft)
-                        TestDB.database.setOppfolgingsplanUtkastUpdatedAt(
-                            draft.uuid,
-                            cutoff.minus(2, ChronoUnit.DAYS),
-                        )
-                    }
-
-                    val deletedDrafts = service.deleteExpiredOppfolgingsplanUtkast(
-                        retentionCutoff = cutoff,
-                        batchSize = 2,
-                    )
-
-                    deletedDrafts shouldBe 3
-                    TestDB.database.countOppfolgingsplanUtkast() shouldBe 0
                 }
 
                 it("should calculate retention cutoff from retentionMonths before deleting expired drafts") {
@@ -294,9 +256,7 @@ class OppfolgingsplanServiceTest :
                         Instant.now().minus(30, ChronoUnit.DAYS),
                     )
 
-                    val deletedDrafts = service.deleteExpiredOppfolgingsplanUtkast(
-                        batchSize = 10,
-                    )
+                    val deletedDrafts = service.deleteExpiredOppfolgingsplanUtkast()
 
                     deletedDrafts shouldBe 1
                     TestDB.database.findOppfolgingsplanUtkastByNarmesteLederId(expiredDraft.narmesteLederId).shouldBeNull()

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanServiceTest.kt
@@ -225,8 +225,8 @@ class OppfolgingsplanServiceTest :
                     )
 
                     val deletedDrafts = service.deleteExpiredOppfolgingsplanUtkast(
+                        retentionCutoff = cutoff,
                         batchSize = 2,
-                        updatedBefore = cutoff,
                     )
 
                     deletedDrafts shouldBe 1
@@ -260,15 +260,15 @@ class OppfolgingsplanServiceTest :
                     }
 
                     val deletedDrafts = service.deleteExpiredOppfolgingsplanUtkast(
+                        retentionCutoff = cutoff,
                         batchSize = 2,
-                        updatedBefore = cutoff,
                     )
 
                     deletedDrafts shouldBe 3
                     TestDB.database.countOppfolgingsplanUtkast() shouldBe 0
                 }
 
-                it("should delete expired drafts using retentionMonths SQL path when updatedBefore is null") {
+                it("should calculate retention cutoff from retentionMonths before deleting expired drafts") {
                     val service = OppfolgingsplanService(
                         database = TestDB.database,
                         pdlService = mockk(relaxed = true),

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/CleanupUtkastTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/CleanupUtkastTaskTest.kt
@@ -4,39 +4,36 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.runBlocking
 import no.nav.syfo.application.leaderelection.LeaderElection
 import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
+import kotlin.time.Duration.Companion.days
 
 class CleanupUtkastTaskTest :
     DescribeSpec({
-        describe("runCleanup") {
-            it("should continue next iteration after exception in cleanup") {
+        describe("execute") {
+            it("should delete expired drafts and increment counter") {
                 val leaderElection = mockk<LeaderElection>()
                 val oppfolgingsplanService = mockk<OppfolgingsplanService>()
 
                 coEvery { leaderElection.isLeader() } returns true
                 coEvery {
                     oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(any<Int>())
-                } throws RuntimeException("boom") andThen 0 andThen 0
+                } returns 3
 
-                val cleanupUtkastTask = CleanupUtkastTask(
+                val task = CleanupUtkastTask(
                     leaderElection = leaderElection,
                     oppfolgingsplanService = oppfolgingsplanService,
-                    delayMillis = 10,
+                    interval = 1.days,
                 )
 
-                runBlocking {
-                    cleanupUtkastTask.runCleanup()
-                    cleanupUtkastTask.runCleanup()
-                }
+                task.execute()
 
-                coVerify(exactly = 2) {
-                    oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(any<Int>())
+                coVerify(exactly = 1) {
+                    oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(4)
                 }
             }
 
-            it("should call cleanup with configured retention months and batch size") {
+            it("should call cleanup with default retention months") {
                 val leaderElection = mockk<LeaderElection>()
                 val oppfolgingsplanService = mockk<OppfolgingsplanService>()
 
@@ -45,15 +42,13 @@ class CleanupUtkastTaskTest :
                     oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(any<Int>())
                 } returns 0
 
-                val cleanupUtkastTask = CleanupUtkastTask(
+                val task = CleanupUtkastTask(
                     leaderElection = leaderElection,
                     oppfolgingsplanService = oppfolgingsplanService,
-                    delayMillis = 10,
+                    interval = 1.days,
                 )
 
-                runBlocking {
-                    cleanupUtkastTask.runCleanup()
-                }
+                task.execute()
 
                 coVerify(exactly = 1) {
                     oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(4)

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/CleanupUtkastTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/CleanupUtkastTaskTest.kt
@@ -1,0 +1,68 @@
+package no.nav.syfo.oppfolgingsplan.task
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.application.leaderelection.LeaderElection
+import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
+
+class CleanupUtkastTaskTest :
+    DescribeSpec({
+        describe("runTask") {
+            it("should continue next iteration after exception in cleanup") {
+                val leaderElection = mockk<LeaderElection>()
+                val oppfolgingsplanService = mockk<OppfolgingsplanService>()
+
+                coEvery { leaderElection.isLeader() } returns true
+                coEvery { oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(any(), any(), any()) } throws RuntimeException("boom") andThen 0 andThen 0
+
+                val cleanupUtkastTask = CleanupUtkastTask(
+                    leaderElection = leaderElection,
+                    oppfolgingsplanService = oppfolgingsplanService,
+                    delayMillis = 10,
+                )
+
+                runBlocking {
+                    val job = launch { cleanupUtkastTask.runTask() }
+
+                    delay(35)
+                    job.cancel()
+                    job.join()
+                }
+
+                coVerify(atLeast = 2) {
+                    oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(any(), any(), any())
+                }
+            }
+
+            it("should call cleanup with configured retention months and batch size") {
+                val leaderElection = mockk<LeaderElection>()
+                val oppfolgingsplanService = mockk<OppfolgingsplanService>()
+
+                coEvery { leaderElection.isLeader() } returns true
+                coEvery { oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(any(), any(), any()) } returns 0
+
+                val cleanupUtkastTask = CleanupUtkastTask(
+                    leaderElection = leaderElection,
+                    oppfolgingsplanService = oppfolgingsplanService,
+                    delayMillis = 10,
+                )
+
+                runBlocking {
+                    val job = launch { cleanupUtkastTask.runTask() }
+
+                    delay(15)
+                    job.cancel()
+                    job.join()
+                }
+
+                coVerify(atLeast = 1) {
+                    oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(4, 100, null)
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/CleanupUtkastTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/CleanupUtkastTaskTest.kt
@@ -17,7 +17,7 @@ class CleanupUtkastTaskTest :
 
                 coEvery { leaderElection.isLeader() } returns true
                 coEvery {
-                    oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(any<Int>(), any<Int>())
+                    oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(any<Int>())
                 } throws RuntimeException("boom") andThen 0 andThen 0
 
                 val cleanupUtkastTask = CleanupUtkastTask(
@@ -32,7 +32,7 @@ class CleanupUtkastTaskTest :
                 }
 
                 coVerify(exactly = 2) {
-                    oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(any<Int>(), any<Int>())
+                    oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(any<Int>())
                 }
             }
 
@@ -42,7 +42,7 @@ class CleanupUtkastTaskTest :
 
                 coEvery { leaderElection.isLeader() } returns true
                 coEvery {
-                    oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(any<Int>(), any<Int>())
+                    oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(any<Int>())
                 } returns 0
 
                 val cleanupUtkastTask = CleanupUtkastTask(
@@ -56,7 +56,7 @@ class CleanupUtkastTaskTest :
                 }
 
                 coVerify(exactly = 1) {
-                    oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(4, 100)
+                    oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(4)
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/CleanupUtkastTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/CleanupUtkastTaskTest.kt
@@ -4,21 +4,21 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import no.nav.syfo.application.leaderelection.LeaderElection
 import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
 
 class CleanupUtkastTaskTest :
     DescribeSpec({
-        describe("runTask") {
+        describe("runCleanup") {
             it("should continue next iteration after exception in cleanup") {
                 val leaderElection = mockk<LeaderElection>()
                 val oppfolgingsplanService = mockk<OppfolgingsplanService>()
 
                 coEvery { leaderElection.isLeader() } returns true
-                coEvery { oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(any(), any(), any()) } throws RuntimeException("boom") andThen 0 andThen 0
+                coEvery {
+                    oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(any<Int>(), any<Int>())
+                } throws RuntimeException("boom") andThen 0 andThen 0
 
                 val cleanupUtkastTask = CleanupUtkastTask(
                     leaderElection = leaderElection,
@@ -27,15 +27,12 @@ class CleanupUtkastTaskTest :
                 )
 
                 runBlocking {
-                    val job = launch { cleanupUtkastTask.runTask() }
-
-                    delay(35)
-                    job.cancel()
-                    job.join()
+                    cleanupUtkastTask.runCleanup()
+                    cleanupUtkastTask.runCleanup()
                 }
 
-                coVerify(atLeast = 2) {
-                    oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(any(), any(), any())
+                coVerify(exactly = 2) {
+                    oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(any<Int>(), any<Int>())
                 }
             }
 
@@ -44,7 +41,9 @@ class CleanupUtkastTaskTest :
                 val oppfolgingsplanService = mockk<OppfolgingsplanService>()
 
                 coEvery { leaderElection.isLeader() } returns true
-                coEvery { oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(any(), any(), any()) } returns 0
+                coEvery {
+                    oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(any<Int>(), any<Int>())
+                } returns 0
 
                 val cleanupUtkastTask = CleanupUtkastTask(
                     leaderElection = leaderElection,
@@ -53,15 +52,11 @@ class CleanupUtkastTaskTest :
                 )
 
                 runBlocking {
-                    val job = launch { cleanupUtkastTask.runTask() }
-
-                    delay(15)
-                    job.cancel()
-                    job.join()
+                    cleanupUtkastTask.runCleanup()
                 }
 
-                coVerify(atLeast = 1) {
-                    oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(4, 100, null)
+                coVerify(exactly = 1) {
+                    oppfolgingsplanService.deleteExpiredOppfolgingsplanUtkast(4, 100)
                 }
             }
         }


### PR DESCRIPTION
## Beskrivelse

Implementerer daglig bakgrunnstask `CleanupUtkastTask` som hard-deleter oppfølgingsplan-utkast eldre enn 4 måneder. I tillegg refaktorerer vi task-infrastrukturen med en felles `RecurringTask`-baseklasse som begge bakgrunnstasker nå bruker.

Closes #269

## Endringer

### Ny funksjonalitet
- **Flyway V13**: Indeks på `oppfolgingsplan_utkast.updated_at` (`IF NOT EXISTS`)
- **DAO**: `DELETE FROM oppfolgingsplan_utkast WHERE updated_at < ?`
- **Service**: Beregner retention-cutoff med `Europe/Oslo` timezone
- **CleanupUtkastTask**: Daglig cleanup, extender `RecurringTask`
- **Prometheus-counter**: `oppfolgingsplan_draft_auto_deleted`
- **DTO**: `utkastUtloperDato` i oversikt-API (informativt, Europe/Oslo)
- **OpenAPI**: `arbeidsgiver.yaml` oppdatert med nytt felt

### Refaktorering
- **RecurringTask**: Ny abstrakt baseklasse med leader election, feilhåndtering og graceful shutdown
- **SendOppfolgingsplanTask**: Refaktorert til å extende `RecurringTask` (fjernet duplisert while/delay/isLeader-logikk, fikk gratis error handling)

## Inspeksjon

Kryssmodell-inspeksjon utført (inspektør-claude + inspektør-gpt) i to runder:
- Runde 1: 5 funn identifisert og utbedret
- Runde 2: 3 funn — duplikat logger og manglende debug-logging fikset, timing-baserte tester og DST-asymmetri akseptert som ikke-blokkerende

## Sjekkliste

- [x] `./gradlew build` passerer (unit tests grønne, integrasjonstester krever Docker/CI)
- [x] Flyway-migrasjon idempotent (`CREATE INDEX IF NOT EXISTS`)
- [x] Ingen PII i logger
- [x] Parameteriserte SQL-spørringer
- [x] OpenAPI-spec synkronisert med DTO-er
- [x] Prometheus-metrikk registrert
- [x] RecurringTask testdekket (5 tester: leader-sjekk, feilhåndtering, cancellation)
- [x] README oppdatert