### PR TITLE
Sanitize output

### DIFF
--- a/src/main/kotlin/no/nav/syfo/pdfgen/PdfGenService.kt
+++ b/src/main/kotlin/no/nav/syfo/pdfgen/PdfGenService.kt
@@ -43,37 +43,41 @@ fun PersistedOppfolgingsplan.toOppfolgingsplanPdfV1(): OppfolgingsplanPdfV1 {
                 .toLocalDate()
                 .format(formatter),
             evaluationDate = this.evalueringsdato.format(formatter),
-            sykmeldtName = this.sykmeldtFullName,
-            sykmeldtFnr = this.sykmeldtFnr,
+            sykmeldtName = this.sykmeldtFullName.sanitizePdfText(),
+            sykmeldtFnr = this.sykmeldtFnr.sanitizePdfText(),
             // organisasjonsnavn should always be set, but it is nullable in the response we get from
             // dine-sykmeldte-backend even though all rows in the database currently have a value
-            organisasjonsnavn = this.organisasjonsnavn ?: throw RuntimeException("Organisasjonsnavn is null"),
-            organisasjonsnummer = this.organisasjonsnummer,
-            stillingstittel = this.stillingstittel,
+            organisasjonsnavn = this.organisasjonsnavn?.sanitizePdfText()
+                ?: throw RuntimeException("Organisasjonsnavn is null"),
+            organisasjonsnummer = this.organisasjonsnummer.sanitizePdfText(),
+            stillingstittel = this.stillingstittel.sanitizePdfTextOrNull(),
             stillingsprosent = this.stillingsprosent?.toPlainString(),
-            narmesteLederName = this.narmesteLederFullName ?: throw RuntimeException("NarmesteLederName is null"),
+            narmesteLederName = this.narmesteLederFullName?.sanitizePdfText()
+                ?: throw RuntimeException("NarmesteLederName is null"),
             sections = content.sections.map { section ->
                 Section(
                     id = section.sectionId,
-                    title = section.sectionTitle,
+                    title = section.sectionTitle.sanitizePdfText(),
                     inputFields = section.fields
                         .map { fieldSnapshot ->
                             InputField(
                                 id = fieldSnapshot.fieldId,
-                                title = fieldSnapshot.label,
-                                description = fieldSnapshot.description,
+                                title = fieldSnapshot.label.sanitizePdfText(),
+                                description = fieldSnapshot.description.sanitizePdfTextOrNull(),
                                 value = when (fieldSnapshot) {
-                                    is TextFieldSnapshot -> fieldSnapshot.value
+                                    is TextFieldSnapshot -> fieldSnapshot.value.sanitizePdfText()
                                     is RadioGroupFieldSnapshot ->
                                         fieldSnapshot.options
-                                            .firstOrNull { it.optionId == fieldSnapshot.selectedOptionId }?.optionLabel
+                                            .firstOrNull { it.optionId == fieldSnapshot.selectedOptionId }
+                                            ?.optionLabel
+                                            ?.sanitizePdfText()
                                             ?: ""
 
                                     is SingleCheckboxFieldSnapshot -> if (fieldSnapshot.value) "Ja" else "Nei"
                                     is CheckboxGroupFieldSnapshot ->
                                         fieldSnapshot.options
                                             .filter { it.wasSelected }
-                                            .joinToString("\n") { it.optionLabel }
+                                            .joinToString("\n") { it.optionLabel.sanitizePdfText() }
                                             .ifEmpty { "" }
 
                                     is DateFieldSnapshot -> fieldSnapshot.value?.format(formatter) ?: ""
@@ -87,3 +91,7 @@ fun PersistedOppfolgingsplan.toOppfolgingsplanPdfV1(): OppfolgingsplanPdfV1 {
         ),
     )
 }
+
+private fun String.sanitizePdfText(): String = replace("\uFEFF", "").replace("\uFFFE", "")
+
+private fun String?.sanitizePdfTextOrNull(): String? = this?.sanitizePdfText()

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/db/PersistedOppfolgingsplanTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/db/PersistedOppfolgingsplanTest.kt
@@ -16,6 +16,7 @@ import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.DateFieldSnapshot
 import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.FormSnapshot
 import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.Section
 import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.SingleCheckboxFieldSnapshot
+import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.TextFieldSnapshot
 import no.nav.syfo.pdfgen.toOppfolgingsplanPdfV1
 import java.time.Instant
 import java.time.LocalDate
@@ -208,6 +209,35 @@ class PersistedOppfolgingsplanTest :
                 fields[0].id shouldBe "testDate"
                 fields[0].title shouldBe "Test Date"
                 fields[0].value shouldBe "25.11.2025"
+            }
+
+            it("should remove zero width no-break space from content before PDF generation") {
+                val formSnapshot = FormSnapshot(
+                    formIdentifier = "oppfolgingsplan",
+                    formSemanticVersion = "1.0.0",
+                    formSnapshotVersion = "2.0.0",
+                    sections = listOf(
+                        Section(
+                            sectionId = "arbeidsoppgaver",
+                            sectionTitle = "Arbeidsoppgaver",
+                            fields = listOf(
+                                TextFieldSnapshot(
+                                    fieldId = "vanligArbeidsdag",
+                                    label = "Hvordan ser en vanlig arbeidsdag ut?",
+                                    description = "Beskriv arbeidsdagen",
+                                    value = "Tekst med\uFEFF usynlig tegn",
+                                ),
+                            ),
+                        ),
+                    ),
+                )
+                val plan = defaultPersistedOppfolgingsplan().copy(content = formSnapshot)
+
+                val pdf = plan.toOppfolgingsplanPdfV1()
+
+                val fields = pdf.oppfolgingsplan.sections[0].inputFields
+                fields.shouldHaveSize(1)
+                fields[0].value shouldBe "Tekst med usynlig tegn"
             }
         }
 

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/db/PersistedOppfolgingsplanTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/db/PersistedOppfolgingsplanTest.kt
@@ -14,6 +14,8 @@ import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.CheckboxGroupFieldOption
 import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.CheckboxGroupFieldSnapshot
 import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.DateFieldSnapshot
 import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.FormSnapshot
+import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.RadioGroupFieldOption
+import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.RadioGroupFieldSnapshot
 import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.Section
 import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.SingleCheckboxFieldSnapshot
 import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.TextFieldSnapshot
@@ -238,6 +240,80 @@ class PersistedOppfolgingsplanTest :
                 val fields = pdf.oppfolgingsplan.sections[0].inputFields
                 fields.shouldHaveSize(1)
                 fields[0].value shouldBe "Tekst med usynlig tegn"
+            }
+
+            it("should sanitize all newly mapped string fields before PDF generation") {
+                val dirty = "A\uFEFFB\uFFFEC"
+                val formSnapshot = FormSnapshot(
+                    formIdentifier = "oppfolgingsplan",
+                    formSemanticVersion = "1.0.0",
+                    formSnapshotVersion = "2.0.0",
+                    sections = listOf(
+                        Section(
+                            sectionId = "section-1",
+                            sectionTitle = "Section $dirty",
+                            fields = listOf(
+                                TextFieldSnapshot(
+                                    fieldId = "text-1",
+                                    label = "Label $dirty",
+                                    description = "Description $dirty",
+                                    value = "Text value $dirty",
+                                ),
+                                RadioGroupFieldSnapshot(
+                                    fieldId = "radio-1",
+                                    label = "Radio label $dirty",
+                                    description = "Radio description $dirty",
+                                    options = listOf(
+                                        RadioGroupFieldOption(optionId = "1", optionLabel = "Option 1"),
+                                        RadioGroupFieldOption(optionId = "2", optionLabel = "Selected $dirty"),
+                                    ),
+                                    selectedOptionId = "2",
+                                ),
+                                CheckboxGroupFieldSnapshot(
+                                    fieldId = "checkbox-1",
+                                    label = "Checkbox label $dirty",
+                                    description = "Checkbox description $dirty",
+                                    options = listOf(
+                                        CheckboxGroupFieldOption(optionId = "a", optionLabel = "A $dirty", wasSelected = true),
+                                        CheckboxGroupFieldOption(optionId = "b", optionLabel = "B $dirty", wasSelected = true),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                )
+
+                val plan = defaultPersistedOppfolgingsplan().copy(
+                    sykmeldtFullName = "Sykmeldt $dirty",
+                    sykmeldtFnr = "Fnr$dirty",
+                    organisasjonsnavn = "Org navn $dirty",
+                    organisasjonsnummer = "Org nr $dirty",
+                    stillingstittel = "Stilling $dirty",
+                    narmesteLederFullName = "Leder $dirty",
+                    content = formSnapshot,
+                )
+
+                val pdf = plan.toOppfolgingsplanPdfV1()
+                val cleaned = "ABC"
+
+                pdf.oppfolgingsplan.sykmeldtName shouldBe "Sykmeldt $cleaned"
+                pdf.oppfolgingsplan.sykmeldtFnr shouldBe "Fnr$cleaned"
+                pdf.oppfolgingsplan.organisasjonsnavn shouldBe "Org navn $cleaned"
+                pdf.oppfolgingsplan.organisasjonsnummer shouldBe "Org nr $cleaned"
+                pdf.oppfolgingsplan.stillingstittel shouldBe "Stilling $cleaned"
+                pdf.oppfolgingsplan.narmesteLederName shouldBe "Leder $cleaned"
+
+                val section = pdf.oppfolgingsplan.sections[0]
+                section.title shouldBe "Section $cleaned"
+                section.inputFields[0].title shouldBe "Label $cleaned"
+                section.inputFields[0].description shouldBe "Description $cleaned"
+                section.inputFields[0].value shouldBe "Text value $cleaned"
+                section.inputFields[1].title shouldBe "Radio label $cleaned"
+                section.inputFields[1].description shouldBe "Radio description $cleaned"
+                section.inputFields[1].value shouldBe "Selected $cleaned"
+                section.inputFields[2].title shouldBe "Checkbox label $cleaned"
+                section.inputFields[2].description shouldBe "Checkbox description $cleaned"
+                section.inputFields[2].value shouldBe "A $cleaned\nB $cleaned"
             }
         }
 


### PR DESCRIPTION
## Beskrivelse

Adds sanitization of text fields before sending oppfølgingsplan data to PDF generation, to prevent invisible/non-printable characters from leaking into the rendered PDF.

**Changes:**
- Sanitize multiple mapped strings in `toOppfolgingsplanPdfV1()` by removing `\uFEFF` and `\uFFFE`.
- Add a regression test ensuring `\uFEFF` is removed from `TextFieldSnapshot.value` before PDF generation.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
