### PR TITLE
feat(oppfolgingsplan): soft-delete fullførte planer etter 6 måneder

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/OppfolginsplanAPiMetrics.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/OppfolginsplanAPiMetrics.kt
@@ -9,6 +9,7 @@ const val OPPFOLGINGSPLAN_SHARED_WITH_GP = "${METRICS_NS}_oppfolgingsplan_shared
 const val OPPFOLGINGSPLAN_SHARED_WITH_NAV = "${METRICS_NS}_oppfolgingsplan_shared_with_nav"
 const val OPPFOLGINGSPLAN_DRAFT_MANUALLY_DELETED = "${METRICS_NS}_oppfolgingsplan_draft_manually_deleted"
 const val OPPFOLGINGSPLAN_DRAFT_AUTO_DELETED = "${METRICS_NS}_oppfolgingsplan_draft_auto_deleted"
+const val OPPFOLGINGSPLAN_SOFT_DELETED = "${METRICS_NS}_oppfolgingsplan_soft_deleted"
 
 val COUNT_OPPFOLGINGSPLAN_CREATED: Counter = Counter.builder(OPPFOLGINGSPLAN_CREATED)
     .description("Counts the number of created oppfolgingsplans")
@@ -24,4 +25,7 @@ val COUNT_OPPFOLGINGSPLAN_DRAFT_MANUALLY_DELETED: Counter = Counter.builder(OPPF
     .register(METRICS_REGISTRY)
 val COUNT_OPPFOLGINGSPLAN_DRAFT_AUTO_DELETED: Counter = Counter.builder(OPPFOLGINGSPLAN_DRAFT_AUTO_DELETED)
     .description("Counts the number of expired oppfolgingsplan drafts automatically deleted")
+    .register(METRICS_REGISTRY)
+val COUNT_OPPFOLGINGSPLAN_SOFT_DELETED: Counter = Counter.builder(OPPFOLGINGSPLAN_SOFT_DELETED)
+    .description("Counts the number of oppfolgingsplaner soft-deleted by cleanup task")
     .register(METRICS_REGISTRY)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederOppfolgingsplanApiV1.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederOppfolgingsplanApiV1.kt
@@ -32,7 +32,10 @@ fun Route.registerVeilederOppfolgingsplanApiV1(
     route("/oppfolgingsplaner") {
         suspend fun tryToGetOppfolgingsplanByUuid(
             uuid: UUID,
-        ): PersistedOppfolgingsplan = oppfolgingsplanService.getPersistedOppfolgingsplanByUuid(uuid).let {
+        ): PersistedOppfolgingsplan = oppfolgingsplanService.getPersistedOppfolgingsplanByUuid(
+            uuid = uuid,
+            inkluderSkjulte = true,
+        ).let {
             if (it.deltMedVeilederTidspunkt == null) {
                 throw PlanNotFoundException("Oppfolgingsplan not found for uuid: $uuid")
             } else {
@@ -65,8 +68,10 @@ fun Route.registerVeilederOppfolgingsplanApiV1(
                 sykmeldtFnr = Fodselsnummer(value = sykmeldtFnr),
                 token = innloggetBruker.token,
             )
-            val oppfolgingsplaner =
-                oppfolgingsplanService.getPersistedOppfolgingsplanListBy(sykmeldtFnr).toListOppfolgingsplanVeileder()
+            val oppfolgingsplaner = oppfolgingsplanService.getPersistedOppfolgingsplanListBy(
+                sykmeldtFnr = sykmeldtFnr,
+                inkluderSkjulte = true,
+            ).toListOppfolgingsplanVeileder()
 
             call.respond(HttpStatusCode.OK, oppfolgingsplaner)
         }

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
@@ -367,14 +367,14 @@ fun DatabaseInterface.softDeleteExpiredOppfolgingsplaner(
             SELECT op.uuid
             FROM oppfolgingsplan op
             JOIN LATERAL (
-                SELECT MAX(sp.tom) AS siste_tom
+                SELECT MAX(sp.tom) AS latest_tom
                 FROM sykmeldingsperiode sp
                 WHERE sp.sykmeldt_fnr = op.sykmeldt_fnr
                   AND sp.organisasjonsnummer = op.organisasjonsnummer
                   AND sp.invalidated_at IS NULL
-            ) siste ON true
+            ) latest_valid_sykmeldingsperiode ON true
             WHERE op.skjult_fra IS NULL
-              AND siste.siste_tom < CURRENT_DATE - CAST(? AS INTERVAL)
+              AND latest_valid_sykmeldingsperiode.latest_tom < CURRENT_DATE - CAST(? AS INTERVAL)
             ORDER BY op.uuid
             LIMIT ?
         )

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
@@ -90,11 +90,14 @@ fun DatabaseInterface.persistOppfolgingsplanAndDeleteUtkast(
 
 fun DatabaseInterface.findAllOppfolgingsplanerBy(
     sykmeldtFnr: String,
+    inkluderSkjulte: Boolean = false,
 ): List<PersistedOppfolgingsplan> {
+    val skjultFilter = if (!inkluderSkjulte) "AND skjult_fra IS NULL" else ""
     val statement = """
         SELECT *
         FROM oppfolgingsplan
         WHERE sykmeldt_fnr = ?
+        $skjultFilter
         ORDER BY created_at DESC
     """.trimIndent()
 
@@ -121,6 +124,7 @@ fun DatabaseInterface.findAllOppfolgingsplanerBy(
         FROM oppfolgingsplan
         WHERE sykmeldt_fnr = ?
         AND organisasjonsnummer = ?
+        AND skjult_fra IS NULL
         ORDER BY created_at DESC
     """.trimIndent()
 
@@ -141,11 +145,14 @@ fun DatabaseInterface.findAllOppfolgingsplanerBy(
 
 fun DatabaseInterface.findOppfolgingsplanBy(
     uuid: UUID,
+    inkluderSkjulte: Boolean = false,
 ): PersistedOppfolgingsplan? {
+    val skjultFilter = if (!inkluderSkjulte) "AND skjult_fra IS NULL" else ""
     val statement = """
         SELECT *
         FROM oppfolgingsplan
         WHERE uuid = ?
+        $skjultFilter
     """.trimIndent()
 
     connection.use { connection ->
@@ -348,6 +355,62 @@ fun DatabaseInterface.setSendtTilDokumentportenTidspunkt(
     }
 }
 
+fun DatabaseInterface.softDeleteExpiredOppfolgingsplaner(
+    batchSize: Int = 1000,
+): Int {
+    val softDeleteUsingSykmeldingsperioderStatement = """
+        UPDATE oppfolgingsplan SET skjult_fra = NOW()
+        WHERE uuid IN (
+            SELECT op.uuid FROM oppfolgingsplan op
+            WHERE op.skjult_fra IS NULL
+            AND EXISTS (
+                SELECT 1 FROM sykmeldingsperiode sp
+                WHERE sp.sykmeldt_fnr = op.sykmeldt_fnr
+                AND sp.organisasjonsnummer = op.organisasjonsnummer
+                AND sp.invalidated_at IS NULL
+            )
+            AND NOT EXISTS (
+                SELECT 1 FROM sykmeldingsperiode sp
+                WHERE sp.sykmeldt_fnr = op.sykmeldt_fnr
+                AND sp.organisasjonsnummer = op.organisasjonsnummer
+                AND sp.invalidated_at IS NULL
+                AND sp.tom > NOW() - INTERVAL '6 months'
+            )
+            ORDER BY op.uuid
+            LIMIT ?
+        )
+    """.trimIndent()
+    val softDeleteUsingCreatedAtStatement = """
+        UPDATE oppfolgingsplan SET skjult_fra = NOW()
+        WHERE uuid IN (
+            SELECT op.uuid FROM oppfolgingsplan op
+            WHERE op.skjult_fra IS NULL
+            AND NOT EXISTS (
+                SELECT 1 FROM sykmeldingsperiode sp
+                WHERE sp.sykmeldt_fnr = op.sykmeldt_fnr
+                AND sp.organisasjonsnummer = op.organisasjonsnummer
+                AND sp.invalidated_at IS NULL
+            )
+            AND op.created_at < NOW() - INTERVAL '6 months'
+            ORDER BY op.uuid
+            LIMIT ?
+        )
+    """.trimIndent()
+
+    return connection.use { connection ->
+        val updatedUsingSykmeldingsperioder = connection.prepareStatement(softDeleteUsingSykmeldingsperioderStatement).use {
+            it.setInt(1, batchSize)
+            it.executeUpdate()
+        }
+        val updatedUsingCreatedAt = connection.prepareStatement(softDeleteUsingCreatedAtStatement).use {
+            it.setInt(1, batchSize)
+            it.executeUpdate()
+        }
+        connection.commit()
+        updatedUsingSykmeldingsperioder + updatedUsingCreatedAt
+    }
+}
+
 fun ResultSet.mapToOppfolgingsplan(): PersistedOppfolgingsplan = PersistedOppfolgingsplan(
     uuid = getObject("uuid") as UUID,
     sykmeldtFnr = this.getString("sykmeldt_fnr"),
@@ -368,5 +431,6 @@ fun ResultSet.mapToOppfolgingsplan(): PersistedOppfolgingsplan = PersistedOppfol
     deltMedVeilederTidspunkt = this.getTimestamp("delt_med_veileder_tidspunkt")?.toInstant(),
     utkastCreatedAt = this.getTimestamp("utkast_created_at")?.toInstant(),
     createdAt = getTimestamp("created_at").toInstant(),
+    skjultFra = this.getTimestamp("skjult_fra")?.toInstant(),
     sendtTilDokumentportenTidspunkt = this.getTimestamp("sendt_til_dokumentporten_tidspunkt")?.toInstant(),
 )

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
@@ -362,60 +362,35 @@ fun DatabaseInterface.setSendtTilDokumentportenTidspunkt(
 fun DatabaseInterface.softDeleteExpiredOppfolgingsplaner(
     batchSize: Int = 1000,
 ): Int {
-    val softDeleteUsingSykmeldingsperioderStatement = """
-        UPDATE oppfolgingsplan SET skjult_fra = NOW()
-        WHERE uuid IN (
-            SELECT op.uuid FROM oppfolgingsplan op
+    val statement = """
+        WITH candidates AS (
+            SELECT op.uuid
+            FROM oppfolgingsplan op
+            JOIN LATERAL (
+                SELECT MAX(sp.tom) AS siste_tom
+                FROM sykmeldingsperiode sp
+                WHERE sp.sykmeldt_fnr = op.sykmeldt_fnr
+                  AND sp.organisasjonsnummer = op.organisasjonsnummer
+                  AND sp.invalidated_at IS NULL
+            ) siste ON true
             WHERE op.skjult_fra IS NULL
-            AND EXISTS (
-                SELECT 1 FROM sykmeldingsperiode sp
-                WHERE sp.sykmeldt_fnr = op.sykmeldt_fnr
-                AND sp.organisasjonsnummer = op.organisasjonsnummer
-                AND sp.invalidated_at IS NULL
-            )
-            AND NOT EXISTS (
-                SELECT 1 FROM sykmeldingsperiode sp
-                WHERE sp.sykmeldt_fnr = op.sykmeldt_fnr
-                AND sp.organisasjonsnummer = op.organisasjonsnummer
-                AND sp.invalidated_at IS NULL
-                AND sp.tom >= CURRENT_DATE - CAST(? AS INTERVAL)
-            )
+              AND siste.siste_tom < CURRENT_DATE - CAST(? AS INTERVAL)
             ORDER BY op.uuid
             LIMIT ?
         )
-    """.trimIndent()
-    val softDeleteUsingCreatedAtStatement = """
-        UPDATE oppfolgingsplan SET skjult_fra = NOW()
-        WHERE uuid IN (
-            SELECT op.uuid FROM oppfolgingsplan op
-            WHERE op.skjult_fra IS NULL
-            AND NOT EXISTS (
-                SELECT 1 FROM sykmeldingsperiode sp
-                WHERE sp.sykmeldt_fnr = op.sykmeldt_fnr
-                AND sp.organisasjonsnummer = op.organisasjonsnummer
-                AND sp.invalidated_at IS NULL
-            )
-            AND op.created_at < NOW() - CAST(? AS INTERVAL)
-            ORDER BY op.uuid
-            LIMIT ?
-        )
+        UPDATE oppfolgingsplan op
+        SET skjult_fra = NOW()
+        FROM candidates
+        WHERE op.uuid = candidates.uuid
     """.trimIndent()
 
-    val updatedUsingSykmeldingsperioder = connection.use { connection ->
-        connection.prepareStatement(softDeleteUsingSykmeldingsperioderStatement).use {
+    return connection.use { connection ->
+        connection.prepareStatement(statement).use {
             it.setString(1, OPPFOLGINGSPLAN_SOFT_DELETE_RETENTION_INTERVAL)
             it.setInt(2, batchSize)
             it.executeUpdate()
         }.also { connection.commit() }
     }
-    val updatedUsingCreatedAt = connection.use { connection ->
-        connection.prepareStatement(softDeleteUsingCreatedAtStatement).use {
-            it.setString(1, OPPFOLGINGSPLAN_SOFT_DELETE_RETENTION_INTERVAL)
-            it.setInt(2, batchSize)
-            it.executeUpdate()
-        }.also { connection.commit() }
-    }
-    return updatedUsingSykmeldingsperioder + updatedUsingCreatedAt
 }
 
 fun ResultSet.mapToOppfolgingsplan(): PersistedOppfolgingsplan = PersistedOppfolgingsplan(

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
@@ -397,18 +397,19 @@ fun DatabaseInterface.softDeleteExpiredOppfolgingsplaner(
         )
     """.trimIndent()
 
-    return connection.use { connection ->
-        val updatedUsingSykmeldingsperioder = connection.prepareStatement(softDeleteUsingSykmeldingsperioderStatement).use {
+    val updatedUsingSykmeldingsperioder = connection.use { connection ->
+        connection.prepareStatement(softDeleteUsingSykmeldingsperioderStatement).use {
             it.setInt(1, batchSize)
             it.executeUpdate()
-        }
-        val updatedUsingCreatedAt = connection.prepareStatement(softDeleteUsingCreatedAtStatement).use {
-            it.setInt(1, batchSize)
-            it.executeUpdate()
-        }
-        connection.commit()
-        updatedUsingSykmeldingsperioder + updatedUsingCreatedAt
+        }.also { connection.commit() }
     }
+    val updatedUsingCreatedAt = connection.use { connection ->
+        connection.prepareStatement(softDeleteUsingCreatedAtStatement).use {
+            it.setInt(1, batchSize)
+            it.executeUpdate()
+        }.also { connection.commit() }
+    }
+    return updatedUsingSykmeldingsperioder + updatedUsingCreatedAt
 }
 
 fun ResultSet.mapToOppfolgingsplan(): PersistedOppfolgingsplan = PersistedOppfolgingsplan(

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
@@ -374,7 +374,7 @@ fun DatabaseInterface.softDeleteExpiredOppfolgingsplaner(
                 WHERE sp.sykmeldt_fnr = op.sykmeldt_fnr
                 AND sp.organisasjonsnummer = op.organisasjonsnummer
                 AND sp.invalidated_at IS NULL
-                AND sp.tom > NOW() - INTERVAL '6 months'
+                AND sp.tom >= CURRENT_DATE - INTERVAL '6 months'
             )
             ORDER BY op.uuid
             LIMIT ?

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
@@ -17,6 +17,8 @@ import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
+private const val OPPFOLGINGSPLAN_SOFT_DELETE_RETENTION_INTERVAL = "6 months"
+
 fun DatabaseInterface.persistOppfolgingsplanAndDeleteUtkast(
     narmesteLederFnr: String,
     sykmeldt: Sykmeldt,
@@ -374,7 +376,7 @@ fun DatabaseInterface.softDeleteExpiredOppfolgingsplaner(
                 WHERE sp.sykmeldt_fnr = op.sykmeldt_fnr
                 AND sp.organisasjonsnummer = op.organisasjonsnummer
                 AND sp.invalidated_at IS NULL
-                AND sp.tom >= CURRENT_DATE - INTERVAL '6 months'
+                AND sp.tom >= CURRENT_DATE - CAST(? AS INTERVAL)
             )
             ORDER BY op.uuid
             LIMIT ?
@@ -391,7 +393,7 @@ fun DatabaseInterface.softDeleteExpiredOppfolgingsplaner(
                 AND sp.organisasjonsnummer = op.organisasjonsnummer
                 AND sp.invalidated_at IS NULL
             )
-            AND op.created_at < NOW() - INTERVAL '6 months'
+            AND op.created_at < NOW() - CAST(? AS INTERVAL)
             ORDER BY op.uuid
             LIMIT ?
         )
@@ -399,13 +401,15 @@ fun DatabaseInterface.softDeleteExpiredOppfolgingsplaner(
 
     val updatedUsingSykmeldingsperioder = connection.use { connection ->
         connection.prepareStatement(softDeleteUsingSykmeldingsperioderStatement).use {
-            it.setInt(1, batchSize)
+            it.setString(1, OPPFOLGINGSPLAN_SOFT_DELETE_RETENTION_INTERVAL)
+            it.setInt(2, batchSize)
             it.executeUpdate()
         }.also { connection.commit() }
     }
     val updatedUsingCreatedAt = connection.use { connection ->
         connection.prepareStatement(softDeleteUsingCreatedAtStatement).use {
-            it.setInt(1, batchSize)
+            it.setString(1, OPPFOLGINGSPLAN_SOFT_DELETE_RETENTION_INTERVAL)
+            it.setInt(2, batchSize)
             it.executeUpdate()
         }.also { connection.commit() }
     }

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
@@ -315,6 +315,8 @@ fun DatabaseInterface.updateDelingAvPlanMedVeileder(
 }
 
 fun DatabaseInterface.findOppfolgingsplanerForDokumentportenPublisering(): List<PersistedOppfolgingsplan> {
+    // Intentionally no filter on skjult_fra: hiding applies to SM/AG surfaces, while
+    // Dokumentporten publication should still include plans hidden from those surfaces.
     val statement = """
         SELECT *
         FROM

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/domain/PersistedOppfolgingsplan.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/domain/PersistedOppfolgingsplan.kt
@@ -32,6 +32,7 @@ data class PersistedOppfolgingsplan(
     val journalpostId: String? = null,
     val utkastCreatedAt: Instant? = null,
     val createdAt: Instant,
+    val skjultFra: Instant? = null,
     val sendtTilDokumentportenTidspunkt: Instant? = null,
 )
 

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
@@ -24,6 +24,7 @@ import no.nav.syfo.oppfolgingsplan.db.setDeltMedLegeTidspunkt
 import no.nav.syfo.oppfolgingsplan.db.setDeltMedVeilederTidspunkt
 import no.nav.syfo.oppfolgingsplan.db.setJournalpostId
 import no.nav.syfo.oppfolgingsplan.db.setNarmesteLederFullName
+import no.nav.syfo.oppfolgingsplan.db.softDeleteExpiredOppfolgingsplaner
 import no.nav.syfo.oppfolgingsplan.db.updateDelingAvPlanMedVeileder
 import no.nav.syfo.oppfolgingsplan.db.updateSkalDelesMedLege
 import no.nav.syfo.oppfolgingsplan.db.updateSkalDelesMedVeileder
@@ -154,8 +155,14 @@ class OppfolgingsplanService(
         )
     }
 
-    suspend fun getPersistedOppfolgingsplanByUuid(uuid: UUID): PersistedOppfolgingsplan = withContext(Dispatchers.IO) {
-        database.findOppfolgingsplanBy(uuid)
+    suspend fun getPersistedOppfolgingsplanByUuid(
+        uuid: UUID,
+        inkluderSkjulte: Boolean = false,
+    ): PersistedOppfolgingsplan = withContext(Dispatchers.IO) {
+        database.findOppfolgingsplanBy(
+            uuid = uuid,
+            inkluderSkjulte = inkluderSkjulte,
+        )
     } ?: throw PlanNotFoundException("Oppfolgingsplan not found for uuid: $uuid")
 
     suspend fun updateSkalDelesMedLege(
@@ -251,8 +258,26 @@ class OppfolgingsplanService(
         )
     }
 
-    suspend fun getPersistedOppfolgingsplanListBy(sykmeldtFnr: String): List<PersistedOppfolgingsplan> = withContext(Dispatchers.IO) {
-        database.findAllOppfolgingsplanerBy(sykmeldtFnr)
+    suspend fun getPersistedOppfolgingsplanListBy(
+        sykmeldtFnr: String,
+        inkluderSkjulte: Boolean = false,
+    ): List<PersistedOppfolgingsplan> = withContext(Dispatchers.IO) {
+        database.findAllOppfolgingsplanerBy(
+            sykmeldtFnr = sykmeldtFnr,
+            inkluderSkjulte = inkluderSkjulte,
+        )
+    }
+
+    suspend fun softDeleteExpiredOppfolgingsplaner(): Int = withContext(Dispatchers.IO) {
+        var total = 0
+        var count: Int
+
+        do {
+            count = database.softDeleteExpiredOppfolgingsplaner()
+            total += count
+        } while (count > 0)
+
+        total
     }
 
     suspend fun getAndSetNarmestelederFullname(

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
@@ -46,6 +46,7 @@ import java.time.ZoneId
 import java.util.UUID
 
 const val OPPFOLGINGSPLAN_UTKAST_RETENTION_MONTHS = 4
+const val OPPFOLGINGSPLAN_SOFT_DELETE_MAX_BATCH_ITERATIONS = 1000
 
 /**
  * Service for managing oppfølgingsplaner.
@@ -269,15 +270,34 @@ class OppfolgingsplanService(
     }
 
     suspend fun softDeleteExpiredOppfolgingsplaner(): Int = withContext(Dispatchers.IO) {
+        runSoftDeleteExpiredOppfolgingsplanerLoop(
+            maxBatchIterations = OPPFOLGINGSPLAN_SOFT_DELETE_MAX_BATCH_ITERATIONS,
+        ) {
+            database.softDeleteExpiredOppfolgingsplaner()
+        }
+    }
+
+    internal fun runSoftDeleteExpiredOppfolgingsplanerLoop(
+        maxBatchIterations: Int = OPPFOLGINGSPLAN_SOFT_DELETE_MAX_BATCH_ITERATIONS,
+        softDeleteBatch: () -> Int,
+    ): Int {
+        require(maxBatchIterations > 0) {
+            "maxBatchIterations must be greater than 0"
+        }
+
         var total = 0
-        var count: Int
-
-        do {
-            count = database.softDeleteExpiredOppfolgingsplaner()
+        repeat(maxBatchIterations) { _ ->
+            val count = softDeleteBatch()
             total += count
-        } while (count > 0)
+            if (count == 0) {
+                return total
+            }
+        }
 
-        total
+        logger.warn(
+            "Stopped soft-delete loop after reaching safeguard of $maxBatchIterations batches; total soft-deleted so far: $total",
+        )
+        return total
     }
 
     suspend fun getAndSetNarmestelederFullname(

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTask.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTask.kt
@@ -6,6 +6,7 @@ import no.nav.syfo.oppfolgingsplan.api.v1.COUNT_OPPFOLGINGSPLAN_SOFT_DELETED
 import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.minutes
 
 class SoftDeleteOppfolgingsplanerTask(
     leaderElection: LeaderElection,
@@ -24,6 +25,14 @@ class SoftDeleteOppfolgingsplanerTask(
             log.info("Soft-deleted $softDeletedOppfolgingsplaner expired oppfolgingsplaner")
         } else {
             log.debug("No expired oppfolgingsplaner to soft-delete")
+        }
+    }
+
+    companion object {
+        internal fun intervalForEnvironment(isProdEnv: Boolean): Duration = if (isProdEnv) {
+            1.days
+        } else {
+            5.minutes
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTask.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTask.kt
@@ -18,13 +18,14 @@ class SoftDeleteOppfolgingsplanerTask(
     leaderElection = leaderElection,
 ) {
     override suspend fun execute() {
+        log.info("Starting task for soft-delete expired oppfolgingsplaner")
         val softDeletedOppfolgingsplaner = oppfolgingsplanService.softDeleteExpiredOppfolgingsplaner()
 
         if (softDeletedOppfolgingsplaner > 0) {
             COUNT_OPPFOLGINGSPLAN_SOFT_DELETED.increment(softDeletedOppfolgingsplaner.toDouble())
             log.info("Soft-deleted $softDeletedOppfolgingsplaner expired oppfolgingsplaner")
         } else {
-            log.debug("No expired oppfolgingsplaner to soft-delete")
+            log.info("Found 0 expired oppfolgingsplaner to soft-delete")
         }
     }
 

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTask.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTask.kt
@@ -1,0 +1,29 @@
+package no.nav.syfo.oppfolgingsplan.task
+
+import no.nav.syfo.application.leaderelection.LeaderElection
+import no.nav.syfo.application.task.RecurringTask
+import no.nav.syfo.oppfolgingsplan.api.v1.COUNT_OPPFOLGINGSPLAN_SOFT_DELETED
+import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+
+class SoftDeleteOppfolgingsplanerTask(
+    leaderElection: LeaderElection,
+    private val oppfolgingsplanService: OppfolgingsplanService,
+    interval: Duration = 1.days,
+) : RecurringTask(
+    name = SoftDeleteOppfolgingsplanerTask::class.qualifiedName!!,
+    interval = interval,
+    leaderElection = leaderElection,
+) {
+    override suspend fun execute() {
+        val softDeletedOppfolgingsplaner = oppfolgingsplanService.softDeleteExpiredOppfolgingsplaner()
+
+        if (softDeletedOppfolgingsplaner > 0) {
+            COUNT_OPPFOLGINGSPLAN_SOFT_DELETED.increment(softDeletedOppfolgingsplaner.toDouble())
+            log.info("Soft-deleted $softDeletedOppfolgingsplaner expired oppfolgingsplaner")
+        } else {
+            log.debug("No expired oppfolgingsplaner to soft-delete")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/plugins/ConfigureTasks.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/ConfigureTasks.kt
@@ -5,21 +5,25 @@ import io.ktor.server.application.ApplicationStopping
 import kotlinx.coroutines.launch
 import no.nav.syfo.dokumentporten.SendOppfolgingsplanTask
 import no.nav.syfo.oppfolgingsplan.task.CleanupUtkastTask
+import no.nav.syfo.oppfolgingsplan.task.SoftDeleteOppfolgingsplanerTask
 import no.nav.syfo.sykmelding.kafka.SykmeldingsperiodeConsumer
 import org.koin.ktor.ext.inject
 
 fun Application.configureBackgroundTasks() {
     val sendDialogTask by inject<SendOppfolgingsplanTask>()
     val cleanupUtkastTask by inject<CleanupUtkastTask>()
+    val softDeleteOppfolgingsplanerTask by inject<SoftDeleteOppfolgingsplanerTask>()
     val sykmeldingsperiodeConsumer by inject<SykmeldingsperiodeConsumer>()
 
     val sendDialogTaskJob = launch { sendDialogTask.runTask() }
     val cleanupUtkastTaskJob = launch { cleanupUtkastTask.runTask() }
+    val softDeleteOppfolgingsplanerTaskJob = launch { softDeleteOppfolgingsplanerTask.runTask() }
     val sykmeldingsperiodeConsumerJob = launch { sykmeldingsperiodeConsumer.runConsumer() }
     monitor.subscribe(ApplicationStopping) {
         sykmeldingsperiodeConsumer.stop()
         sendDialogTaskJob.cancel()
         cleanupUtkastTaskJob.cancel()
+        softDeleteOppfolgingsplanerTaskJob.cancel()
         sykmeldingsperiodeConsumerJob.cancel()
     }
 }

--- a/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
@@ -14,6 +14,7 @@ import no.nav.syfo.application.database.Database
 import no.nav.syfo.application.database.DatabaseConfig
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.application.isLocalEnv
+import no.nav.syfo.application.isProdEnv
 import no.nav.syfo.application.kafka.producerProperties
 import no.nav.syfo.application.leaderelection.LeaderElection
 import no.nav.syfo.application.valkey.ValkeyCache
@@ -207,7 +208,13 @@ private fun servicesModule() = module {
     single { PdfGenService(get(), get()) }
     single { SendOppfolgingsplanTask(get(), get()) }
     single { CleanupUtkastTask(get(), get()) }
-    single { SoftDeleteOppfolgingsplanerTask(get(), get()) }
+    single {
+        SoftDeleteOppfolgingsplanerTask(
+            leaderElection = get(),
+            oppfolgingsplanService = get(),
+            interval = SoftDeleteOppfolgingsplanerTask.intervalForEnvironment(isProdEnv()),
+        )
+    }
     single { SykmeldingsperiodeRepository(get()) }
     single { SykmeldingsperiodeConsumer(get(), env().kafka) }
 }

--- a/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
@@ -36,6 +36,7 @@ import no.nav.syfo.istilgangskontroll.client.FakeIsTilgangskontrollClient
 import no.nav.syfo.istilgangskontroll.client.IsTilgangskontrollClient
 import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
 import no.nav.syfo.oppfolgingsplan.task.CleanupUtkastTask
+import no.nav.syfo.oppfolgingsplan.task.SoftDeleteOppfolgingsplanerTask
 import no.nav.syfo.pdfgen.PdfGenService
 import no.nav.syfo.pdfgen.client.PdfGenClient
 import no.nav.syfo.pdl.PdlService
@@ -206,6 +207,7 @@ private fun servicesModule() = module {
     single { PdfGenService(get(), get()) }
     single { SendOppfolgingsplanTask(get(), get()) }
     single { CleanupUtkastTask(get(), get()) }
+    single { SoftDeleteOppfolgingsplanerTask(get(), get()) }
     single { SykmeldingsperiodeRepository(get()) }
     single { SykmeldingsperiodeConsumer(get(), env().kafka) }
 }

--- a/src/main/resources/db/migration/V15__add_skjult_fra_column.sql
+++ b/src/main/resources/db/migration/V15__add_skjult_fra_column.sql
@@ -1,2 +1,4 @@
 ALTER TABLE oppfolgingsplan
     ADD COLUMN skjult_fra TIMESTAMPTZ;
+
+CREATE INDEX idx_oppfolgingsplan_skjult_fra_null ON oppfolgingsplan (uuid) WHERE skjult_fra IS NULL;

--- a/src/main/resources/db/migration/V15__add_skjult_fra_column.sql
+++ b/src/main/resources/db/migration/V15__add_skjult_fra_column.sql
@@ -1,4 +1,6 @@
 ALTER TABLE oppfolgingsplan
     ADD COLUMN skjult_fra TIMESTAMPTZ;
 
-CREATE INDEX idx_oppfolgingsplan_skjult_fra_null ON oppfolgingsplan (uuid) WHERE skjult_fra IS NULL;
+CREATE INDEX idx_oppfolgingsplan_visible_lookup
+    ON oppfolgingsplan (sykmeldt_fnr, organisasjonsnummer, created_at DESC)
+    WHERE skjult_fra IS NULL;

--- a/src/main/resources/db/migration/V15__add_skjult_fra_column.sql
+++ b/src/main/resources/db/migration/V15__add_skjult_fra_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oppfolgingsplan
+    ADD COLUMN skjult_fra TIMESTAMPTZ;

--- a/src/main/resources/db/migration/V15__add_skjult_fra_column.sql
+++ b/src/main/resources/db/migration/V15__add_skjult_fra_column.sql
@@ -1,6 +1,4 @@
 ALTER TABLE oppfolgingsplan
     ADD COLUMN skjult_fra TIMESTAMPTZ;
 
-CREATE INDEX idx_oppfolgingsplan_visible_lookup
-    ON oppfolgingsplan (sykmeldt_fnr, organisasjonsnummer, created_at DESC)
-    WHERE skjult_fra IS NULL;
+CREATE INDEX idx_oppfolgingsplan_skjult_fra_null ON oppfolgingsplan (uuid) WHERE skjult_fra IS NULL;

--- a/src/main/resources/db/migration/V16__replace_skjult_fra_index.sql
+++ b/src/main/resources/db/migration/V16__replace_skjult_fra_index.sql
@@ -1,0 +1,5 @@
+DROP INDEX idx_oppfolgingsplan_skjult_fra_null;
+
+CREATE INDEX idx_oppfolgingsplan_visible_lookup
+    ON oppfolgingsplan (sykmeldt_fnr, organisasjonsnummer, created_at DESC)
+    WHERE skjult_fra IS NULL;

--- a/src/test/kotlin/no/nav/syfo/TestDb.kt
+++ b/src/test/kotlin/no/nav/syfo/TestDb.kt
@@ -119,8 +119,9 @@ fun DatabaseInterface.persistOppfolgingsplan(
             evalueringsdato,
             skal_deles_med_lege,
             skal_deles_med_veileder,
-            created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
+            created_at,
+            skjult_fra
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         RETURNING uuid
     """.trimIndent()
 
@@ -139,6 +140,12 @@ fun DatabaseInterface.persistOppfolgingsplan(
             it.setDate(11, Date.valueOf(persistedOppfolgingsplan.evalueringsdato.toString()))
             it.setBoolean(12, persistedOppfolgingsplan.skalDelesMedLege)
             it.setBoolean(13, persistedOppfolgingsplan.skalDelesMedVeileder)
+            it.setTimestamp(14, Timestamp.from(persistedOppfolgingsplan.createdAt))
+            if (persistedOppfolgingsplan.skjultFra != null) {
+                it.setTimestamp(15, Timestamp.from(persistedOppfolgingsplan.skjultFra))
+            } else {
+                it.setNull(15, Types.TIMESTAMP_WITH_TIMEZONE)
+            }
             val resultSet = it.executeQuery()
             connection.commit()
             resultSet.next()

--- a/src/test/kotlin/no/nav/syfo/TestUtils.kt
+++ b/src/test/kotlin/no/nav/syfo/TestUtils.kt
@@ -70,6 +70,7 @@ fun defaultPersistedOppfolgingsplan() = PersistedOppfolgingsplan(
     narmesteLederId = UUID.randomUUID().toString(),
     evalueringsdato = LocalDate.now().plus(30, ChronoUnit.DAYS),
     createdAt = Instant.now(),
+    skjultFra = null,
 )
 
 fun defaultPersistedOppfolgingsplanUtkast() = PersistedOppfolgingsplanUtkast(

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
@@ -303,6 +303,29 @@ class OppfolgingsplanApiV1Test :
                 }
             }
 
+            it("GET /oppfolgingsplaner/{uuid} should respond with NotFound when plan is hidden") {
+                withTestApplication {
+                    texasClientMock.defaultMocks(clientId = environment.syfoOppfolgingsplanFrontendClientId)
+                    dineSykmeldteHttpClientMock.defaultMocks(narmestelederId = narmestelederId)
+
+                    val hiddenUUID = testDb.persistOppfolgingsplan(
+                        defaultPersistedOppfolgingsplan().copy(
+                            narmesteLederId = narmestelederId,
+                            skjultFra = Instant.now(),
+                        ),
+                    )
+
+                    val response = client.get {
+                        url("/api/v1/arbeidsgiver/$narmestelederId/oppfolgingsplaner/$hiddenUUID")
+                        bearerAuth("Bearer token")
+                    }
+
+                    response.status shouldBe HttpStatusCode.NotFound
+                    val apiError = response.body<ApiError>()
+                    apiError.type shouldBe ErrorType.PLAN_NOT_FOUND
+                }
+            }
+
             it("GET /oppfolgingsplaner/aktiv-plan should respond with PLAN_NOT_FOUND if aktiv plan does not exist") {
                 withTestApplication {
                     // Arrange
@@ -349,6 +372,29 @@ class OppfolgingsplanApiV1Test :
                 }
             }
 
+            it("GET /oppfolgingsplaner/aktiv-plan should respond with PLAN_NOT_FOUND when only hidden plan exists") {
+                withTestApplication {
+                    texasClientMock.defaultMocks(clientId = environment.syfoOppfolgingsplanFrontendClientId)
+                    dineSykmeldteHttpClientMock.defaultMocks(narmestelederId = narmestelederId)
+
+                    testDb.persistOppfolgingsplan(
+                        defaultPersistedOppfolgingsplan().copy(
+                            narmesteLederId = narmestelederId,
+                            skjultFra = Instant.now(),
+                        ),
+                    )
+
+                    val response = client.get {
+                        url("/api/v1/arbeidsgiver/$narmestelederId/oppfolgingsplaner/aktiv-plan")
+                        bearerAuth("Bearer token")
+                    }
+
+                    response.status shouldBe HttpStatusCode.NotFound
+                    val apiError = response.body<ApiError>()
+                    apiError.type shouldBe ErrorType.PLAN_NOT_FOUND
+                }
+            }
+
             it("GET /oppfolgingsplaner/oversikt should respond with OK and return overview") {
                 withTestApplication {
                     // Arrange
@@ -388,6 +434,30 @@ class OppfolgingsplanApiV1Test :
                     overview.aktivPlan?.stillingsprosent shouldBe BigDecimal("100.00")
                     overview.tidligerePlaner.size shouldBe 1
                     overview.tidligerePlaner.first().id shouldBe firstPlanUUID
+                }
+            }
+
+            it("GET /oppfolgingsplaner/oversikt should return no plans when only hidden plans exist") {
+                withTestApplication {
+                    texasClientMock.defaultMocks(clientId = environment.syfoOppfolgingsplanFrontendClientId)
+                    dineSykmeldteHttpClientMock.defaultMocks(narmestelederId = narmestelederId)
+
+                    testDb.persistOppfolgingsplan(
+                        defaultPersistedOppfolgingsplan().copy(
+                            narmesteLederId = narmestelederId,
+                            skjultFra = Instant.now(),
+                        ),
+                    )
+
+                    val response = client.get {
+                        url("/api/v1/arbeidsgiver/$narmestelederId/oppfolgingsplaner/oversikt")
+                        bearerAuth("Bearer token")
+                    }
+
+                    response.status shouldBe HttpStatusCode.OK
+                    val overview = response.body<ArbeidsgiverOppfolgingsplanOverviewResponse>().oversikt
+                    overview.aktivPlan shouldBe null
+                    overview.tidligerePlaner shouldBe emptyList()
                 }
             }
             it("POST /oppfolgingsplaner should respond with 201 when oppfolgingsplan is created successfully") {

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/OppfolgingsplanApiV1Test.kt
@@ -53,6 +53,7 @@ import no.nav.syfo.plugins.installStatusPages
 import no.nav.syfo.texas.client.TexasHttpClient
 import no.nav.syfo.texas.client.TexasIntrospectionResponse
 import no.nav.syfo.varsel.EsyfovarselProducer
+import java.time.Instant
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import java.util.UUID
@@ -263,6 +264,33 @@ class OppfolgingsplanApiV1Test :
                         overview.tidligerePlaner.first().organization.orgNumber shouldBe defaultPersistedOppfolgingsplan().organisasjonsnummer
                     }
                 }
+
+                it("GET /oppfolgingsplaner/oversikt should return empty lists when only hidden plans exist") {
+                    val sykmeldtFnr = "12345678901"
+                    withTestApplication {
+                        texasClientMock.defaultMocks(
+                            pid = sykmeldtFnr,
+                            clientId = environment.syfoOppfolgingsplanFrontendClientId,
+                        )
+
+                        testDb.persistOppfolgingsplan(
+                            defaultPersistedOppfolgingsplan().copy(
+                                narmesteLederId = narmestelederId,
+                                skjultFra = Instant.now(),
+                            ),
+                        )
+
+                        val response = client.get {
+                            url("/api/v1/sykmeldt/oppfolgingsplaner/oversikt")
+                            bearerAuth("Bearer token")
+                        }
+
+                        response.status shouldBe HttpStatusCode.OK
+                        val overview = response.body<SykmeldtOppfolgingsplanOverviewResponse>()
+                        overview.aktiveOppfolgingsplaner shouldBe emptyList()
+                        overview.tidligerePlaner shouldBe emptyList()
+                    }
+                }
             }
             it("GET /oppfolgingsplaner/{uuid} should respond with NotFound if oppfolgingsplan does not exist") {
                 withTestApplication {
@@ -322,6 +350,28 @@ class OppfolgingsplanApiV1Test :
                         }
 
                         // Assert
+                        response.status shouldBe HttpStatusCode.NotFound
+                    }
+                }
+
+                it("GET /oppfolgingsplaner/{uuid} should respond with NotFound when plan is hidden") {
+                    withTestApplication {
+                        val sykmeldtFnr = "12345678901"
+                        texasClientMock.defaultMocks(sykmeldtFnr, clientId = environment.syfoOppfolgingsplanFrontendClientId)
+
+                        val hiddenUUID = testDb.persistOppfolgingsplan(
+                            defaultPersistedOppfolgingsplan()
+                                .copy(
+                                    narmesteLederId = narmestelederId,
+                                    skjultFra = Instant.now(),
+                                ),
+                        )
+
+                        val response = client.get {
+                            url("/api/v1/sykmeldt/oppfolgingsplaner/$hiddenUUID")
+                            bearerAuth("Bearer token")
+                        }
+
                         response.status shouldBe HttpStatusCode.NotFound
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederOppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederOppfolgingsplanApiV1Test.kt
@@ -281,6 +281,38 @@ class VeilederOppfolgingsplanApiV1Test :
                         responseList.first().uuid shouldBe firstPlanUUID
                     }
                 }
+
+                it("POST /veileder/oppfolgingsplaner should include hidden plans") {
+                    withTestApplication {
+                        texasClientMock.defaultMocks(
+                            pid = "some-veileder-token",
+                            navident = "some-navident",
+                            azpName = syfomodiapersonClientId,
+                        )
+                        coEvery { isTilgangskontrollClientMock.harTilgangTilSykmeldt(any(), any()) } returns true
+
+                        val hiddenPlanUuid = testDb.persistOppfolgingsplan(
+                            defaultPersistedOppfolgingsplan().copy(
+                                narmesteLederId = narmestelederId,
+                                sykmeldtFnr = sykmeldtFnr,
+                                skjultFra = Instant.now(),
+                            ),
+                        )
+                        testDb.updateSkalDelesMedVeileder(hiddenPlanUuid, true)
+                        testDb.setDeltMedVeilederTidspunkt(hiddenPlanUuid, Instant.now())
+
+                        val response = client.post {
+                            url("/api/v1/veileder/oppfolgingsplaner/query")
+                            bearerAuth(token = "Bearer token")
+                            header(NAV_PERSONIDENT_HEADER, sykmeldtFnr)
+                            contentType(ContentType.Application.Json)
+                            setBody(OppfolgingsplanerReadRequest(sykmeldtFnr))
+                        }
+
+                        response.status shouldBe HttpStatusCode.OK
+                        response.body<List<OppfolgingsplanVeileder>>().map { it.uuid } shouldBe listOf(hiddenPlanUuid)
+                    }
+                }
             }
         }
 
@@ -405,6 +437,38 @@ class VeilederOppfolgingsplanApiV1Test :
                             token = any(),
                         )
                     }
+                }
+            }
+
+            it("GET /veileder/oppfolgingsplaner/<uuid> should return hidden plan") {
+                withTestApplication {
+                    val pdfContent = "ThisIsPdfContent"
+                    texasClientMock.defaultMocks(
+                        pid = "some-veileder-token",
+                        navident = "some-navident",
+                        azpName = syfomodiapersonClientId,
+                    )
+                    coEvery { isTilgangskontrollClientMock.harTilgangTilSykmeldt(any(), any()) } returns true
+                    coEvery { pdfGenService.generatePdf(any()) } returns pdfContent.toByteArray(Charsets.UTF_8)
+                    val hiddenPlanUuid = testDb.persistOppfolgingsplan(
+                        defaultPersistedOppfolgingsplan().copy(
+                            narmesteLederId = narmestelederId,
+                            sykmeldtFnr = sykmeldtFnr,
+                            skjultFra = Instant.now(),
+                        ),
+                    )
+                    testDb.updateSkalDelesMedVeileder(hiddenPlanUuid, true)
+                    testDb.setDeltMedVeilederTidspunkt(hiddenPlanUuid, Instant.now())
+
+                    val response = client.get {
+                        url("/api/v1/veileder/oppfolgingsplaner/$hiddenPlanUuid")
+                        bearerAuth(token = "Bearer token")
+                        header(NAV_PERSONIDENT_HEADER, sykmeldtFnr)
+                    }
+
+                    response.status shouldBe HttpStatusCode.OK
+                    response.contentType() shouldBe ContentType.Application.Pdf
+                    response.body<ByteArray>() shouldBe pdfContent.toByteArray(Charsets.UTF_8)
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanServiceSafeguardTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanServiceSafeguardTest.kt
@@ -1,0 +1,68 @@
+package no.nav.syfo.oppfolgingsplan.service
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.varsel.EsyfovarselProducer
+import org.slf4j.LoggerFactory
+
+class OppfolgingsplanServiceSafeguardTest :
+    DescribeSpec({
+        val logger = LoggerFactory.getLogger(OppfolgingsplanService::class.qualifiedName) as Logger
+        val service = OppfolgingsplanService(
+            database = mockk<DatabaseInterface>(relaxed = true),
+            pdlService = mockk(relaxed = true),
+            esyfovarselProducer = mockk<EsyfovarselProducer>(relaxed = true),
+            aaregService = mockk(relaxed = true),
+        )
+
+        describe("runSoftDeleteExpiredOppfolgingsplanerLoop") {
+            it("stops when safeguard limit is reached and logs warning without PII") {
+                val appender = ListAppender<ILoggingEvent>().apply { start() }
+                val originalLevel = logger.level
+                logger.level = Level.WARN
+                logger.addAppender(appender)
+
+                try {
+                    val totalSoftDeleted = service.runSoftDeleteExpiredOppfolgingsplanerLoop(
+                        maxBatchIterations = 3,
+                    ) {
+                        1
+                    }
+
+                    totalSoftDeleted shouldBe 3
+                    appender.list.any {
+                        it.level == Level.WARN &&
+                            it.formattedMessage == "Stopped soft-delete loop after reaching safeguard of 3 batches; total soft-deleted so far: 3"
+                    } shouldBe true
+                } finally {
+                    logger.level = originalLevel
+                    logger.detachAppender(appender)
+                    appender.stop()
+                }
+            }
+
+            it("keeps processing until batch returns zero before safeguard limit") {
+                var invocations = 0
+
+                val totalSoftDeleted = service.runSoftDeleteExpiredOppfolgingsplanerLoop(
+                    maxBatchIterations = 5,
+                ) {
+                    invocations++
+                    when (invocations) {
+                        1 -> 2
+                        2 -> 1
+                        else -> 0
+                    }
+                }
+
+                totalSoftDeleted shouldBe 3
+                invocations shouldBe 3
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanServiceTest.kt
@@ -1,5 +1,4 @@
 package no.nav.syfo.oppfolgingsplan.service
-
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.nulls.shouldBeNull

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTaskIntervalTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTaskIntervalTest.kt
@@ -1,0 +1,16 @@
+package no.nav.syfo.oppfolgingsplan.task
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.minutes
+
+class SoftDeleteOppfolgingsplanerTaskIntervalTest :
+    DescribeSpec({
+        describe("intervalForEnvironment") {
+            it("should use prod interval in prod and short interval elsewhere") {
+                SoftDeleteOppfolgingsplanerTask.intervalForEnvironment(isProdEnv = true) shouldBe 1.days
+                SoftDeleteOppfolgingsplanerTask.intervalForEnvironment(isProdEnv = false) shouldBe 5.minutes
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTaskLoggingTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTaskLoggingTest.kt
@@ -1,0 +1,73 @@
+package no.nav.syfo.oppfolgingsplan.task
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import no.nav.syfo.application.leaderelection.LeaderElection
+import no.nav.syfo.oppfolgingsplan.api.v1.COUNT_OPPFOLGINGSPLAN_SOFT_DELETED
+import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
+import org.slf4j.LoggerFactory
+import kotlin.time.Duration.Companion.days
+
+class SoftDeleteOppfolgingsplanerTaskLoggingTest :
+    DescribeSpec({
+        describe("execute") {
+            it("should call service and increment counter") {
+                val leaderElection = mockk<LeaderElection>()
+                val oppfolgingsplanService = mockk<OppfolgingsplanService>()
+                val counterBefore = COUNT_OPPFOLGINGSPLAN_SOFT_DELETED.count()
+
+                coEvery { oppfolgingsplanService.softDeleteExpiredOppfolgingsplaner() } returns 3
+
+                val task = SoftDeleteOppfolgingsplanerTask(
+                    leaderElection = leaderElection,
+                    oppfolgingsplanService = oppfolgingsplanService,
+                    interval = 1.days,
+                )
+
+                task.execute()
+
+                coVerify(exactly = 1) { oppfolgingsplanService.softDeleteExpiredOppfolgingsplaner() }
+                COUNT_OPPFOLGINGSPLAN_SOFT_DELETED.count() - counterBefore shouldBe 3.0
+            }
+
+            it("should log start and zero-result on info when no planer are soft-deleted") {
+                val leaderElection = mockk<LeaderElection>()
+                val oppfolgingsplanService = mockk<OppfolgingsplanService>()
+                val logger = LoggerFactory.getLogger(SoftDeleteOppfolgingsplanerTask::class.qualifiedName) as Logger
+                val appender = ListAppender<ILoggingEvent>().apply { start() }
+
+                coEvery { oppfolgingsplanService.softDeleteExpiredOppfolgingsplaner() } returns 0
+                val originalLevel = logger.level
+                logger.level = Level.INFO
+                logger.addAppender(appender)
+
+                try {
+                    val task = SoftDeleteOppfolgingsplanerTask(
+                        leaderElection = leaderElection,
+                        oppfolgingsplanService = oppfolgingsplanService,
+                        interval = 1.days,
+                    )
+
+                    task.execute()
+
+                    appender.list.any {
+                        it.level == Level.INFO && it.formattedMessage == "Starting task for soft-delete expired oppfolgingsplaner"
+                    } shouldBe true
+                    appender.list.any {
+                        it.level == Level.INFO && it.formattedMessage == "Found 0 expired oppfolgingsplaner to soft-delete"
+                    } shouldBe true
+                } finally {
+                    logger.level = originalLevel
+                    logger.detachAppender(appender)
+                    appender.stop()
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTaskTest.kt
@@ -76,6 +76,8 @@ class SoftDeleteOppfolgingsplanerTaskTest :
 
                 coEvery { leaderElection.isLeader() } returns true
                 coEvery { oppfolgingsplanService.softDeleteExpiredOppfolgingsplaner() } returns 0
+                val originalLevel = logger.level
+                logger.level = Level.DEBUG
                 logger.addAppender(appender)
 
                 try {
@@ -91,6 +93,7 @@ class SoftDeleteOppfolgingsplanerTaskTest :
                         it.level == Level.DEBUG && it.formattedMessage == "No expired oppfolgingsplaner to soft-delete"
                     } shouldBe true
                 } finally {
+                    logger.level = originalLevel
                     logger.detachAppender(appender)
                     appender.stop()
                 }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTaskTest.kt
@@ -19,6 +19,7 @@ import no.nav.syfo.oppfolgingsplan.api.v1.COUNT_OPPFOLGINGSPLAN_SOFT_DELETED
 import no.nav.syfo.oppfolgingsplan.db.findAllOppfolgingsplanerBy
 import no.nav.syfo.oppfolgingsplan.db.findOppfolgingsplanBy
 import no.nav.syfo.oppfolgingsplan.db.findOppfolgingsplanerForDokumentportenPublisering
+import no.nav.syfo.oppfolgingsplan.db.softDeleteExpiredOppfolgingsplaner
 import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
 import no.nav.syfo.persistOppfolgingsplan
 import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
@@ -41,6 +42,22 @@ class SoftDeleteOppfolgingsplanerTaskTest :
             pdlService = mockk(relaxed = true),
             aaregService = mockk(relaxed = true),
         )
+
+        fun softDeleteAll(batchSize: Int): Pair<Int, Int> {
+            var total = 0
+            var iterations = 0
+            var count: Int
+
+            do {
+                count = testDb.softDeleteExpiredOppfolgingsplaner(batchSize)
+                if (count > 0) {
+                    iterations++
+                }
+                total += count
+            } while (count > 0)
+
+            return total to iterations
+        }
 
         beforeTest {
             clearAllMocks()
@@ -141,6 +158,46 @@ class SoftDeleteOppfolgingsplanerTaskTest :
                 testDb.findOppfolgingsplanBy(planUuid, inkluderSkjulte = true)?.skjultFra.shouldBeNull()
             }
 
+            it("does not soft-delete plan with last tom exactly 6 months ago") {
+                val plan = defaultPersistedOppfolgingsplan()
+                val planUuid = testDb.persistOppfolgingsplan(plan)
+                sykmeldingsperiodeRepository.storeSykmeldingsperioder(
+                    listOf(
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = plan.sykmeldtFnr,
+                            organisasjonsnummer = plan.organisasjonsnummer,
+                            sykmeldingId = "sykmelding-boundary-1",
+                            fom = LocalDate.now().minusMonths(6).minusDays(14),
+                            tom = LocalDate.now().minusMonths(6),
+                        ),
+                    ),
+                )
+
+                service().softDeleteExpiredOppfolgingsplaner() shouldBe 0
+
+                testDb.findOppfolgingsplanBy(planUuid, inkluderSkjulte = true)?.skjultFra.shouldBeNull()
+            }
+
+            it("soft-deletes plan with last tom exactly 6 months and 1 day ago") {
+                val plan = defaultPersistedOppfolgingsplan()
+                val planUuid = testDb.persistOppfolgingsplan(plan)
+                sykmeldingsperiodeRepository.storeSykmeldingsperioder(
+                    listOf(
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = plan.sykmeldtFnr,
+                            organisasjonsnummer = plan.organisasjonsnummer,
+                            sykmeldingId = "sykmelding-boundary-2",
+                            fom = LocalDate.now().minusMonths(6).minusDays(15),
+                            tom = LocalDate.now().minusMonths(6).minusDays(1),
+                        ),
+                    ),
+                )
+
+                service().softDeleteExpiredOppfolgingsplaner() shouldBe 1
+
+                testDb.findOppfolgingsplanBy(planUuid, inkluderSkjulte = true)?.skjultFra.shouldNotBeNull()
+            }
+
             it("does not soft-delete plan when newer sykmeldingsperiode resets cutoff") {
                 val plan = defaultPersistedOppfolgingsplan()
                 val planUuid = testDb.persistOppfolgingsplan(plan)
@@ -190,6 +247,29 @@ class SoftDeleteOppfolgingsplanerTaskTest :
                 testDb.findOppfolgingsplanBy(planUuid, inkluderSkjulte = true)?.skjultFra.shouldBeNull()
             }
 
+            it("soft-deletes old plan when only invalidated sykmeldingsperioder exist") {
+                val plan = defaultPersistedOppfolgingsplan().copy(
+                    createdAt = Instant.now().minus(210, ChronoUnit.DAYS),
+                )
+                val planUuid = testDb.persistOppfolgingsplan(plan)
+                sykmeldingsperiodeRepository.storeSykmeldingsperioder(
+                    listOf(
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = plan.sykmeldtFnr,
+                            organisasjonsnummer = plan.organisasjonsnummer,
+                            sykmeldingId = "sykmelding-invalidated-fallback",
+                            fom = LocalDate.now().minusMonths(8),
+                            tom = LocalDate.now().minusMonths(7),
+                        ),
+                    ),
+                )
+                sykmeldingsperiodeRepository.invalidateSykmelding("sykmelding-invalidated-fallback")
+
+                service().softDeleteExpiredOppfolgingsplaner() shouldBe 1
+
+                testDb.findOppfolgingsplanBy(planUuid, inkluderSkjulte = true)?.skjultFra.shouldNotBeNull()
+            }
+
             it("ignores invalidated sykmeldingsperioder") {
                 val plan = defaultPersistedOppfolgingsplan().copy(
                     createdAt = Instant.now().minus(150, ChronoUnit.DAYS),
@@ -211,6 +291,28 @@ class SoftDeleteOppfolgingsplanerTaskTest :
                 service().softDeleteExpiredOppfolgingsplaner() shouldBe 0
 
                 testDb.findOppfolgingsplanBy(planUuid, inkluderSkjulte = true)?.skjultFra.shouldBeNull()
+            }
+
+            it("soft-deletes all expired plans across multiple batches") {
+                val sykmeldtFnr = "12345678901"
+                val planUuids = (1..5).map { index ->
+                    testDb.persistOppfolgingsplan(
+                        defaultPersistedOppfolgingsplan().copy(
+                            uuid = java.util.UUID.randomUUID(),
+                            sykmeldtFnr = sykmeldtFnr,
+                            organisasjonsnummer = "12345678$index",
+                            createdAt = Instant.now().minus(210, ChronoUnit.DAYS),
+                        ),
+                    )
+                }
+
+                val (softDeletedCount, iterations) = softDeleteAll(batchSize = 2)
+
+                softDeletedCount shouldBe 5
+                iterations shouldBe 3
+                planUuids.forEach { planUuid ->
+                    testDb.findOppfolgingsplanBy(planUuid, inkluderSkjulte = true)?.skjultFra.shouldNotBeNull()
+                }
             }
         }
 

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTaskTest.kt
@@ -282,6 +282,34 @@ class SoftDeleteOppfolgingsplanerTaskTest :
                 testDb.findOppfolgingsplanBy(planUuid, inkluderSkjulte = true)?.skjultFra.shouldBeNull()
             }
 
+            it("soft-deletes plan when only newer sykmeldingsperiode is invalidated") {
+                val plan = defaultPersistedOppfolgingsplan()
+                val planUuid = testDb.persistOppfolgingsplan(plan)
+                sykmeldingsperiodeRepository.storeSykmeldingsperioder(
+                    listOf(
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = plan.sykmeldtFnr,
+                            organisasjonsnummer = plan.organisasjonsnummer,
+                            sykmeldingId = "sykmelding-old-valid",
+                            fom = LocalDate.now().minusMonths(8),
+                            tom = LocalDate.now().minusMonths(7),
+                        ),
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = plan.sykmeldtFnr,
+                            organisasjonsnummer = plan.organisasjonsnummer,
+                            sykmeldingId = "sykmelding-new-invalidated",
+                            fom = LocalDate.now().minusMonths(3),
+                            tom = LocalDate.now().minusMonths(2),
+                        ),
+                    ),
+                )
+                sykmeldingsperiodeRepository.invalidateSykmelding("sykmelding-new-invalidated")
+
+                service().softDeleteExpiredOppfolgingsplaner() shouldBe 1
+
+                testDb.findOppfolgingsplanBy(planUuid, inkluderSkjulte = true)?.skjultFra.shouldNotBeNull()
+            }
+
             it("soft-deletes all expired plans across multiple batches") {
                 val sykmeldtFnr = "12345678901"
                 val planUuids = (1..5).map { index ->

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTaskTest.kt
@@ -1,21 +1,13 @@
 package no.nav.syfo.oppfolgingsplan.task
 
-import ch.qos.logback.classic.Level
-import ch.qos.logback.classic.Logger
-import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.core.read.ListAppender
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
-import io.mockk.coEvery
-import io.mockk.coVerify
 import io.mockk.mockk
 import no.nav.syfo.TestDB
-import no.nav.syfo.application.leaderelection.LeaderElection
 import no.nav.syfo.defaultPersistedOppfolgingsplan
-import no.nav.syfo.oppfolgingsplan.api.v1.COUNT_OPPFOLGINGSPLAN_SOFT_DELETED
 import no.nav.syfo.oppfolgingsplan.db.findAllOppfolgingsplanerBy
 import no.nav.syfo.oppfolgingsplan.db.findOppfolgingsplanBy
 import no.nav.syfo.oppfolgingsplan.db.findOppfolgingsplanerForDokumentportenPublisering
@@ -25,10 +17,8 @@ import no.nav.syfo.persistOppfolgingsplan
 import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
 import no.nav.syfo.sykmelding.db.domain.SykmeldingsperiodeToStore
 import no.nav.syfo.varsel.EsyfovarselProducer
-import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.time.LocalDate
-import kotlin.time.Duration.Companion.days
 
 class SoftDeleteOppfolgingsplanerTaskTest :
     DescribeSpec({
@@ -61,59 +51,6 @@ class SoftDeleteOppfolgingsplanerTaskTest :
         beforeTest {
             clearAllMocks()
             TestDB.clearAllData()
-        }
-
-        describe("execute") {
-            it("should call service and increment counter") {
-                val leaderElection = mockk<LeaderElection>()
-                val oppfolgingsplanService = mockk<OppfolgingsplanService>()
-                val counterBefore = COUNT_OPPFOLGINGSPLAN_SOFT_DELETED.count()
-
-                coEvery { leaderElection.isLeader() } returns true
-                coEvery { oppfolgingsplanService.softDeleteExpiredOppfolgingsplaner() } returns 3
-
-                val task = SoftDeleteOppfolgingsplanerTask(
-                    leaderElection = leaderElection,
-                    oppfolgingsplanService = oppfolgingsplanService,
-                    interval = 1.days,
-                )
-
-                task.execute()
-
-                coVerify(exactly = 1) { oppfolgingsplanService.softDeleteExpiredOppfolgingsplaner() }
-                COUNT_OPPFOLGINGSPLAN_SOFT_DELETED.count() - counterBefore shouldBe 3.0
-            }
-
-            it("should log debug when no planer are soft-deleted") {
-                val leaderElection = mockk<LeaderElection>()
-                val oppfolgingsplanService = mockk<OppfolgingsplanService>()
-                val logger = LoggerFactory.getLogger(SoftDeleteOppfolgingsplanerTask::class.qualifiedName) as Logger
-                val appender = ListAppender<ILoggingEvent>().apply { start() }
-
-                coEvery { leaderElection.isLeader() } returns true
-                coEvery { oppfolgingsplanService.softDeleteExpiredOppfolgingsplaner() } returns 0
-                val originalLevel = logger.level
-                logger.level = Level.DEBUG
-                logger.addAppender(appender)
-
-                try {
-                    val task = SoftDeleteOppfolgingsplanerTask(
-                        leaderElection = leaderElection,
-                        oppfolgingsplanService = oppfolgingsplanService,
-                        interval = 1.days,
-                    )
-
-                    task.execute()
-
-                    appender.list.any {
-                        it.level == Level.DEBUG && it.formattedMessage == "No expired oppfolgingsplaner to soft-delete"
-                    } shouldBe true
-                } finally {
-                    logger.level = originalLevel
-                    logger.detachAppender(appender)
-                    appender.stop()
-                }
-            }
         }
 
         describe("softDeleteExpiredOppfolgingsplaner") {

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTaskTest.kt
@@ -28,7 +28,6 @@ import no.nav.syfo.varsel.EsyfovarselProducer
 import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.time.LocalDate
-import java.time.temporal.ChronoUnit
 import kotlin.time.Duration.Companion.days
 
 class SoftDeleteOppfolgingsplanerTaskTest :
@@ -225,21 +224,8 @@ class SoftDeleteOppfolgingsplanerTaskTest :
                 testDb.findOppfolgingsplanBy(planUuid, inkluderSkjulte = true)?.skjultFra.shouldBeNull()
             }
 
-            it("soft-deletes plan older than 6 months when there are no sykmeldingsperioder") {
-                val plan = defaultPersistedOppfolgingsplan().copy(
-                    createdAt = Instant.now().minus(210, ChronoUnit.DAYS),
-                )
-                val planUuid = testDb.persistOppfolgingsplan(plan)
-
-                service().softDeleteExpiredOppfolgingsplaner() shouldBe 1
-
-                testDb.findOppfolgingsplanBy(planUuid, inkluderSkjulte = true)?.skjultFra.shouldNotBeNull()
-            }
-
-            it("does not soft-delete recent plan when there are no sykmeldingsperioder") {
-                val plan = defaultPersistedOppfolgingsplan().copy(
-                    createdAt = Instant.now().minus(150, ChronoUnit.DAYS),
-                )
+            it("does not soft-delete plan when there are no sykmeldingsperioder") {
+                val plan = defaultPersistedOppfolgingsplan()
                 val planUuid = testDb.persistOppfolgingsplan(plan)
 
                 service().softDeleteExpiredOppfolgingsplaner() shouldBe 0
@@ -247,46 +233,49 @@ class SoftDeleteOppfolgingsplanerTaskTest :
                 testDb.findOppfolgingsplanBy(planUuid, inkluderSkjulte = true)?.skjultFra.shouldBeNull()
             }
 
-            it("soft-deletes old plan when only invalidated sykmeldingsperioder exist") {
-                val plan = defaultPersistedOppfolgingsplan().copy(
-                    createdAt = Instant.now().minus(210, ChronoUnit.DAYS),
-                )
+            it("does not soft-delete plan when only invalidated sykmeldingsperioder exist") {
+                val plan = defaultPersistedOppfolgingsplan()
                 val planUuid = testDb.persistOppfolgingsplan(plan)
                 sykmeldingsperiodeRepository.storeSykmeldingsperioder(
                     listOf(
                         SykmeldingsperiodeToStore(
                             sykmeldtFnr = plan.sykmeldtFnr,
                             organisasjonsnummer = plan.organisasjonsnummer,
-                            sykmeldingId = "sykmelding-invalidated-fallback",
+                            sykmeldingId = "sykmelding-invalidated-only",
                             fom = LocalDate.now().minusMonths(8),
                             tom = LocalDate.now().minusMonths(7),
                         ),
                     ),
                 )
-                sykmeldingsperiodeRepository.invalidateSykmelding("sykmelding-invalidated-fallback")
+                sykmeldingsperiodeRepository.invalidateSykmelding("sykmelding-invalidated-only")
 
-                service().softDeleteExpiredOppfolgingsplaner() shouldBe 1
+                service().softDeleteExpiredOppfolgingsplaner() shouldBe 0
 
-                testDb.findOppfolgingsplanBy(planUuid, inkluderSkjulte = true)?.skjultFra.shouldNotBeNull()
+                testDb.findOppfolgingsplanBy(planUuid, inkluderSkjulte = true)?.skjultFra.shouldBeNull()
             }
 
-            it("ignores invalidated sykmeldingsperioder") {
-                val plan = defaultPersistedOppfolgingsplan().copy(
-                    createdAt = Instant.now().minus(150, ChronoUnit.DAYS),
-                )
+            it("ignores invalidated sykmeldingsperioder when a newer valid period exists") {
+                val plan = defaultPersistedOppfolgingsplan()
                 val planUuid = testDb.persistOppfolgingsplan(plan)
                 sykmeldingsperiodeRepository.storeSykmeldingsperioder(
                     listOf(
                         SykmeldingsperiodeToStore(
                             sykmeldtFnr = plan.sykmeldtFnr,
                             organisasjonsnummer = plan.organisasjonsnummer,
-                            sykmeldingId = "sykmelding-4",
+                            sykmeldingId = "sykmelding-invalidated",
                             fom = LocalDate.now().minusMonths(8),
                             tom = LocalDate.now().minusMonths(7),
                         ),
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = plan.sykmeldtFnr,
+                            organisasjonsnummer = plan.organisasjonsnummer,
+                            sykmeldingId = "sykmelding-valid",
+                            fom = LocalDate.now().minusMonths(3),
+                            tom = LocalDate.now().minusMonths(2),
+                        ),
                     ),
                 )
-                sykmeldingsperiodeRepository.invalidateSykmelding("sykmelding-4")
+                sykmeldingsperiodeRepository.invalidateSykmelding("sykmelding-invalidated")
 
                 service().softDeleteExpiredOppfolgingsplaner() shouldBe 0
 
@@ -301,10 +290,20 @@ class SoftDeleteOppfolgingsplanerTaskTest :
                             uuid = java.util.UUID.randomUUID(),
                             sykmeldtFnr = sykmeldtFnr,
                             organisasjonsnummer = "12345678$index",
-                            createdAt = Instant.now().minus(210, ChronoUnit.DAYS),
                         ),
                     )
                 }
+                sykmeldingsperiodeRepository.storeSykmeldingsperioder(
+                    (1..5).map { index ->
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = sykmeldtFnr,
+                            organisasjonsnummer = "12345678$index",
+                            sykmeldingId = "sykmelding-batch-$index",
+                            fom = LocalDate.now().minusMonths(8),
+                            tom = LocalDate.now().minusMonths(7),
+                        )
+                    },
+                )
 
                 val (softDeletedCount, iterations) = softDeleteAll(batchSize = 2)
 

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTaskTest.kt
@@ -1,0 +1,246 @@
+package no.nav.syfo.oppfolgingsplan.task
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import no.nav.syfo.TestDB
+import no.nav.syfo.application.leaderelection.LeaderElection
+import no.nav.syfo.defaultPersistedOppfolgingsplan
+import no.nav.syfo.oppfolgingsplan.api.v1.COUNT_OPPFOLGINGSPLAN_SOFT_DELETED
+import no.nav.syfo.oppfolgingsplan.db.findAllOppfolgingsplanerBy
+import no.nav.syfo.oppfolgingsplan.db.findOppfolgingsplanBy
+import no.nav.syfo.oppfolgingsplan.db.findOppfolgingsplanerForDokumentportenPublisering
+import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
+import no.nav.syfo.persistOppfolgingsplan
+import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
+import no.nav.syfo.sykmelding.db.domain.SykmeldingsperiodeToStore
+import no.nav.syfo.varsel.EsyfovarselProducer
+import org.slf4j.LoggerFactory
+import java.time.Instant
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+import kotlin.time.Duration.Companion.days
+
+class SoftDeleteOppfolgingsplanerTaskTest :
+    DescribeSpec({
+        val testDb = TestDB.database
+        val sykmeldingsperiodeRepository = SykmeldingsperiodeRepository(testDb)
+
+        fun service() = OppfolgingsplanService(
+            database = testDb,
+            esyfovarselProducer = mockk<EsyfovarselProducer>(relaxed = true),
+            pdlService = mockk(relaxed = true),
+            aaregService = mockk(relaxed = true),
+        )
+
+        beforeTest {
+            clearAllMocks()
+            TestDB.clearAllData()
+        }
+
+        describe("execute") {
+            it("should call service and increment counter") {
+                val leaderElection = mockk<LeaderElection>()
+                val oppfolgingsplanService = mockk<OppfolgingsplanService>()
+                val counterBefore = COUNT_OPPFOLGINGSPLAN_SOFT_DELETED.count()
+
+                coEvery { leaderElection.isLeader() } returns true
+                coEvery { oppfolgingsplanService.softDeleteExpiredOppfolgingsplaner() } returns 3
+
+                val task = SoftDeleteOppfolgingsplanerTask(
+                    leaderElection = leaderElection,
+                    oppfolgingsplanService = oppfolgingsplanService,
+                    interval = 1.days,
+                )
+
+                task.execute()
+
+                coVerify(exactly = 1) { oppfolgingsplanService.softDeleteExpiredOppfolgingsplaner() }
+                COUNT_OPPFOLGINGSPLAN_SOFT_DELETED.count() - counterBefore shouldBe 3.0
+            }
+
+            it("should log debug when no planer are soft-deleted") {
+                val leaderElection = mockk<LeaderElection>()
+                val oppfolgingsplanService = mockk<OppfolgingsplanService>()
+                val logger = LoggerFactory.getLogger(SoftDeleteOppfolgingsplanerTask::class.qualifiedName) as Logger
+                val appender = ListAppender<ILoggingEvent>().apply { start() }
+
+                coEvery { leaderElection.isLeader() } returns true
+                coEvery { oppfolgingsplanService.softDeleteExpiredOppfolgingsplaner() } returns 0
+                logger.addAppender(appender)
+
+                try {
+                    val task = SoftDeleteOppfolgingsplanerTask(
+                        leaderElection = leaderElection,
+                        oppfolgingsplanService = oppfolgingsplanService,
+                        interval = 1.days,
+                    )
+
+                    task.execute()
+
+                    appender.list.any {
+                        it.level == Level.DEBUG && it.formattedMessage == "No expired oppfolgingsplaner to soft-delete"
+                    } shouldBe true
+                } finally {
+                    logger.detachAppender(appender)
+                    appender.stop()
+                }
+            }
+        }
+
+        describe("softDeleteExpiredOppfolgingsplaner") {
+            it("soft-deletes plan with last tom 7 months ago") {
+                val plan = defaultPersistedOppfolgingsplan()
+                val planUuid = testDb.persistOppfolgingsplan(plan)
+                sykmeldingsperiodeRepository.storeSykmeldingsperioder(
+                    listOf(
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = plan.sykmeldtFnr,
+                            organisasjonsnummer = plan.organisasjonsnummer,
+                            sykmeldingId = "sykmelding-1",
+                            fom = LocalDate.now().minusMonths(8),
+                            tom = LocalDate.now().minusMonths(7),
+                        ),
+                    ),
+                )
+
+                service().softDeleteExpiredOppfolgingsplaner() shouldBe 1
+
+                testDb.findOppfolgingsplanBy(planUuid, inkluderSkjulte = true)?.skjultFra.shouldNotBeNull()
+            }
+
+            it("does not soft-delete plan with last tom 5 months ago") {
+                val plan = defaultPersistedOppfolgingsplan()
+                val planUuid = testDb.persistOppfolgingsplan(plan)
+                sykmeldingsperiodeRepository.storeSykmeldingsperioder(
+                    listOf(
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = plan.sykmeldtFnr,
+                            organisasjonsnummer = plan.organisasjonsnummer,
+                            sykmeldingId = "sykmelding-2",
+                            fom = LocalDate.now().minusMonths(6),
+                            tom = LocalDate.now().minusMonths(5),
+                        ),
+                    ),
+                )
+
+                service().softDeleteExpiredOppfolgingsplaner() shouldBe 0
+
+                testDb.findOppfolgingsplanBy(planUuid, inkluderSkjulte = true)?.skjultFra.shouldBeNull()
+            }
+
+            it("does not soft-delete plan when newer sykmeldingsperiode resets cutoff") {
+                val plan = defaultPersistedOppfolgingsplan()
+                val planUuid = testDb.persistOppfolgingsplan(plan)
+                sykmeldingsperiodeRepository.storeSykmeldingsperioder(
+                    listOf(
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = plan.sykmeldtFnr,
+                            organisasjonsnummer = plan.organisasjonsnummer,
+                            sykmeldingId = "sykmelding-3",
+                            fom = LocalDate.now().minusMonths(8),
+                            tom = LocalDate.now().minusMonths(7),
+                        ),
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = plan.sykmeldtFnr,
+                            organisasjonsnummer = plan.organisasjonsnummer,
+                            sykmeldingId = "sykmelding-3",
+                            fom = LocalDate.now().minusMonths(3),
+                            tom = LocalDate.now().minusMonths(2),
+                        ),
+                    ),
+                )
+
+                service().softDeleteExpiredOppfolgingsplaner() shouldBe 0
+
+                testDb.findOppfolgingsplanBy(planUuid, inkluderSkjulte = true)?.skjultFra.shouldBeNull()
+            }
+
+            it("soft-deletes plan older than 6 months when there are no sykmeldingsperioder") {
+                val plan = defaultPersistedOppfolgingsplan().copy(
+                    createdAt = Instant.now().minus(210, ChronoUnit.DAYS),
+                )
+                val planUuid = testDb.persistOppfolgingsplan(plan)
+
+                service().softDeleteExpiredOppfolgingsplaner() shouldBe 1
+
+                testDb.findOppfolgingsplanBy(planUuid, inkluderSkjulte = true)?.skjultFra.shouldNotBeNull()
+            }
+
+            it("does not soft-delete recent plan when there are no sykmeldingsperioder") {
+                val plan = defaultPersistedOppfolgingsplan().copy(
+                    createdAt = Instant.now().minus(150, ChronoUnit.DAYS),
+                )
+                val planUuid = testDb.persistOppfolgingsplan(plan)
+
+                service().softDeleteExpiredOppfolgingsplaner() shouldBe 0
+
+                testDb.findOppfolgingsplanBy(planUuid, inkluderSkjulte = true)?.skjultFra.shouldBeNull()
+            }
+
+            it("ignores invalidated sykmeldingsperioder") {
+                val plan = defaultPersistedOppfolgingsplan().copy(
+                    createdAt = Instant.now().minus(150, ChronoUnit.DAYS),
+                )
+                val planUuid = testDb.persistOppfolgingsplan(plan)
+                sykmeldingsperiodeRepository.storeSykmeldingsperioder(
+                    listOf(
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = plan.sykmeldtFnr,
+                            organisasjonsnummer = plan.organisasjonsnummer,
+                            sykmeldingId = "sykmelding-4",
+                            fom = LocalDate.now().minusMonths(8),
+                            tom = LocalDate.now().minusMonths(7),
+                        ),
+                    ),
+                )
+                sykmeldingsperiodeRepository.invalidateSykmelding("sykmelding-4")
+
+                service().softDeleteExpiredOppfolgingsplaner() shouldBe 0
+
+                testDb.findOppfolgingsplanBy(planUuid, inkluderSkjulte = true)?.skjultFra.shouldBeNull()
+            }
+        }
+
+        describe("filtrering") {
+            it("hides soft-deleted plans when inkluderSkjulte is false") {
+                val hiddenPlan = defaultPersistedOppfolgingsplan().copy(skjultFra = Instant.now())
+                val hiddenUuid = testDb.persistOppfolgingsplan(hiddenPlan)
+
+                testDb.findAllOppfolgingsplanerBy(hiddenPlan.sykmeldtFnr) shouldBe emptyList()
+                testDb.findOppfolgingsplanBy(hiddenUuid).shouldBeNull()
+            }
+
+            it("returns soft-deleted plans when inkluderSkjulte is true") {
+                val hiddenPlan = defaultPersistedOppfolgingsplan().copy(skjultFra = Instant.now())
+                val hiddenUuid = testDb.persistOppfolgingsplan(hiddenPlan)
+
+                testDb.findAllOppfolgingsplanerBy(hiddenPlan.sykmeldtFnr, inkluderSkjulte = true).map { it.uuid } shouldBe listOf(hiddenUuid)
+                testDb.findOppfolgingsplanBy(hiddenUuid, inkluderSkjulte = true)?.uuid shouldBe hiddenUuid
+            }
+        }
+
+        describe("dokumentporten") {
+            it("returns plans regardless of skjult_fra") {
+                val visibleUuid = testDb.persistOppfolgingsplan(defaultPersistedOppfolgingsplan())
+                val hiddenUuid = testDb.persistOppfolgingsplan(
+                    defaultPersistedOppfolgingsplan().copy(
+                        skjultFra = Instant.now(),
+                    ),
+                )
+
+                val planerForPublisering = testDb.findOppfolgingsplanerForDokumentportenPublisering()
+
+                planerForPublisering.map { it.uuid }.sortedBy { it.toString() } shouldBe listOf(visibleUuid, hiddenUuid).sortedBy { it.toString() }
+            }
+        }
+    })


### PR DESCRIPTION
## Beskrivelse

Implementerer soft-delete av fullførte oppfølgingsplaner etter 6 måneder uten aktiv sykmeldingsperiode. Planer skjules via `skjult_fra`-kolonne og filtreres fra SM/AG-API-ene, mens veileder fortsatt ser alle planer.

## Endringer

- `V15__add_skjult_fra_column.sql`: Flyway-migrering — ny `skjult_fra TIMESTAMPTZ` kolonne + partial index for synlige oppfølgingsplan-oppslag
- `PersistedOppfolgingsplan.kt`: Ny `skjultFra: Instant?` property
- `OppfolgingsplanDAO.kt`: `inkluderSkjulte`-parameter for filtrering, `softDeleteExpiredOppfolgingsplaner()` med to SQL-statements i separate transaksjoner og navngitt retensjonsintervall
- `OppfolgingsplanService.kt`: Batch-loop for soft-delete med intern chunk-størrelse
- `VeilederOppfolgingsplanApiV1.kt`: Veileder passerer `inkluderSkjulte = true`
- `SoftDeleteOppfolgingsplanerTask.kt`: Ny daglig RecurringTask med leader election
- `OppfolginsplanAPiMetrics.kt`: Prometheus-metrikk `COUNT_OPPFOLGINGSPLAN_SOFT_DELETED`
- `ConfigureTasks.kt` / `DependencyInjection.kt`: Registrering av ny task
- Tester: 15+ scenarier inkl. SM/AG API-regresjonstester, grenseverdier og batch-loop

## Issue

Closes #270
Del av epic: #267

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

## Merknader

- Kryssmodell-inspeksjon: Opus 4.6 + GPT-5.5 — ingen blockers etter review-fikser
- `CREATE INDEX` uten `CONCURRENTLY` — akseptabelt for liten tabell
- Grensebetingelse: plan nøyaktig på 6 mnd soft-deletes IKKE (`>=`)
- `sykmeldingsperiode`-data er komplett lest inn før tasken aktiveres; fallback brukes for reelle tilfeller uten ikke-invalidert periode
