### PR TITLE
fix(kafka): strip DTO to minimum fields and force consumer replay

### DIFF
--- a/src/main/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumer.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.sykmelding.kafka
 
+import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.module.kotlin.readValue
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -57,7 +58,24 @@ class SykmeldingsperiodeConsumer(
 
                 while (currentCoroutineContext().isActive && running) {
                     val records = kafkaConsumer.poll(POLL_DURATION)
-                    records.forEach { processRecord(it) }
+                    var deserializationErrors = 0
+
+                    records.forEach { record ->
+                        try {
+                            processRecord(record)
+                        } catch (ex: JsonProcessingException) {
+                            deserializationErrors++
+                            COUNT_SYKMELDING_DESERIALIZATION_ERROR.increment()
+                            log.error(
+                                "Failed to deserialize sykmelding at partition=${record.partition()}, offset=${record.offset()}",
+                                ex,
+                            )
+                        }
+                    }
+
+                    if (deserializationErrors > 0 && deserializationErrors >= records.count()) {
+                        error("All ${records.count()} records failed deserialization — likely a systematic DTO mismatch")
+                    }
 
                     if (!records.isEmpty) {
                         kafkaConsumer.commitSync()

--- a/src/main/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumer.kt
@@ -24,7 +24,7 @@ import java.time.LocalDate
 import kotlin.time.Duration.Companion.seconds
 
 const val SYKMELDINGSPERIODE_TOPIC = "teamsykmelding.syfo-sendt-sykmelding"
-const val SYKMELDINGSPERIODE_CONSUMER_GROUP = "syfo-oppfolgingsplan-backend-sykmeldingsperiode"
+const val SYKMELDINGSPERIODE_CONSUMER_GROUP = "syfo-oppfolgingsplan-backend-sykmeldingsperiode-v2"
 
 class SykmeldingsperiodeConsumer(
     private val sykmeldingsperiodeRepository: SykmeldingsperiodeRepository,

--- a/src/main/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumer.kt
@@ -66,7 +66,7 @@ class SykmeldingsperiodeConsumer(
                         } catch (ex: JsonProcessingException) {
                             deserializationErrors++
                             COUNT_SYKMELDING_DESERIALIZATION_ERROR.increment()
-                            log.error(
+                            log.warn(
                                 "Failed to deserialize sykmelding at partition=${record.partition()}, offset=${record.offset()}",
                                 ex,
                             )

--- a/src/main/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumer.kt
@@ -1,6 +1,5 @@
 package no.nav.syfo.sykmelding.kafka
 
-import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.module.kotlin.readValue
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -97,21 +96,11 @@ class SykmeldingsperiodeConsumer(
             return
         }
 
-        val kafkaMessage = try {
-            configuredJacksonMapper.readValue<SendtSykmeldingKafkaMessage>(recordValue)
-        } catch (ex: JsonProcessingException) {
-            COUNT_SYKMELDING_DESERIALIZATION_ERROR.increment()
-            log.error(
-                "Failed to deserialize sykmelding Kafka message at topic=${record.topic()}, partition=${record.partition()}, offset=${record.offset()}",
-                ex,
-            )
-            return
-        }
+        val kafkaMessage = configuredJacksonMapper.readValue<SendtSykmeldingKafkaMessage>(recordValue)
 
         val sykmeldingId = record.key()
         val organisasjonsnummer = kafkaMessage.event.arbeidsgiver?.orgnummer
         if (organisasjonsnummer == null) {
-            COUNT_SYKMELDING_DESERIALIZATION_ERROR.increment()
             log.warn(
                 "Skipping sykmelding Kafka message without arbeidsgiver for sykmeldingId=$sykmeldingId",
             )

--- a/src/main/kotlin/no/nav/syfo/sykmelding/kafka/model/SendtSykmeldingKafkaMessage.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/kafka/model/SendtSykmeldingKafkaMessage.kt
@@ -6,6 +6,7 @@ import java.time.LocalDate
 /**
  * Minimal DTO for teamsykmelding.syfo-sendt-sykmelding topic.
  * Only fields actually used by this consumer are modeled.
+ * Note: sykmeldingId is taken from the Kafka record key, not from the JSON payload.
  * All classes use @JsonIgnoreProperties(ignoreUnknown = true) to safely ignore
  * any fields added by the producer without breaking deserialization.
  */

--- a/src/main/kotlin/no/nav/syfo/sykmelding/kafka/model/SendtSykmeldingKafkaMessage.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/kafka/model/SendtSykmeldingKafkaMessage.kt
@@ -26,9 +26,8 @@ data class SykmeldingsperiodeAGDTO(
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Event(
     val sykmeldingId: String,
-    val timestamp: OffsetDateTime,
+    val timestamp: OffsetDateTime? = null,
     val arbeidsgiver: Arbeidsgiver? = null,
-    val brukerSvar: BrukerSvar? = null,
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -36,11 +35,6 @@ data class Arbeidsgiver(
     val orgnummer: String,
     val juridiskOrgnummer: String? = null,
     val orgNavn: String? = null,
-)
-
-@JsonIgnoreProperties(ignoreUnknown = true)
-data class BrukerSvar(
-    val erOpplysningeneRiktige: String? = null,
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/kotlin/no/nav/syfo/sykmelding/kafka/model/SendtSykmeldingKafkaMessage.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/kafka/model/SendtSykmeldingKafkaMessage.kt
@@ -2,8 +2,13 @@ package no.nav.syfo.sykmelding.kafka.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import java.time.LocalDate
-import java.time.OffsetDateTime
 
+/**
+ * Minimal DTO for teamsykmelding.syfo-sendt-sykmelding topic.
+ * Only fields actually used by this consumer are modeled.
+ * All classes use @JsonIgnoreProperties(ignoreUnknown = true) to safely ignore
+ * any fields added by the producer without breaking deserialization.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class SendtSykmeldingKafkaMessage(
     val sykmelding: ArbeidsgiverSykmelding,
@@ -14,7 +19,6 @@ data class SendtSykmeldingKafkaMessage(
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ArbeidsgiverSykmelding(
     val sykmeldingsperioder: List<SykmeldingsperiodeAGDTO>,
-    val syketilfelleStartDato: LocalDate?,
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -25,22 +29,15 @@ data class SykmeldingsperiodeAGDTO(
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Event(
-    val sykmeldingId: String,
-    val timestamp: OffsetDateTime? = null,
     val arbeidsgiver: Arbeidsgiver? = null,
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Arbeidsgiver(
     val orgnummer: String,
-    val juridiskOrgnummer: String? = null,
-    val orgNavn: String? = null,
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class KafkaMetadata(
-    val sykmeldingId: String,
-    val timestamp: OffsetDateTime? = null,
     val fnr: String,
-    val source: String? = null,
 )

--- a/src/test/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumerTest.kt
@@ -1,5 +1,7 @@
 package no.nav.syfo.sykmelding.kafka
 
+import com.fasterxml.jackson.core.JsonProcessingException
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -171,16 +173,18 @@ class SykmeldingsperiodeConsumerTest :
                 }
             }
 
-            it("skips invalid JSON without touching the repository") {
-                consumer.processRecord(
-                    ConsumerRecord(
-                        SYKMELDINGSPERIODE_TOPIC,
-                        0,
-                        0L,
-                        "sykmelding-4",
-                        "{invalid-json}",
-                    ),
-                )
+            it("throws on invalid JSON so offsets are not committed") {
+                shouldThrow<JsonProcessingException> {
+                    consumer.processRecord(
+                        ConsumerRecord(
+                            SYKMELDINGSPERIODE_TOPIC,
+                            0,
+                            0L,
+                            "sykmelding-4",
+                            "{invalid-json}",
+                        ),
+                    )
+                }
 
                 verify(exactly = 0) { repository.storeSykmeldingsperioder(any()) }
                 verify(exactly = 0) { repository.invalidateSykmelding(any()) }

--- a/src/test/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumerTest.kt
@@ -50,7 +50,6 @@ class SykmeldingsperiodeConsumerTest :
                         0L,
                         "sykmelding-1",
                         kafkaMessage(
-                            sykmeldingId = "sykmelding-1",
                             perioder = listOf(
                                 SykmeldingsperiodeAGDTO(
                                     fom = LocalDate.of(2025, 1, 1),
@@ -98,7 +97,6 @@ class SykmeldingsperiodeConsumerTest :
                         0L,
                         "sykmelding-2",
                         kafkaMessage(
-                            sykmeldingId = "sykmelding-2",
                             perioder = listOf(
                                 SykmeldingsperiodeAGDTO(
                                     fom = LocalDate.of(2023, 4, 1),
@@ -152,7 +150,6 @@ class SykmeldingsperiodeConsumerTest :
                         0L,
                         "sykmelding-boundary",
                         kafkaMessage(
-                            sykmeldingId = "sykmelding-boundary",
                             perioder = listOf(
                                 SykmeldingsperiodeAGDTO(
                                     fom = LocalDate.of(2023, 5, 1),
@@ -252,7 +249,6 @@ class SykmeldingsperiodeConsumerTest :
     })
 
 private fun kafkaMessage(
-    sykmeldingId: String,
     perioder: List<SykmeldingsperiodeAGDTO>,
 ): String = configuredJacksonMapper.writeValueAsString(
     SendtSykmeldingKafkaMessage(

--- a/src/test/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumerTest.kt
@@ -212,7 +212,7 @@ private fun kafkaMessage(
                 juridiskOrgnummer = null,
                 orgNavn = "Test AS",
             ),
-            brukerSvar = null,
+
         ),
     ),
 )

--- a/src/test/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumerTest.kt
@@ -21,7 +21,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
-import java.time.OffsetDateTime
 import java.time.ZoneId
 
 class SykmeldingsperiodeConsumerTest :
@@ -186,6 +185,65 @@ class SykmeldingsperiodeConsumerTest :
                 verify(exactly = 0) { repository.storeSykmeldingsperioder(any()) }
                 verify(exactly = 0) { repository.invalidateSykmelding(any()) }
             }
+
+            it("deserializes realistic raw Kafka JSON with unknown fields like brukerSvar") {
+                every { repository.storeSykmeldingsperioder(any()) } returns 1
+
+                val rawJson = """
+                    {
+                      "sykmelding": {
+                        "id": "sykmelding-raw",
+                        "sykmeldingsperioder": [
+                          {"fom": "2025-01-10", "tom": "2025-01-20", "type": "AKTIVITET_IKKE_MULIG", "gradert": null, "behandlingsdager": null}
+                        ],
+                        "syketilfelleStartDato": "2025-01-10",
+                        "mottattTidspunkt": "2025-01-10T08:00:00Z",
+                        "behandletTidspunkt": "2025-01-10T09:00:00Z",
+                        "arbeidsgiver": {"orgnummer": "111222333", "orgNavn": "Foo AS"},
+                        "merknader": null
+                      },
+                      "kafkaMetadata": {
+                        "sykmeldingId": "sykmelding-raw",
+                        "timestamp": "2025-01-10T10:00:00Z",
+                        "fnr": "99887766554",
+                        "source": "syfosmregister"
+                      },
+                      "event": {
+                        "sykmeldingId": "sykmelding-raw",
+                        "timestamp": "2025-01-10T10:00:00Z",
+                        "statusEvent": "SENDT",
+                        "arbeidsgiver": {"orgnummer": "111222333", "juridiskOrgnummer": "111222333", "orgNavn": "Foo AS"},
+                        "brukerSvar": {
+                          "erOpplysningeneRiktige": {"svar": true, "sporsmaltekst": "Er opplysningene riktige?", "svartekster": null},
+                          "arbeidssituasjon": {"svar": "ARBEIDSTAKER", "sporsmaltekst": "Hva er din arbeidssituasjon?", "svartekster": null}
+                        },
+                        "tidligereArbeidsgiver": null
+                      }
+                    }
+                """.trimIndent()
+
+                consumer.processRecord(
+                    ConsumerRecord(
+                        SYKMELDINGSPERIODE_TOPIC,
+                        0,
+                        0L,
+                        "sykmelding-raw",
+                        rawJson,
+                    ),
+                )
+
+                verify(exactly = 1) {
+                    repository.storeSykmeldingsperioder(
+                        withArg { perioder ->
+                            perioder.shouldHaveSize(1)
+                            perioder.single().sykmeldtFnr shouldBe "99887766554"
+                            perioder.single().organisasjonsnummer shouldBe "111222333"
+                            perioder.single().fom shouldBe LocalDate.of(2025, 1, 10)
+                            perioder.single().tom shouldBe LocalDate.of(2025, 1, 20)
+                        },
+                    )
+                }
+            }
         }
     })
 
@@ -196,23 +254,14 @@ private fun kafkaMessage(
     SendtSykmeldingKafkaMessage(
         sykmelding = ArbeidsgiverSykmelding(
             sykmeldingsperioder = perioder,
-            syketilfelleStartDato = null,
         ),
         kafkaMetadata = KafkaMetadata(
-            sykmeldingId = sykmeldingId,
-            timestamp = OffsetDateTime.parse("2025-05-01T12:00:00Z"),
             fnr = "12345678901",
-            source = "syfosmregister",
         ),
         event = Event(
-            sykmeldingId = sykmeldingId,
-            timestamp = OffsetDateTime.parse("2025-05-01T12:00:00Z"),
             arbeidsgiver = Arbeidsgiver(
                 orgnummer = "987654321",
-                juridiskOrgnummer = null,
-                orgNavn = "Test AS",
             ),
-
         ),
     ),
 )


### PR DESCRIPTION
## Beskrivelse

Hotfix for kritisk deserialiserings-bug i sykmeldingsperiode-consumer (#281).

`BrukerSvar.erOpplysningeneRiktige` var modellert som `String?` men den faktiske Kafka-meldingen sender et nested JSON-objekt. Resulterte i 1M+ feil i dev.

Relates to #268
Del av epic: #267

## Endringer

1. **Strippet DTO til minimum** — kun felter vi faktisk bruker (fnr, orgnummer, fom, tom). Verifisert mot `dinesykmeldte-backend` sin referansemodell.
2. **Bumped consumer group til v2** — tvinger full replay fra earliest, siden forrige gruppe allerede har committed offsets for records som feilet deserialisering (catch + return i processRecord).
3. **Lagt til raw JSON contract test** — med realistisk payload inkludert `brukerSvar` som nested objekt for å fange kontraktsdrift.

## Verifisert

- [x] `./gradlew build` grønn
- [x] Inspektør-review (GPT) — alle BLOCKER-funn løst
- [x] DTO verifisert mot teamsykmeldings faktiske meldingsformat
- [x] Replay er trygt pga idempotente inserts (`ON CONFLICT DO NOTHING`)

## Risiko

- 🟡 Full replay fra earliest vil generere last ved deploy — men er nødvendig for å få inn de manglende meldingene
- 🟢 Idempotente inserts gjør duplikatprosessering ufarlig