### PR TITLE
feat(foresporsel): legg til API for at sykmeldt kan be om oppfølgingsplan

### DIFF
--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -78,6 +78,8 @@ spec:
         - application: syfo-dokumentporten
         - application: syfooppdfgen
         - application: dinesykmeldte-backend
+        - application: isnarmesteleder
+          namespace: teamsykefravr
         - application: isdialogmelding
           namespace: teamsykefravr
         - application: istilgangskontroll
@@ -96,6 +98,10 @@ spec:
       value: production
     - name: DINE_SYKMELDTE_BASE_URL
       value: http://dinesykmeldte-backend
+    - name: ISNARMESTELEDER_BASE_URL
+      value: http://isnarmesteleder.teamsykefravr
+    - name: ISNARMESTELEDER_SCOPE
+      value: dev-gcp:teamsykefravr:isnarmesteleder
     - name: PDFGEN_BASE_URL
       value: http://syfooppdfgen
     - name: ISDIALOGMELDING_BASE_URL

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -74,6 +74,8 @@ spec:
         - application: syfo-dokumentporten
         - application: syfooppdfgen
         - application: dinesykmeldte-backend
+        - application: isnarmesteleder
+          namespace: teamsykefravr
         - application: isdialogmelding
           namespace: teamsykefravr
         - application: istilgangskontroll
@@ -92,6 +94,10 @@ spec:
       value: production
     - name: DINE_SYKMELDTE_BASE_URL
       value: http://dinesykmeldte-backend
+    - name: ISNARMESTELEDER_BASE_URL
+      value: http://isnarmesteleder.teamsykefravr
+    - name: ISNARMESTELEDER_SCOPE
+      value: prod-gcp:teamsykefravr:isnarmesteleder
     - name: PDFGEN_BASE_URL
       value: http://syfooppdfgen
     - name: ISDIALOGMELDING_BASE_URL

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -12,6 +12,7 @@ interface Environment {
     val texas: TexasEnvironment
     val valkeyEnvironment: ValkeyEnvironment
     val dineSykmeldteBaseUrl: String
+    val isnarmestelederBaseUrl: String
     val dokarkivBaseUrl: String
     val dokarkivScope: String
     val dokumentportenBaseUrl: String
@@ -46,6 +47,7 @@ data class NaisEnvironment(
         tokenExchangeEndpoint = getEnvVar("NAIS_TOKEN_EXCHANGE_ENDPOINT"),
         tokenEndpoint = getEnvVar("NAIS_TOKEN_ENDPOINT"),
         exchangeTargetDineSykmeldte = "${getEnvVar("NAIS_CLUSTER_NAME")}:team-esyfo:dinesykmeldte-backend",
+        exchangeTargetIsnarmesteleder = getEnvVar("ISNARMESTELEDER_SCOPE"),
         exchangeTargetIsDialogmelding = "${getEnvVar("NAIS_CLUSTER_NAME")}:teamsykefravr:isdialogmelding",
         exchangeTargetIsTilgangskontroll = "${getEnvVar("NAIS_CLUSTER_NAME")}.teamsykefravr.istilgangskontroll",
     ),
@@ -57,6 +59,7 @@ data class NaisEnvironment(
     ),
     override val pdfGenUrl: String = getEnvVar("PDFGEN_BASE_URL"),
     override val dineSykmeldteBaseUrl: String = getEnvVar("DINE_SYKMELDTE_BASE_URL"),
+    override val isnarmestelederBaseUrl: String = getEnvVar("ISNARMESTELEDER_BASE_URL"),
     override val dokarkivBaseUrl: String = getEnvVar("DOKARKIV_URL"),
     override val dokarkivScope: String = getEnvVar("DOKARKIV_SCOPE"),
     override val dokumentportenBaseUrl: String = getEnvVar("DOKUMENTPORTEN_URL"),
@@ -96,6 +99,7 @@ data class LocalEnvironment(
         tokenExchangeEndpoint = "http://localhost:3000/api/v1/token/exchange",
         tokenEndpoint = "http://localhost:3000/api/v1/token",
         exchangeTargetDineSykmeldte = "dev-gcp:team-esyfo:dinesykmeldte-backend",
+        exchangeTargetIsnarmesteleder = "dev-gcp:teamsykefravr:isnarmesteleder",
         exchangeTargetIsDialogmelding = "dev-gcp:teamsykefravr:isdialogmelding",
         exchangeTargetIsTilgangskontroll = "dev-gcp:teamsykefravr:istilgangskontroll",
     ),
@@ -107,6 +111,7 @@ data class LocalEnvironment(
         ssl = false,
     ),
     override val dineSykmeldteBaseUrl: String = "https://dinesykmeldte-backend.dev.intern.nav.no",
+    override val isnarmestelederBaseUrl: String = "http://isnarmesteleder.teamsykefravr",
     override val dokarkivScope: String = "dokarkiv",
     override val dokarkivBaseUrl: String = "https://isdialogmelding.intern.dev.nav.no",
     override val dokumentportenBaseUrl: String = "http://localhost:8090",

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -10,6 +10,7 @@ import no.nav.syfo.application.isProdEnv
 import no.nav.syfo.application.metric.registerMetricApi
 import no.nav.syfo.dinesykmeldte.DineSykmeldteService
 import no.nav.syfo.dokarkiv.DokarkivService
+import no.nav.syfo.foresporsel.ForesporselService
 import no.nav.syfo.isdialogmelding.IsDialogmeldingService
 import no.nav.syfo.istilgangskontroll.IsTilgangskontrollService
 import no.nav.syfo.oppfolgingsplan.api.v1.registerApiV1
@@ -31,6 +32,7 @@ fun Application.configureRouting() {
     val isDialogmeldingService by inject<IsDialogmeldingService>()
     val isTilgangskontrollService by inject<IsTilgangskontrollService>()
     val dokarkivService by inject<DokarkivService>()
+    val foresporselService by inject<ForesporselService>()
     val environment by inject<Environment>()
 
     installCallId()
@@ -53,6 +55,7 @@ fun Application.configureRouting() {
             isDialogmeldingService = isDialogmeldingService,
             isTilgangskontrollService = isTilgangskontrollService,
             dokarkivService = dokarkivService,
+            foresporselService = foresporselService,
             environment = environment,
         )
     }

--- a/src/main/kotlin/no/nav/syfo/foresporsel/ForesporselService.kt
+++ b/src/main/kotlin/no/nav/syfo/foresporsel/ForesporselService.kt
@@ -1,0 +1,159 @@
+package no.nav.syfo.foresporsel
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import no.nav.syfo.application.exception.ApiErrorException
+import no.nav.syfo.foresporsel.db.ForesporselOppfolgingsplanRepository
+import no.nav.syfo.foresporsel.domain.ForesporselStatus
+import no.nav.syfo.foresporsel.domain.SykmeldtArbeidsforhold
+import no.nav.syfo.isnarmesteleder.client.IIsnarmestelederClient
+import no.nav.syfo.isnarmesteleder.client.NarmesteLederRelasjonDTO
+import no.nav.syfo.oppfolgingsplan.db.domain.PersistedOppfolgingsplan
+import no.nav.syfo.sykmelding.db.FORESPORSEL_GRACE_PERIOD_DAYS
+import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
+import no.nav.syfo.util.logger
+import no.nav.syfo.varsel.EsyfovarselProducer
+import no.nav.syfo.varsel.domain.ArbeidstakerHendelse
+import no.nav.syfo.varsel.domain.HendelseType
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+private const val NARMESTELEDER_STATUS_INNMELDT_AKTIV = "INNMELDT_AKTIV"
+
+class ForesporselService(
+    private val sykmeldingsperiodeRepository: SykmeldingsperiodeRepository,
+    private val isnarmestelederClient: IIsnarmestelederClient,
+    private val foresporselOppfolgingsplanRepository: ForesporselOppfolgingsplanRepository,
+    private val esyfovarselProducer: EsyfovarselProducer,
+) {
+    private val logger = logger()
+
+    suspend fun getSykmeldteArbeidsforhold(
+        sykmeldtFnr: String,
+        userToken: String,
+        eksisterendePlaner: List<PersistedOppfolgingsplan>,
+    ): List<SykmeldtArbeidsforhold> {
+        val organisasjonsnumre = withContext(Dispatchers.IO) {
+            sykmeldingsperiodeRepository.findOrganisasjonerMedAktivSykmeldingsperiode(sykmeldtFnr)
+        }.sorted()
+
+        if (organisasjonsnumre.isEmpty()) {
+            return emptyList()
+        }
+
+        val organisasjonerMedAktivPlan = eksisterendePlaner
+            .map { it.organisasjonsnummer }
+            .toSet()
+
+        val foresporsler = withContext(Dispatchers.IO) {
+            foresporselOppfolgingsplanRepository.findForesporselForSykmeldt(sykmeldtFnr)
+        }
+        val gracePeriodCutoff = Instant.now().minus(FORESPORSEL_GRACE_PERIOD_DAYS, ChronoUnit.DAYS)
+
+        val aktiveNarmesteLederRelasjoner = try {
+            isnarmestelederClient.getNarmesteLederRelasjoner(userToken)
+                .filter { it.isActive() }
+                .associateBy { it.virksomhetsnummer }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn("Kunne ikke hente nærmeste leder-relasjoner, returnerer ukjent forespørselstatus", e)
+            null
+        }
+
+        return organisasjonsnumre.map { organisasjonsnummer ->
+            val narmesteLederRelasjon = aktiveNarmesteLederRelasjoner?.get(organisasjonsnummer)
+            val harAktivPlan = organisasjonsnummer in organisasjonerMedAktivPlan
+
+            val (status, tidspunkt) = bestemStatus(
+                harAktivPlan = harAktivPlan,
+                narmesteLederRelasjon = narmesteLederRelasjon,
+                nlTilgjengelig = aktiveNarmesteLederRelasjoner != null,
+                foresporsler = foresporsler,
+                gracePeriodCutoff = gracePeriodCutoff,
+            )
+
+            SykmeldtArbeidsforhold(
+                organisasjonsnummer = organisasjonsnummer,
+                organisasjonsnavn = narmesteLederRelasjon?.virksomhetsnavn,
+                narmesteLederNavn = narmesteLederRelasjon?.narmesteLederNavn,
+                foresporselStatus = status,
+                foresporselTidspunkt = tidspunkt,
+            )
+        }
+    }
+
+    private fun bestemStatus(
+        harAktivPlan: Boolean,
+        narmesteLederRelasjon: NarmesteLederRelasjonDTO?,
+        nlTilgjengelig: Boolean,
+        foresporsler: List<no.nav.syfo.foresporsel.domain.PersistedForesporsel>,
+        gracePeriodCutoff: Instant,
+    ): Pair<ForesporselStatus, Instant?> = when {
+        harAktivPlan -> ForesporselStatus.HAS_ACTIVE_PLAN to null
+
+        !nlTilgjengelig -> ForesporselStatus.NARMESTELEDER_UNKNOWN to null
+
+        narmesteLederRelasjon == null -> ForesporselStatus.MISSING_NARMESTELEDER to null
+
+        else -> {
+            val nyligForesporsel = foresporsler.firstOrNull {
+                it.narmesteLederFnr == narmesteLederRelasjon.narmesteLederPersonIdentNumber &&
+                    it.createdAt.isAfter(gracePeriodCutoff)
+            }
+            if (nyligForesporsel != null) {
+                ForesporselStatus.ALREADY_REQUESTED to nyligForesporsel.createdAt
+            } else {
+                ForesporselStatus.CAN_REQUEST to null
+            }
+        }
+    }
+
+    suspend fun beOmPlan(
+        sykmeldtFnr: String,
+        organisasjonsnummer: String,
+        userToken: String,
+    ) {
+        val aktiveOrganisasjoner = withContext(Dispatchers.IO) {
+            sykmeldingsperiodeRepository.findOrganisasjonerMedAktivSykmeldingsperiode(sykmeldtFnr)
+        }
+        if (organisasjonsnummer !in aktiveOrganisasjoner) {
+            throw ApiErrorException.BadRequest("Ingen aktiv sykmelding for virksomheten")
+        }
+
+        val narmesteLederRelasjon = isnarmestelederClient.getNarmesteLederRelasjoner(userToken)
+            .firstOrNull {
+                it.virksomhetsnummer == organisasjonsnummer && it.isActive()
+            }
+            ?: throw ApiErrorException.NotFound("Fant ingen aktiv nærmeste leder-relasjon for virksomheten")
+
+        val foresporselId = withContext(Dispatchers.IO) {
+            foresporselOppfolgingsplanRepository.storeIfNotRecentlyRequested(
+                sykmeldtFnr = sykmeldtFnr,
+                narmesteLederFnr = narmesteLederRelasjon.narmesteLederPersonIdentNumber,
+                organisasjonsnummer = organisasjonsnummer,
+            )
+        } ?: throw ApiErrorException.Conflict("Forespørsel om oppfølgingsplan er allerede sendt nylig")
+
+        try {
+            withContext(Dispatchers.IO) {
+                esyfovarselProducer.sendVarselToEsyfovarsel(
+                    ArbeidstakerHendelse(
+                        type = HendelseType.SM_OPPFOLGINGSPLAN_FORESPORSEL,
+                        ferdigstill = false,
+                        data = null,
+                        arbeidstakerFnr = sykmeldtFnr,
+                        orgnummer = organisasjonsnummer,
+                    ),
+                )
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.error("Kunne ikke sende Kafka-varsel for forespørsel $foresporselId (org $organisasjonsnummer)", e)
+        }
+    }
+}
+
+private fun NarmesteLederRelasjonDTO.isActive(): Boolean = status == NARMESTELEDER_STATUS_INNMELDT_AKTIV && aktivTom == null

--- a/src/main/kotlin/no/nav/syfo/foresporsel/db/ForesporselOppfolgingsplanRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/foresporsel/db/ForesporselOppfolgingsplanRepository.kt
@@ -1,0 +1,93 @@
+package no.nav.syfo.foresporsel.db
+
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.foresporsel.domain.PersistedForesporsel
+import no.nav.syfo.sykmelding.db.FORESPORSEL_GRACE_PERIOD_DAYS
+import java.sql.ResultSet
+import java.util.UUID
+
+class ForesporselOppfolgingsplanRepository(
+    private val database: DatabaseInterface,
+) {
+    fun storeIfNotRecentlyRequested(
+        sykmeldtFnr: String,
+        narmesteLederFnr: String,
+        organisasjonsnummer: String,
+    ): UUID? {
+        val statement = """
+            WITH advisory_lock AS (
+                SELECT pg_advisory_xact_lock(hashtext(?), hashtext(?))
+            )
+            INSERT INTO foresporsel_oppfolgingsplan (
+                sykmeldt_fnr,
+                narmeste_leder_fnr,
+                organisasjonsnummer
+            )
+            SELECT ?, ?, ?
+            FROM advisory_lock
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM foresporsel_oppfolgingsplan
+                WHERE sykmeldt_fnr = ?
+                  AND narmeste_leder_fnr = ?
+                  AND created_at > NOW() - (? * INTERVAL '1 day')
+            )
+            RETURNING id
+        """.trimIndent()
+
+        return database.connection.use { connection ->
+            connection.prepareStatement(statement).use { preparedStatement ->
+                preparedStatement.setString(1, sykmeldtFnr)
+                preparedStatement.setString(2, narmesteLederFnr)
+                preparedStatement.setString(3, sykmeldtFnr)
+                preparedStatement.setString(4, narmesteLederFnr)
+                preparedStatement.setString(5, organisasjonsnummer)
+                preparedStatement.setString(6, sykmeldtFnr)
+                preparedStatement.setString(7, narmesteLederFnr)
+                preparedStatement.setLong(8, FORESPORSEL_GRACE_PERIOD_DAYS)
+
+                preparedStatement.executeQuery().use { resultSet ->
+                    val insertedId = if (resultSet.next()) {
+                        resultSet.getObject("id", UUID::class.java)
+                    } else {
+                        null
+                    }
+                    connection.commit()
+                    insertedId
+                }
+            }
+        }
+    }
+
+    fun findForesporselForSykmeldt(
+        sykmeldtFnr: String,
+    ): List<PersistedForesporsel> {
+        val statement = """
+            SELECT id, sykmeldt_fnr, narmeste_leder_fnr, organisasjonsnummer, created_at
+            FROM foresporsel_oppfolgingsplan
+            WHERE sykmeldt_fnr = ?
+            ORDER BY created_at DESC
+        """.trimIndent()
+
+        return database.connection.use { connection ->
+            connection.prepareStatement(statement).use { preparedStatement ->
+                preparedStatement.setString(1, sykmeldtFnr)
+                preparedStatement.executeQuery().use { resultSet ->
+                    buildList {
+                        while (resultSet.next()) {
+                            add(resultSet.toPersistedForesporsel())
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun ResultSet.toPersistedForesporsel(): PersistedForesporsel = PersistedForesporsel(
+    id = getObject("id", UUID::class.java),
+    sykmeldtFnr = getString("sykmeldt_fnr"),
+    narmesteLederFnr = getString("narmeste_leder_fnr"),
+    organisasjonsnummer = getString("organisasjonsnummer"),
+    createdAt = getTimestamp("created_at").toInstant(),
+)

--- a/src/main/kotlin/no/nav/syfo/foresporsel/domain/ForesporselStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/foresporsel/domain/ForesporselStatus.kt
@@ -1,0 +1,9 @@
+package no.nav.syfo.foresporsel.domain
+
+enum class ForesporselStatus {
+    CAN_REQUEST,
+    ALREADY_REQUESTED,
+    HAS_ACTIVE_PLAN,
+    MISSING_NARMESTELEDER,
+    NARMESTELEDER_UNKNOWN,
+}

--- a/src/main/kotlin/no/nav/syfo/foresporsel/domain/PersistedForesporsel.kt
+++ b/src/main/kotlin/no/nav/syfo/foresporsel/domain/PersistedForesporsel.kt
@@ -1,0 +1,12 @@
+package no.nav.syfo.foresporsel.domain
+
+import java.time.Instant
+import java.util.UUID
+
+data class PersistedForesporsel(
+    val id: UUID,
+    val sykmeldtFnr: String,
+    val narmesteLederFnr: String,
+    val organisasjonsnummer: String,
+    val createdAt: Instant,
+)

--- a/src/main/kotlin/no/nav/syfo/foresporsel/domain/SykmeldtArbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/syfo/foresporsel/domain/SykmeldtArbeidsforhold.kt
@@ -1,0 +1,11 @@
+package no.nav.syfo.foresporsel.domain
+
+import java.time.Instant
+
+data class SykmeldtArbeidsforhold(
+    val organisasjonsnummer: String,
+    val organisasjonsnavn: String?,
+    val narmesteLederNavn: String?,
+    val foresporselStatus: ForesporselStatus,
+    val foresporselTidspunkt: Instant?,
+)

--- a/src/main/kotlin/no/nav/syfo/foresporsel/dto/BeOmPlanRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/foresporsel/dto/BeOmPlanRequest.kt
@@ -1,0 +1,5 @@
+package no.nav.syfo.foresporsel.dto
+
+data class BeOmPlanRequest(
+    val organisasjonsnummer: String,
+)

--- a/src/main/kotlin/no/nav/syfo/isnarmesteleder/client/IsnarmestelederClient.kt
+++ b/src/main/kotlin/no/nav/syfo/isnarmesteleder/client/IsnarmestelederClient.kt
@@ -1,0 +1,89 @@
+package no.nav.syfo.isnarmesteleder.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.ResponseException
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import no.nav.syfo.texas.client.TexasHttpClient
+import no.nav.syfo.util.logger
+import java.time.LocalDate
+
+fun interface IIsnarmestelederClient {
+    suspend fun getNarmesteLederRelasjoner(token: String): List<NarmesteLederRelasjonDTO>
+}
+
+class IsnarmestelederHttpClient(
+    private val httpClient: HttpClient,
+    private val texasHttpClient: TexasHttpClient,
+    private val isnarmestelederBaseUrl: String,
+) : IIsnarmestelederClient {
+    private val logger = logger()
+
+    override suspend fun getNarmesteLederRelasjoner(token: String): List<NarmesteLederRelasjonDTO> {
+        val exchangedToken = try {
+            texasHttpClient.exchangeTokenForIsnarmesteleder(token).accessToken
+        } catch (e: ResponseException) {
+            logger.error("Error while exchanging TokenX token for isnarmesteleder", e)
+            throw RuntimeException("Error while exchanging TokenX token for isnarmesteleder", e)
+        }
+
+        return try {
+            httpClient
+                .get("$isnarmestelederBaseUrl$NARMESTELEDER_RELASJONER_PATH") {
+                    header(HttpHeaders.Authorization, "Bearer $exchangedToken")
+                }
+                .body<List<NarmesteLederRelasjonDTO>>()
+        } catch (e: ResponseException) {
+            logger.error(
+                "Error fetching nærmeste leder-relasjoner from isnarmesteleder: ${e.response.bodyAsText()}",
+                e,
+            )
+            throw RuntimeException("Error while fetching nærmeste leder-relasjoner from isnarmesteleder", e)
+        }
+    }
+
+    companion object {
+        const val NARMESTELEDER_RELASJONER_PATH = "/api/selvbetjening/v1/narmestelederrelasjoner"
+    }
+}
+
+class FakeIsnarmestelederClient : IIsnarmestelederClient {
+    override suspend fun getNarmesteLederRelasjoner(token: String): List<NarmesteLederRelasjonDTO> = listOf(
+        NarmesteLederRelasjonDTO(
+            uuid = "11111111-1111-1111-1111-111111111111",
+            virksomhetsnummer = "999888777",
+            virksomhetsnavn = "Testbedrift AS",
+            narmesteLederPersonIdentNumber = "12345678910",
+            narmesteLederNavn = "Test Testesen",
+            status = "INNMELDT_AKTIV",
+            aktivFom = LocalDate.now().minusMonths(6),
+            aktivTom = null,
+        ),
+        NarmesteLederRelasjonDTO(
+            uuid = "22222222-2222-2222-2222-222222222222",
+            virksomhetsnummer = "888777666",
+            virksomhetsnavn = "Eksempelbedrift AS",
+            narmesteLederPersonIdentNumber = "01987654321",
+            narmesteLederNavn = "Leder Ledersen",
+            status = "DEAKTIVERT",
+            aktivFom = LocalDate.now().minusYears(1),
+            aktivTom = LocalDate.now().minusMonths(1),
+        ),
+    )
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class NarmesteLederRelasjonDTO(
+    val uuid: String,
+    val virksomhetsnummer: String,
+    val virksomhetsnavn: String?,
+    val narmesteLederPersonIdentNumber: String,
+    val narmesteLederNavn: String?,
+    val status: String,
+    val aktivFom: LocalDate,
+    val aktivTom: LocalDate?,
+)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/ApiV1.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/ApiV1.kt
@@ -6,6 +6,7 @@ import no.nav.syfo.application.Environment
 import no.nav.syfo.application.auth.ClientAuthorizationPlugin
 import no.nav.syfo.dinesykmeldte.DineSykmeldteService
 import no.nav.syfo.dokarkiv.DokarkivService
+import no.nav.syfo.foresporsel.ForesporselService
 import no.nav.syfo.isdialogmelding.IsDialogmeldingService
 import no.nav.syfo.istilgangskontroll.IsTilgangskontrollService
 import no.nav.syfo.oppfolgingsplan.api.v1.arbeidsgiver.registerArbeidsgiverOppfolgingsplanApiV1
@@ -27,6 +28,7 @@ fun Route.registerApiV1(
     isDialogmeldingService: IsDialogmeldingService,
     isTilgangskontrollService: IsTilgangskontrollService,
     dokarkivService: DokarkivService,
+    foresporselService: ForesporselService,
     environment: Environment,
 ) {
     route("/api/v1/arbeidsgiver") {
@@ -61,6 +63,7 @@ fun Route.registerApiV1(
             texasHttpClient,
             oppfolgingsplanService,
             pdfGenService,
+            foresporselService,
         )
     }
     route("/api/v1/veileder") {

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/SykmeldtOppfolgingsplanApiV1.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/SykmeldtOppfolgingsplanApiV1.kt
@@ -2,11 +2,15 @@ package no.nav.syfo.oppfolgingsplan.api.v1.sykmeldt
 
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.syfo.application.exception.ApiErrorException
+import no.nav.syfo.foresporsel.ForesporselService
+import no.nav.syfo.foresporsel.dto.BeOmPlanRequest
 import no.nav.syfo.oppfolgingsplan.api.v1.extractAndValidateUUIDParameter
 import no.nav.syfo.oppfolgingsplan.db.domain.PersistedOppfolgingsplan
 import no.nav.syfo.oppfolgingsplan.db.domain.toResponse
@@ -14,14 +18,18 @@ import no.nav.syfo.oppfolgingsplan.db.domain.toSykmeldtOppfolgingsplanOverviewRe
 import no.nav.syfo.oppfolgingsplan.domain.Fodselsnummer
 import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
 import no.nav.syfo.pdfgen.PdfGenService
+import no.nav.syfo.texas.bearerToken
 import no.nav.syfo.texas.client.TexasHttpClient
 import no.nav.syfo.util.logger
 import java.util.UUID
+
+private val NINE_DIGIT_ORG_NUMBER = Regex("^\\d{9}$")
 
 fun Route.registerSykmeldtOppfolgingsplanApiV1(
     texasHttpClient: TexasHttpClient,
     oppfolgingsplanService: OppfolgingsplanService,
     pdfGenService: PdfGenService,
+    foresporselService: ForesporselService,
 ) {
     val logger = logger()
 
@@ -50,12 +58,43 @@ fun Route.registerSykmeldtOppfolgingsplanApiV1(
          */
         get("/oversikt") {
             val brukerFnr = call.attributes[CALL_ATTRIBUTE_SYKMELDT_BRUKER_FODSELSNUMMER]
-            val oppfolgingsplaner =
-                oppfolgingsplanService
-                    .getPersistedOppfolgingsplanListBy(brukerFnr.value)
-                    .toSykmeldtOppfolgingsplanOverviewResponse()
+            val userToken = call.bearerToken()
+                ?: throw ApiErrorException.Unauthorized("Missing bearer token")
+            val persistedPlaner = oppfolgingsplanService.getPersistedOppfolgingsplanListBy(brukerFnr.value)
+            val oppfolgingsplaner = persistedPlaner.toSykmeldtOppfolgingsplanOverviewResponse()
+            val sykmeldteArbeidsforhold = foresporselService.getSykmeldteArbeidsforhold(
+                sykmeldtFnr = brukerFnr.value,
+                userToken = userToken,
+                eksisterendePlaner = persistedPlaner,
+            )
 
-            call.respond(HttpStatusCode.OK, oppfolgingsplaner)
+            call.respond(
+                HttpStatusCode.OK,
+                oppfolgingsplaner.copy(sykmeldteArbeidsforhold = sykmeldteArbeidsforhold),
+            )
+        }
+
+        post("/be-om-plan") {
+            val brukerFnr = call.attributes[CALL_ATTRIBUTE_SYKMELDT_BRUKER_FODSELSNUMMER]
+            val userToken = call.bearerToken()
+                ?: throw ApiErrorException.Unauthorized("Missing bearer token")
+            val request = try {
+                call.receive<BeOmPlanRequest>()
+            } catch (e: Exception) {
+                throw ApiErrorException.BadRequest("Invalid request body: ${e.message}", e)
+            }
+
+            if (!request.organisasjonsnummer.matches(NINE_DIGIT_ORG_NUMBER)) {
+                throw ApiErrorException.BadRequest("organisasjonsnummer must be 9 digits")
+            }
+
+            foresporselService.beOmPlan(
+                sykmeldtFnr = brukerFnr.value,
+                organisasjonsnummer = request.organisasjonsnummer,
+                userToken = userToken,
+            )
+
+            call.respond(HttpStatusCode.Created)
         }
 
         /**

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/ArbeidsgiverOppfolgingsplanOverviewResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/ArbeidsgiverOppfolgingsplanOverviewResponse.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.oppfolgingsplan.dto
 
+import no.nav.syfo.foresporsel.domain.SykmeldtArbeidsforhold
 import no.nav.syfo.oppfolgingsplan.domain.EmployeeDetails
 import no.nav.syfo.oppfolgingsplan.domain.OrganizationDetails
 import java.math.BigDecimal
@@ -39,4 +40,5 @@ data class ArbeidsgiverOppfolgingsplanOverviewResponse(
 data class SykmeldtOppfolgingsplanOverviewResponse(
     val aktiveOppfolgingsplaner: List<OppfolgingsplanMetadata>,
     val tidligerePlaner: List<OppfolgingsplanMetadata>,
+    val sykmeldteArbeidsforhold: List<SykmeldtArbeidsforhold> = emptyList(),
 )

--- a/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
@@ -28,9 +28,14 @@ import no.nav.syfo.dokumentporten.SendOppfolgingsplanTask
 import no.nav.syfo.dokumentporten.client.DokumentportenClient
 import no.nav.syfo.dokumentporten.client.FakeDokumentportenClient
 import no.nav.syfo.dokumentporten.client.IDokumentportenClient
+import no.nav.syfo.foresporsel.ForesporselService
+import no.nav.syfo.foresporsel.db.ForesporselOppfolgingsplanRepository
 import no.nav.syfo.isdialogmelding.IsDialogmeldingService
 import no.nav.syfo.isdialogmelding.client.FakeIsDialogmeldingClient
 import no.nav.syfo.isdialogmelding.client.IsDialogmeldingClient
+import no.nav.syfo.isnarmesteleder.client.FakeIsnarmestelederClient
+import no.nav.syfo.isnarmesteleder.client.IIsnarmestelederClient
+import no.nav.syfo.isnarmesteleder.client.IsnarmestelederHttpClient
 import no.nav.syfo.istilgangskontroll.IsTilgangskontrollService
 import no.nav.syfo.istilgangskontroll.client.FakeIsTilgangskontrollClient
 import no.nav.syfo.istilgangskontroll.client.IsTilgangskontrollClient
@@ -141,6 +146,17 @@ private fun clientsModule() = module {
             )
         }
     }
+    single<IIsnarmestelederClient> {
+        if (isLocalEnv()) {
+            FakeIsnarmestelederClient()
+        } else {
+            IsnarmestelederHttpClient(
+                httpClient = get(),
+                texasHttpClient = get(),
+                isnarmestelederBaseUrl = env().isnarmestelederBaseUrl,
+            )
+        }
+    }
     single {
         if (isLocalEnv()) {
             FakeDokumentportenClient()
@@ -206,6 +222,8 @@ private fun servicesModule() = module {
     single { PdfGenService(get(), get()) }
     single { SendOppfolgingsplanTask(get(), get()) }
     single { CleanupUtkastTask(get(), get()) }
+    single { ForesporselOppfolgingsplanRepository(get()) }
+    single { ForesporselService(get(), get(), get(), get()) }
     single { SykmeldingsperiodeRepository(get()) }
     single { SykmeldingsperiodeConsumer(get(), env().kafka) }
 }

--- a/src/main/kotlin/no/nav/syfo/sykmelding/db/SykmeldingsperiodeRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/db/SykmeldingsperiodeRepository.kt
@@ -8,6 +8,8 @@ import java.sql.ResultSet
 import java.sql.Statement
 import java.util.UUID
 
+const val FORESPORSEL_GRACE_PERIOD_DAYS = 16L
+
 class SykmeldingsperiodeRepository(
     private val database: DatabaseInterface,
 ) {
@@ -86,6 +88,33 @@ class SykmeldingsperiodeRepository(
                     buildList {
                         while (resultSet.next()) {
                             add(resultSet.toPersistedSykmeldingsperiode())
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fun findOrganisasjonerMedAktivSykmeldingsperiode(
+        sykmeldtFnr: String,
+    ): List<String> {
+        val statement = """
+            SELECT DISTINCT organisasjonsnummer
+            FROM sykmeldingsperiode
+            WHERE sykmeldt_fnr = ?
+              AND fom <= CURRENT_DATE
+              AND tom + (? * INTERVAL '1 day') >= CURRENT_DATE
+              AND invalidated_at IS NULL
+        """.trimIndent()
+
+        return database.connection.use { connection ->
+            connection.prepareStatement(statement).use { preparedStatement ->
+                preparedStatement.setString(1, sykmeldtFnr)
+                preparedStatement.setLong(2, FORESPORSEL_GRACE_PERIOD_DAYS)
+                preparedStatement.executeQuery().use { resultSet ->
+                    buildList {
+                        while (resultSet.next()) {
+                            add(resultSet.getString("organisasjonsnummer"))
                         }
                     }
                 }

--- a/src/main/kotlin/no/nav/syfo/texas/TexasEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/texas/TexasEnvironment.kt
@@ -5,6 +5,7 @@ data class TexasEnvironment(
     val tokenEndpoint: String,
     val tokenExchangeEndpoint: String,
     val exchangeTargetDineSykmeldte: String,
+    val exchangeTargetIsnarmesteleder: String,
     val exchangeTargetIsDialogmelding: String,
     val exchangeTargetIsTilgangskontroll: String,
 )

--- a/src/main/kotlin/no/nav/syfo/texas/client/TexasHttpClient.kt
+++ b/src/main/kotlin/no/nav/syfo/texas/client/TexasHttpClient.kt
@@ -25,6 +25,8 @@ class TexasHttpClient(
 
     suspend fun exchangeTokenForDineSykmeldte(token: String): TexasResponse = exchangeToken(IDENTITY_PROVIDER_TOKENX, environment.exchangeTargetDineSykmeldte, token)
 
+    suspend fun exchangeTokenForIsnarmesteleder(token: String): TexasResponse = exchangeToken(IDENTITY_PROVIDER_TOKENX, environment.exchangeTargetIsnarmesteleder, token)
+
     suspend fun exchangeTokenForIsDialogmelding(token: String): TexasResponse = exchangeToken(IDENTITY_PROVIDER_TOKENX, environment.exchangeTargetIsDialogmelding, token)
 
     suspend fun exchangeTokenForIsTilgangskontroll(token: String): TexasResponse = exchangeToken(

--- a/src/main/kotlin/no/nav/syfo/varsel/domain/EsyfoVarselDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/domain/EsyfoVarselDTO.kt
@@ -20,4 +20,5 @@ data class ArbeidstakerHendelse(
 
 enum class HendelseType {
     SM_OPPFOLGINGSPLAN_OPPRETTET,
+    SM_OPPFOLGINGSPLAN_FORESPORSEL,
 }

--- a/src/main/resources/db/migration/V15__create_foresporsel_oppfolgingsplan_table.sql
+++ b/src/main/resources/db/migration/V15__create_foresporsel_oppfolgingsplan_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE foresporsel_oppfolgingsplan
+(
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    sykmeldt_fnr        VARCHAR(11)                NOT NULL,
+    narmeste_leder_fnr  VARCHAR(11)                NOT NULL,
+    organisasjonsnummer VARCHAR(9)                 NOT NULL,
+    created_at          TIMESTAMPTZ      DEFAULT NOW() NOT NULL
+);
+
+CREATE INDEX idx_foresporsel_sykmeldt_nl
+    ON foresporsel_oppfolgingsplan (sykmeldt_fnr, narmeste_leder_fnr);
+
+GRANT SELECT ON foresporsel_oppfolgingsplan TO "esyfo-analyse";

--- a/src/main/resources/openapi/sykmeldt.yaml
+++ b/src/main/resources/openapi/sykmeldt.yaml
@@ -49,6 +49,38 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/v1/sykmeldt/oppfolgingsplaner/be-om-plan:
+    post:
+      tags:
+        - Oppfølgingsplan
+      summary: Be om oppfølgingsplan fra arbeidsgiver
+      description: |
+        Oppretter en forespørsel om oppfølgingsplan for innlogget sykmeldt og valgt virksomhet.
+      operationId: postBeOmOppfolgingsplan
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BeOmPlanRequest'
+      responses:
+        '201':
+          description: Forespørsel opprettet
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NarmesteLederNotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /api/v1/sykmeldt/oppfolgingsplaner/{uuid}:
     get:
       tags:
@@ -184,6 +216,32 @@ components:
             timestamp: "2025-11-28T12:00:00Z"
             path: "/api/v1/sykmeldt/oppfolgingsplaner/987fcdeb-51a2-3bc4-d567-890123456789"
 
+    NarmesteLederNotFound:
+      description: Fant ingen aktiv nærmeste leder-relasjon for virksomheten
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiError'
+          example:
+            status: 404
+            type: NOT_FOUND
+            message: "Fant ingen aktiv nærmeste leder-relasjon for virksomheten"
+            timestamp: "2025-11-28T12:00:00Z"
+            path: "/api/v1/sykmeldt/oppfolgingsplaner/be-om-plan"
+
+    Conflict:
+      description: Forespørselen kan ikke opprettes akkurat nå
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiError'
+          example:
+            status: 409
+            type: CONFLICT
+            message: "Forespørsel om oppfølgingsplan er allerede sendt nylig"
+            timestamp: "2025-11-28T12:00:00Z"
+            path: "/api/v1/sykmeldt/oppfolgingsplaner/be-om-plan"
+
     InternalServerError:
       description: Intern serverfeil
       content:
@@ -241,6 +299,7 @@ components:
       required:
         - aktiveOppfolgingsplaner
         - tidligerePlaner
+        - sykmeldteArbeidsforhold
       properties:
         aktiveOppfolgingsplaner:
           type: array
@@ -252,6 +311,53 @@ components:
           description: Oppfølgingsplaner med evalueringsdato < i dag
           items:
             $ref: '#/components/schemas/OppfolgingsplanMetadata'
+        sykmeldteArbeidsforhold:
+          type: array
+          items:
+            $ref: '#/components/schemas/SykmeldtArbeidsforhold'
+
+    BeOmPlanRequest:
+      type: object
+      required:
+        - organisasjonsnummer
+      properties:
+        organisasjonsnummer:
+          type: string
+          pattern: '^\d{9}$'
+          example: "999888777"
+
+    SykmeldtArbeidsforhold:
+      type: object
+      required:
+        - organisasjonsnummer
+        - foresporselStatus
+      properties:
+        organisasjonsnummer:
+          type: string
+          example: "999888777"
+        organisasjonsnavn:
+          type: string
+          nullable: true
+          example: "Plan AS"
+        narmesteLederNavn:
+          type: string
+          nullable: true
+          example: "Plan Leder"
+        foresporselStatus:
+          $ref: '#/components/schemas/ForesporselStatus'
+        foresporselTidspunkt:
+          type: string
+          format: date-time
+          nullable: true
+
+    ForesporselStatus:
+      type: string
+      enum:
+        - CAN_REQUEST
+        - ALREADY_REQUESTED
+        - HAS_ACTIVE_PLAN
+        - MISSING_NARMESTELEDER
+        - NARMESTELEDER_UNKNOWN
 
     OppfolgingsplanResponse:
       type: object

--- a/src/test/kotlin/no/nav/syfo/TestDb.kt
+++ b/src/test/kotlin/no/nav/syfo/TestDb.kt
@@ -91,6 +91,7 @@ class TestDB private constructor() {
             it
                 .prepareStatement(
                     """
+                    DELETE FROM foresporsel_oppfolgingsplan;
                     DELETE FROM sykmeldingsperiode;
                     DELETE FROM oppfolgingsplan_utkast;
                     DELETE FROM oppfolgingsplan;

--- a/src/test/kotlin/no/nav/syfo/foresporsel/ForesporselServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/foresporsel/ForesporselServiceTest.kt
@@ -1,0 +1,397 @@
+package no.nav.syfo.foresporsel
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.CancellationException
+import no.nav.syfo.TestDB
+import no.nav.syfo.defaultPersistedOppfolgingsplan
+import no.nav.syfo.foresporsel.db.ForesporselOppfolgingsplanRepository
+import no.nav.syfo.foresporsel.domain.ForesporselStatus
+import no.nav.syfo.isnarmesteleder.client.IIsnarmestelederClient
+import no.nav.syfo.isnarmesteleder.client.NarmesteLederRelasjonDTO
+import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
+import no.nav.syfo.sykmelding.db.domain.SykmeldingsperiodeToStore
+import no.nav.syfo.varsel.EsyfovarselProducer
+import no.nav.syfo.varsel.domain.ArbeidstakerHendelse
+import no.nav.syfo.varsel.domain.EsyfovarselHendelse
+import no.nav.syfo.varsel.domain.HendelseType
+import java.sql.Timestamp
+import java.time.Instant
+import java.time.LocalDate
+
+class ForesporselServiceTest :
+    DescribeSpec({
+        val sykmeldingsperiodeRepository = SykmeldingsperiodeRepository(TestDB.database)
+        val foresporselRepository = ForesporselOppfolgingsplanRepository(TestDB.database)
+        val isnarmestelederClient = mockk<IIsnarmestelederClient>()
+        val esyfovarselProducer = mockk<EsyfovarselProducer>(relaxed = true)
+        val service = ForesporselService(
+            sykmeldingsperiodeRepository = sykmeldingsperiodeRepository,
+            isnarmestelederClient = isnarmestelederClient,
+            foresporselOppfolgingsplanRepository = foresporselRepository,
+            esyfovarselProducer = esyfovarselProducer,
+        )
+
+        beforeEach {
+            TestDB.clearAllData()
+            clearAllMocks()
+        }
+
+        describe("getSykmeldteArbeidsforhold") {
+            it("beregner status per arbeidsforhold med riktig prioritet") {
+                val sykmeldtFnr = "12345678901"
+                val requestedAt = Instant.now().minusSeconds(60)
+                storeAktiveSykmeldinger(
+                    sykmeldingsperiodeRepository = sykmeldingsperiodeRepository,
+                    sykmeldtFnr = sykmeldtFnr,
+                    organisasjonsnumre = listOf(
+                        "111111111",
+                        "222222222",
+                        "333333333",
+                        "444444444",
+                        "555555555",
+                    ),
+                )
+                coEvery { isnarmestelederClient.getNarmesteLederRelasjoner("user-token") } returns listOf(
+                    activeRelasjon(
+                        virksomhetsnummer = "111111111",
+                        virksomhetsnavn = "Plan AS",
+                        narmesteLederFnr = "10101010101",
+                        narmesteLederNavn = "Plan Leder",
+                    ),
+                    activeRelasjon(
+                        virksomhetsnummer = "333333333",
+                        virksomhetsnavn = "Varsel AS",
+                        narmesteLederFnr = "30303030303",
+                        narmesteLederNavn = "Varsel Leder",
+                    ),
+                    activeRelasjon(
+                        virksomhetsnummer = "444444444",
+                        virksomhetsnavn = "Klar AS",
+                        narmesteLederFnr = "40404040404",
+                        narmesteLederNavn = "Klar Leder",
+                    ),
+                )
+                val eksisterendePlaner = listOf(
+                    defaultPersistedOppfolgingsplan().copy(
+                        sykmeldtFnr = sykmeldtFnr,
+                        organisasjonsnummer = "111111111",
+                    ),
+                    defaultPersistedOppfolgingsplan().copy(
+                        sykmeldtFnr = sykmeldtFnr,
+                        organisasjonsnummer = "555555555",
+                    ),
+                )
+                foresporselRepository.storeIfNotRecentlyRequested(
+                    sykmeldtFnr = sykmeldtFnr,
+                    narmesteLederFnr = "30303030303",
+                    organisasjonsnummer = "333333333",
+                )
+                setCreatedAtForForesporsler(
+                    sykmeldtFnr = sykmeldtFnr,
+                    createdAt = requestedAt,
+                )
+
+                val result = service.getSykmeldteArbeidsforhold(
+                    sykmeldtFnr = sykmeldtFnr,
+                    userToken = "user-token",
+                    eksisterendePlaner = eksisterendePlaner,
+                )
+
+                result.shouldHaveSize(5)
+                result[0].organisasjonsnummer shouldBe "111111111"
+                result[0].foresporselStatus shouldBe ForesporselStatus.HAS_ACTIVE_PLAN
+                result[0].organisasjonsnavn shouldBe "Plan AS"
+                result[0].narmesteLederNavn shouldBe "Plan Leder"
+
+                result[1].organisasjonsnummer shouldBe "222222222"
+                result[1].foresporselStatus shouldBe ForesporselStatus.MISSING_NARMESTELEDER
+                result[1].organisasjonsnavn shouldBe null
+
+                result[2].organisasjonsnummer shouldBe "333333333"
+                result[2].foresporselStatus shouldBe ForesporselStatus.ALREADY_REQUESTED
+                result[2].organisasjonsnavn shouldBe "Varsel AS"
+                result[2].narmesteLederNavn shouldBe "Varsel Leder"
+                result[2].foresporselTidspunkt shouldBe requestedAt
+
+                result[3].organisasjonsnummer shouldBe "444444444"
+                result[3].foresporselStatus shouldBe ForesporselStatus.CAN_REQUEST
+                result[3].organisasjonsnavn shouldBe "Klar AS"
+                result[3].narmesteLederNavn shouldBe "Klar Leder"
+
+                result[4].organisasjonsnummer shouldBe "555555555"
+                result[4].foresporselStatus shouldBe ForesporselStatus.HAS_ACTIVE_PLAN
+                result[4].organisasjonsnavn shouldBe null
+            }
+
+            it("returnerer CAN_REQUEST når tidligere forespørsel var til gammel nærmeste leder") {
+                val sykmeldtFnr = "12345678901"
+                storeAktiveSykmeldinger(
+                    sykmeldingsperiodeRepository = sykmeldingsperiodeRepository,
+                    sykmeldtFnr = sykmeldtFnr,
+                    organisasjonsnumre = listOf("111111111"),
+                )
+                coEvery { isnarmestelederClient.getNarmesteLederRelasjoner("user-token") } returns listOf(
+                    activeRelasjon(
+                        virksomhetsnummer = "111111111",
+                        virksomhetsnavn = "Ny Leder AS",
+                        narmesteLederFnr = "10101010101",
+                        narmesteLederNavn = "Ny Leder",
+                    ),
+                )
+                foresporselRepository.storeIfNotRecentlyRequested(
+                    sykmeldtFnr = sykmeldtFnr,
+                    narmesteLederFnr = "20202020202",
+                    organisasjonsnummer = "111111111",
+                )
+
+                val result = service.getSykmeldteArbeidsforhold(
+                    sykmeldtFnr = sykmeldtFnr,
+                    userToken = "user-token",
+                    eksisterendePlaner = emptyList(),
+                )
+
+                result shouldBe listOf(
+                    no.nav.syfo.foresporsel.domain.SykmeldtArbeidsforhold(
+                        organisasjonsnummer = "111111111",
+                        organisasjonsnavn = "Ny Leder AS",
+                        narmesteLederNavn = "Ny Leder",
+                        foresporselStatus = ForesporselStatus.CAN_REQUEST,
+                        foresporselTidspunkt = null,
+                    ),
+                )
+            }
+
+            it("returnerer ukjent status når isnarmesteleder er utilgjengelig") {
+                val sykmeldtFnr = "12345678901"
+                storeAktiveSykmeldinger(
+                    sykmeldingsperiodeRepository = sykmeldingsperiodeRepository,
+                    sykmeldtFnr = sykmeldtFnr,
+                    organisasjonsnumre = listOf("111111111", "222222222"),
+                )
+                coEvery {
+                    isnarmestelederClient.getNarmesteLederRelasjoner("user-token")
+                } throws RuntimeException("boom")
+
+                val result = service.getSykmeldteArbeidsforhold(
+                    sykmeldtFnr = sykmeldtFnr,
+                    userToken = "user-token",
+                    eksisterendePlaner = emptyList(),
+                )
+
+                result shouldBe listOf(
+                    arbeidsforhold("111111111", ForesporselStatus.NARMESTELEDER_UNKNOWN),
+                    arbeidsforhold("222222222", ForesporselStatus.NARMESTELEDER_UNKNOWN),
+                )
+            }
+
+            it("rethrowser CancellationException fra isnarmesteleder") {
+                storeAktiveSykmeldinger(
+                    sykmeldingsperiodeRepository = sykmeldingsperiodeRepository,
+                    sykmeldtFnr = "12345678901",
+                    organisasjonsnumre = listOf("111111111"),
+                )
+                coEvery {
+                    isnarmestelederClient.getNarmesteLederRelasjoner("user-token")
+                } throws CancellationException("cancelled")
+
+                shouldThrow<CancellationException> {
+                    service.getSykmeldteArbeidsforhold(
+                        sykmeldtFnr = "12345678901",
+                        userToken = "user-token",
+                        eksisterendePlaner = emptyList(),
+                    )
+                }
+            }
+        }
+
+        describe("beOmPlan") {
+            it("lagrer forespørsel og publiserer kafka-event") {
+                val sykmeldtFnr = "12345678901"
+                val hendelseSlot = slot<EsyfovarselHendelse>()
+                storeAktiveSykmeldinger(
+                    sykmeldingsperiodeRepository = sykmeldingsperiodeRepository,
+                    sykmeldtFnr = sykmeldtFnr,
+                    organisasjonsnumre = listOf("111111111"),
+                )
+                coEvery { isnarmestelederClient.getNarmesteLederRelasjoner("user-token") } returns listOf(
+                    activeRelasjon(
+                        virksomhetsnummer = "111111111",
+                        virksomhetsnavn = "Plan AS",
+                        narmesteLederFnr = "10101010101",
+                        narmesteLederNavn = "Plan Leder",
+                    ),
+                )
+                every { esyfovarselProducer.sendVarselToEsyfovarsel(capture(hendelseSlot)) } returns Unit
+
+                service.beOmPlan(
+                    sykmeldtFnr = sykmeldtFnr,
+                    organisasjonsnummer = "111111111",
+                    userToken = "user-token",
+                )
+
+                val persisted = foresporselRepository.findForesporselForSykmeldt(sykmeldtFnr)
+                persisted.shouldHaveSize(1)
+                persisted.single().narmesteLederFnr shouldBe "10101010101"
+                persisted.single().organisasjonsnummer shouldBe "111111111"
+
+                val hendelse = hendelseSlot.captured as ArbeidstakerHendelse
+                hendelse.type shouldBe HendelseType.SM_OPPFOLGINGSPLAN_FORESPORSEL
+                hendelse.arbeidstakerFnr shouldBe sykmeldtFnr
+                hendelse.orgnummer shouldBe "111111111"
+                hendelse.ferdigstill shouldBe false
+            }
+
+            it("kaster bad request når ingen aktiv sykmelding for virksomheten") {
+                val sykmeldtFnr = "12345678901"
+
+                val exception = shouldThrow<no.nav.syfo.application.exception.ApiErrorException.BadRequest> {
+                    service.beOmPlan(
+                        sykmeldtFnr = sykmeldtFnr,
+                        organisasjonsnummer = "111111111",
+                        userToken = "user-token",
+                    )
+                }
+
+                exception.errorMessage shouldBe "Ingen aktiv sykmelding for virksomheten"
+                verify(exactly = 0) { esyfovarselProducer.sendVarselToEsyfovarsel(any()) }
+            }
+
+            it("kaster conflict når forespørsel nylig er sendt") {
+                val sykmeldtFnr = "12345678901"
+                storeAktiveSykmeldinger(
+                    sykmeldingsperiodeRepository = sykmeldingsperiodeRepository,
+                    sykmeldtFnr = sykmeldtFnr,
+                    organisasjonsnumre = listOf("111111111"),
+                )
+                coEvery { isnarmestelederClient.getNarmesteLederRelasjoner("user-token") } returns listOf(
+                    activeRelasjon(
+                        virksomhetsnummer = "111111111",
+                        virksomhetsnavn = "Plan AS",
+                        narmesteLederFnr = "10101010101",
+                        narmesteLederNavn = "Plan Leder",
+                    ),
+                )
+                foresporselRepository.storeIfNotRecentlyRequested(
+                    sykmeldtFnr = sykmeldtFnr,
+                    narmesteLederFnr = "10101010101",
+                    organisasjonsnummer = "111111111",
+                )
+
+                val exception = shouldThrow<no.nav.syfo.application.exception.ApiErrorException.Conflict> {
+                    service.beOmPlan(
+                        sykmeldtFnr = sykmeldtFnr,
+                        organisasjonsnummer = "111111111",
+                        userToken = "user-token",
+                    )
+                }
+
+                exception.errorMessage shouldBe "Forespørsel om oppfølgingsplan er allerede sendt nylig"
+                verify(exactly = 0) { esyfovarselProducer.sendVarselToEsyfovarsel(any()) }
+            }
+
+            it("kaster not found når aktiv nærmeste leder-relasjon mangler") {
+                val sykmeldtFnr = "12345678901"
+                storeAktiveSykmeldinger(
+                    sykmeldingsperiodeRepository = sykmeldingsperiodeRepository,
+                    sykmeldtFnr = sykmeldtFnr,
+                    organisasjonsnumre = listOf("111111111"),
+                )
+                coEvery { isnarmestelederClient.getNarmesteLederRelasjoner("user-token") } returns listOf(
+                    activeRelasjon(
+                        virksomhetsnummer = "222222222",
+                        virksomhetsnavn = "Annen AS",
+                        narmesteLederFnr = "20202020202",
+                        narmesteLederNavn = "Annen Leder",
+                        aktivTom = LocalDate.now(),
+                    ),
+                )
+
+                val exception = shouldThrow<no.nav.syfo.application.exception.ApiErrorException.NotFound> {
+                    service.beOmPlan(
+                        sykmeldtFnr = sykmeldtFnr,
+                        organisasjonsnummer = "111111111",
+                        userToken = "user-token",
+                    )
+                }
+
+                exception.errorMessage shouldBe "Fant ingen aktiv nærmeste leder-relasjon for virksomheten"
+                verify(exactly = 0) { esyfovarselProducer.sendVarselToEsyfovarsel(any()) }
+            }
+        }
+    })
+
+private fun storeAktiveSykmeldinger(
+    sykmeldingsperiodeRepository: SykmeldingsperiodeRepository,
+    sykmeldtFnr: String,
+    organisasjonsnumre: List<String>,
+) {
+    val today = LocalDate.now()
+    sykmeldingsperiodeRepository.storeSykmeldingsperioder(
+        organisasjonsnumre.mapIndexed { index, organisasjonsnummer ->
+            SykmeldingsperiodeToStore(
+                sykmeldtFnr = sykmeldtFnr,
+                organisasjonsnummer = organisasjonsnummer,
+                sykmeldingId = "sykmelding-$index",
+                fom = today.minusDays(10),
+                tom = today.plusDays(5),
+            )
+        },
+    )
+}
+
+private fun activeRelasjon(
+    virksomhetsnummer: String,
+    virksomhetsnavn: String,
+    narmesteLederFnr: String,
+    narmesteLederNavn: String,
+    aktivTom: LocalDate? = null,
+) = NarmesteLederRelasjonDTO(
+    uuid = virksomhetsnummer,
+    virksomhetsnummer = virksomhetsnummer,
+    virksomhetsnavn = virksomhetsnavn,
+    narmesteLederPersonIdentNumber = narmesteLederFnr,
+    narmesteLederNavn = narmesteLederNavn,
+    status = "INNMELDT_AKTIV",
+    aktivFom = LocalDate.now().minusDays(30),
+    aktivTom = aktivTom,
+)
+
+private fun arbeidsforhold(
+    organisasjonsnummer: String,
+    status: ForesporselStatus,
+) = no.nav.syfo.foresporsel.domain.SykmeldtArbeidsforhold(
+    organisasjonsnummer = organisasjonsnummer,
+    organisasjonsnavn = null,
+    narmesteLederNavn = null,
+    foresporselStatus = status,
+    foresporselTidspunkt = null,
+)
+
+private fun setCreatedAtForForesporsler(
+    sykmeldtFnr: String,
+    createdAt: Instant,
+) {
+    TestDB.database.connection.use { connection ->
+        connection.prepareStatement(
+            """
+            UPDATE foresporsel_oppfolgingsplan
+            SET created_at = ?
+            WHERE sykmeldt_fnr = ?
+            """.trimIndent(),
+        ).use { preparedStatement ->
+            preparedStatement.setTimestamp(1, Timestamp.from(createdAt))
+            preparedStatement.setString(2, sykmeldtFnr)
+            preparedStatement.executeUpdate()
+        }
+        connection.commit()
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/foresporsel/db/ForesporselOppfolgingsplanRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/syfo/foresporsel/db/ForesporselOppfolgingsplanRepositoryTest.kt
@@ -1,0 +1,135 @@
+package no.nav.syfo.foresporsel.db
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import no.nav.syfo.TestDB
+import no.nav.syfo.sykmelding.db.FORESPORSEL_GRACE_PERIOD_DAYS
+import java.sql.Timestamp
+import java.time.Instant
+
+class ForesporselOppfolgingsplanRepositoryTest :
+    DescribeSpec({
+        val repository = ForesporselOppfolgingsplanRepository(TestDB.database)
+
+        beforeEach {
+            TestDB.clearAllData()
+        }
+
+        describe("storeIfNotRecentlyRequested") {
+            it("stores request and returns id when no recent request exists") {
+                val insertedId = repository.storeIfNotRecentlyRequested(
+                    sykmeldtFnr = "12345678901",
+                    narmesteLederFnr = "10987654321",
+                    organisasjonsnummer = "999888777",
+                )
+
+                val persisted = repository.findForesporselForSykmeldt("12345678901")
+
+                insertedId shouldBe persisted.single().id
+            }
+
+            it("returns null when a recent request already exists") {
+                repository.storeIfNotRecentlyRequested(
+                    sykmeldtFnr = "12345678901",
+                    narmesteLederFnr = "10987654321",
+                    organisasjonsnummer = "999888777",
+                )
+
+                val duplicateInsertId = repository.storeIfNotRecentlyRequested(
+                    sykmeldtFnr = "12345678901",
+                    narmesteLederFnr = "10987654321",
+                    organisasjonsnummer = "999888777",
+                )
+
+                val persisted = repository.findForesporselForSykmeldt("12345678901")
+
+                duplicateInsertId shouldBe null
+                persisted.shouldHaveSize(1)
+            }
+
+            it("stores new request when nearest leader changes within grace period") {
+                repository.storeIfNotRecentlyRequested(
+                    sykmeldtFnr = "12345678901",
+                    narmesteLederFnr = "10987654321",
+                    organisasjonsnummer = "999888777",
+                )
+
+                val insertedId = repository.storeIfNotRecentlyRequested(
+                    sykmeldtFnr = "12345678901",
+                    narmesteLederFnr = "10987654322",
+                    organisasjonsnummer = "999888777",
+                )
+
+                val persisted = repository.findForesporselForSykmeldt("12345678901")
+
+                insertedId shouldBe persisted.first().id
+                persisted.shouldHaveSize(2)
+            }
+
+            it("stores new request when previous request is outside grace period") {
+                repository.storeIfNotRecentlyRequested(
+                    sykmeldtFnr = "12345678901",
+                    narmesteLederFnr = "10987654321",
+                    organisasjonsnummer = "999888777",
+                )
+                setCreatedAtForAllRequests(
+                    sykmeldtFnr = "12345678901",
+                    createdAt = Instant.now().minusSeconds((FORESPORSEL_GRACE_PERIOD_DAYS + 1) * 24 * 60 * 60),
+                )
+
+                val insertedId = repository.storeIfNotRecentlyRequested(
+                    sykmeldtFnr = "12345678901",
+                    narmesteLederFnr = "10987654321",
+                    organisasjonsnummer = "999888777",
+                )
+
+                val persisted = repository.findForesporselForSykmeldt("12345678901")
+
+                insertedId shouldBe persisted.first().id
+                persisted.shouldHaveSize(2)
+            }
+        }
+
+        describe("findForesporselForSykmeldt") {
+            it("returns only requests for requested sykmeldt") {
+                repository.storeIfNotRecentlyRequested(
+                    sykmeldtFnr = "12345678901",
+                    narmesteLederFnr = "10987654321",
+                    organisasjonsnummer = "999888777",
+                )
+                repository.storeIfNotRecentlyRequested(
+                    sykmeldtFnr = "12345678902",
+                    narmesteLederFnr = "10987654322",
+                    organisasjonsnummer = "111222333",
+                )
+
+                val persisted = repository.findForesporselForSykmeldt("12345678901")
+
+                persisted.shouldHaveSize(1)
+                persisted.single().sykmeldtFnr shouldBe "12345678901"
+                persisted.single().narmesteLederFnr shouldBe "10987654321"
+                persisted.single().organisasjonsnummer shouldBe "999888777"
+            }
+        }
+    })
+
+private fun setCreatedAtForAllRequests(
+    sykmeldtFnr: String,
+    createdAt: Instant,
+) {
+    TestDB.database.connection.use { connection ->
+        connection.prepareStatement(
+            """
+            UPDATE foresporsel_oppfolgingsplan
+            SET created_at = ?
+            WHERE sykmeldt_fnr = ?
+            """.trimIndent(),
+        ).use { preparedStatement ->
+            preparedStatement.setTimestamp(1, Timestamp.from(createdAt))
+            preparedStatement.setString(2, sykmeldtFnr)
+            preparedStatement.executeUpdate()
+        }
+        connection.commit()
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/isnarmesteleder/client/IsnarmestelederClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/isnarmesteleder/client/IsnarmestelederClientTest.kt
@@ -1,0 +1,65 @@
+package no.nav.syfo.isnarmesteleder.client
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.http.Headers
+import io.ktor.http.HttpStatusCode
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import no.nav.syfo.getMockEngine
+import no.nav.syfo.texas.client.TexasHttpClient
+import no.nav.syfo.texas.client.TexasResponse
+import no.nav.syfo.util.httpClientDefault
+
+class IsnarmestelederClientTest :
+    DescribeSpec({
+        describe("IsnarmestelederHttpClient") {
+            it("exchanges TokenX token and returns nærmeste leder-relasjoner") {
+                val texasClient = mockk<TexasHttpClient>()
+                coEvery {
+                    texasClient.exchangeTokenForIsnarmesteleder("user-token")
+                } returns TexasResponse(
+                    accessToken = "exchanged-token",
+                    expiresIn = 3600,
+                    tokenType = "Bearer",
+                )
+
+                val mockEngine = getMockEngine(
+                    path = IsnarmestelederHttpClient.NARMESTELEDER_RELASJONER_PATH,
+                    status = HttpStatusCode.OK,
+                    headers = Headers.build {
+                        append("Content-Type", "application/json")
+                    },
+                    content = """
+                        [
+                          {
+                            "uuid": "11111111-1111-1111-1111-111111111111",
+                            "virksomhetsnummer": "999888777",
+                            "virksomhetsnavn": "Testbedrift AS",
+                            "narmesteLederPersonIdentNumber": "12345678910",
+                            "narmesteLederNavn": "Test Testesen",
+                            "status": "INNMELDT_AKTIV",
+                            "aktivFom": "2024-01-01",
+                            "aktivTom": null
+                          }
+                        ]
+                    """.trimIndent(),
+                )
+
+                val client = IsnarmestelederHttpClient(
+                    httpClient = httpClientDefault(HttpClient(mockEngine)),
+                    texasHttpClient = texasClient,
+                    isnarmestelederBaseUrl = "",
+                )
+
+                val result = client.getNarmesteLederRelasjoner("user-token")
+
+                result shouldHaveSize 1
+                result.first().virksomhetsnummer shouldBe "999888777"
+                coVerify(exactly = 1) { texasClient.exchangeTokenForIsnarmesteleder("user-token") }
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
@@ -45,6 +45,7 @@ import no.nav.syfo.defaultUtkastRequest
 import no.nav.syfo.dinesykmeldte.DineSykmeldteService
 import no.nav.syfo.dinesykmeldte.client.DineSykmeldteHttpClient
 import no.nav.syfo.dokarkiv.DokarkivService
+import no.nav.syfo.foresporsel.ForesporselService
 import no.nav.syfo.generatedPdfStandin
 import no.nav.syfo.isdialogmelding.IsDialogmeldingService
 import no.nav.syfo.isdialogmelding.client.IsDialogmeldingClient
@@ -93,6 +94,7 @@ class OppfolgingsplanApiV1Test :
 
         val dokarkivServiceMock = mockk<DokarkivService>()
         val isTilgangskontrollServiceMock = IsTilgangskontrollService(isTilgangskontrollClientMock)
+        val foresporselServiceMock = mockk<ForesporselService>(relaxed = true)
 
         beforeTest {
             clearAllMocks()
@@ -137,6 +139,7 @@ class OppfolgingsplanApiV1Test :
                             isDialogmeldingService = IsDialogmeldingService(isDialogmeldingClientMock),
                             dokarkivService = dokarkivServiceMock,
                             isTilgangskontrollService = isTilgangskontrollServiceMock,
+                            foresporselService = foresporselServiceMock,
                             environment = environment,
                         )
                     }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanUtkastApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanUtkastApiV1Test.kt
@@ -36,6 +36,7 @@ import no.nav.syfo.defaultUtkastRequest
 import no.nav.syfo.dinesykmeldte.DineSykmeldteService
 import no.nav.syfo.dinesykmeldte.client.DineSykmeldteHttpClient
 import no.nav.syfo.dokarkiv.DokarkivService
+import no.nav.syfo.foresporsel.ForesporselService
 import no.nav.syfo.isdialogmelding.IsDialogmeldingService
 import no.nav.syfo.isdialogmelding.client.IsDialogmeldingClient
 import no.nav.syfo.istilgangskontroll.IsTilgangskontrollService
@@ -68,6 +69,7 @@ class OppfolgingsplanUtkastApiV1Test :
         val isTilgangskontrollClientMock = mockk<IIsTilgangskontrollClient>()
         val dokarkivServiceMock = mockk<DokarkivService>()
         val isTilgangskontrollServiceMock = IsTilgangskontrollService(isTilgangskontrollClientMock)
+        val foresporselServiceMock = mockk<ForesporselService>(relaxed = true)
         val pdlClientMock = mockk<PdlClient>()
         val pdlService = PdlService(pdlClientMock)
         val oppfolgingsplanService = OppfolgingsplanService(
@@ -113,6 +115,7 @@ class OppfolgingsplanUtkastApiV1Test :
                             isDialogmeldingService = IsDialogmeldingService(isDialogmeldingClientMock),
                             dokarkivService = dokarkivServiceMock,
                             isTilgangskontrollService = isTilgangskontrollServiceMock,
+                            foresporselService = foresporselServiceMock,
                             environment = environment,
                         )
                     }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/OppfolgingsplanApiV1Test.kt
@@ -5,14 +5,19 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.shouldBe
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import io.ktor.client.request.url
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.HttpStatusCode.Companion.InternalServerError
 import io.ktor.http.contentType
@@ -22,12 +27,14 @@ import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.syfo.TestDB
 import no.nav.syfo.aareg.AaregService
 import no.nav.syfo.application.Environment
 import no.nav.syfo.application.LocalEnvironment
+import no.nav.syfo.application.exception.ApiErrorException
 import no.nav.syfo.application.valkey.ValkeyCache
 import no.nav.syfo.defaultMocks
 import no.nav.syfo.defaultPersistedOppfolgingsplan
@@ -35,6 +42,9 @@ import no.nav.syfo.defaultPersistedOppfolgingsplanUtkast
 import no.nav.syfo.dinesykmeldte.DineSykmeldteService
 import no.nav.syfo.dinesykmeldte.client.DineSykmeldteHttpClient
 import no.nav.syfo.dokarkiv.DokarkivService
+import no.nav.syfo.foresporsel.ForesporselService
+import no.nav.syfo.foresporsel.domain.ForesporselStatus
+import no.nav.syfo.foresporsel.domain.SykmeldtArbeidsforhold
 import no.nav.syfo.generatedPdfStandin
 import no.nav.syfo.isdialogmelding.IsDialogmeldingService
 import no.nav.syfo.isdialogmelding.client.IsDialogmeldingClient
@@ -74,11 +84,13 @@ class OppfolgingsplanApiV1Test :
         val pdlServiceMock = mockk<PdlService>(relaxed = true)
         val environment: Environment = LocalEnvironment()
         val aaregServiceMock = mockk<AaregService>(relaxed = true)
+        val foresporselServiceMock = mockk<ForesporselService>(relaxed = true)
 
         beforeTest {
             clearAllMocks()
             TestDB.clearAllData()
             every { valkeyCacheMock.getSykmeldt(any(), any()) } returns null
+            coEvery { foresporselServiceMock.getSykmeldteArbeidsforhold(any(), any(), any()) } returns emptyList()
         }
 
         fun withTestApplication(
@@ -112,6 +124,7 @@ class OppfolgingsplanApiV1Test :
                             isDialogmeldingService = IsDialogmeldingService(isDialogmeldingClientMock),
                             dokarkivService = dokarkivServiceMock,
                             isTilgangskontrollService = isTilgangskontrollServiceMock,
+                            foresporselService = foresporselServiceMock,
                             environment = environment,
                         )
                     }
@@ -261,6 +274,123 @@ class OppfolgingsplanApiV1Test :
                         overview.tidligerePlaner.size shouldBe 1
                         overview.tidligerePlaner.first().id shouldBe firstPlanUUID
                         overview.tidligerePlaner.first().organization.orgNumber shouldBe defaultPersistedOppfolgingsplan().organisasjonsnummer
+                        overview.sykmeldteArbeidsforhold shouldBe emptyList()
+                    }
+                }
+
+                it("GET /oppfolgingsplaner/oversikt should include sykmeldte arbeidsforhold and strip bearer prefix") {
+                    val sykmeldtFnr = "12345678901"
+                    val arbeidsforhold = listOf(
+                        SykmeldtArbeidsforhold(
+                            organisasjonsnummer = "111111111",
+                            organisasjonsnavn = "Plan AS",
+                            narmesteLederNavn = "Plan Leder",
+                            foresporselStatus = ForesporselStatus.CAN_REQUEST,
+                            foresporselTidspunkt = null,
+                        ),
+                    )
+                    withTestApplication {
+                        texasClientMock.defaultMocks(
+                            pid = sykmeldtFnr,
+                            clientId = environment.syfoOppfolgingsplanFrontendClientId,
+                        )
+                        coEvery {
+                            foresporselServiceMock.getSykmeldteArbeidsforhold(sykmeldtFnr, "user-token", any())
+                        } returns arbeidsforhold
+
+                        val response = client.get {
+                            url("/api/v1/sykmeldt/oppfolgingsplaner/oversikt")
+                            header(HttpHeaders.Authorization, "Bearer user-token")
+                        }
+
+                        response.status shouldBe HttpStatusCode.OK
+                        val overview = response.body<SykmeldtOppfolgingsplanOverviewResponse>()
+                        overview.sykmeldteArbeidsforhold.shouldContainExactly(arbeidsforhold)
+                    }
+                }
+            }
+            describe("Be om plan") {
+                it("POST /oppfolgingsplaner/be-om-plan should respond with Created and call service") {
+                    val sykmeldtFnr = "12345678901"
+                    withTestApplication {
+                        texasClientMock.defaultMocks(
+                            pid = sykmeldtFnr,
+                            clientId = environment.syfoOppfolgingsplanFrontendClientId,
+                        )
+                        coEvery {
+                            foresporselServiceMock.beOmPlan(sykmeldtFnr, "111111111", "user-token")
+                        } returns Unit
+
+                        val response = client.post("/api/v1/sykmeldt/oppfolgingsplaner/be-om-plan") {
+                            header(HttpHeaders.Authorization, "Bearer user-token")
+                            contentType(ContentType.Application.Json)
+                            setBody("""{"organisasjonsnummer":"111111111"}""")
+                        }
+
+                        response.status shouldBe HttpStatusCode.Created
+                        coVerify {
+                            foresporselServiceMock.beOmPlan(sykmeldtFnr, "111111111", "user-token")
+                        }
+                    }
+                }
+
+                it("POST /oppfolgingsplaner/be-om-plan should respond with NotFound when no nearest leader exists") {
+                    val sykmeldtFnr = "12345678901"
+                    withTestApplication {
+                        texasClientMock.defaultMocks(
+                            pid = sykmeldtFnr,
+                            clientId = environment.syfoOppfolgingsplanFrontendClientId,
+                        )
+                        coEvery {
+                            foresporselServiceMock.beOmPlan(sykmeldtFnr, "111111111", "user-token")
+                        } throws ApiErrorException.NotFound("Fant ingen aktiv nærmeste leder-relasjon for virksomheten")
+
+                        val response = client.post("/api/v1/sykmeldt/oppfolgingsplaner/be-om-plan") {
+                            header(HttpHeaders.Authorization, "Bearer user-token")
+                            contentType(ContentType.Application.Json)
+                            setBody("""{"organisasjonsnummer":"111111111"}""")
+                        }
+
+                        response.status shouldBe HttpStatusCode.NotFound
+                    }
+                }
+
+                it("POST /oppfolgingsplaner/be-om-plan should respond with Conflict when request was sent recently") {
+                    val sykmeldtFnr = "12345678901"
+                    withTestApplication {
+                        texasClientMock.defaultMocks(
+                            pid = sykmeldtFnr,
+                            clientId = environment.syfoOppfolgingsplanFrontendClientId,
+                        )
+                        coEvery {
+                            foresporselServiceMock.beOmPlan(sykmeldtFnr, "111111111", "user-token")
+                        } throws ApiErrorException.Conflict("Forespørsel om oppfølgingsplan er allerede sendt nylig")
+
+                        val response = client.post("/api/v1/sykmeldt/oppfolgingsplaner/be-om-plan") {
+                            header(HttpHeaders.Authorization, "Bearer user-token")
+                            contentType(ContentType.Application.Json)
+                            setBody("""{"organisasjonsnummer":"111111111"}""")
+                        }
+
+                        response.status shouldBe HttpStatusCode.Conflict
+                    }
+                }
+
+                it("POST /oppfolgingsplaner/be-om-plan should respond with BadRequest for invalid organisasjonsnummer") {
+                    val sykmeldtFnr = "12345678901"
+                    withTestApplication {
+                        texasClientMock.defaultMocks(
+                            pid = sykmeldtFnr,
+                            clientId = environment.syfoOppfolgingsplanFrontendClientId,
+                        )
+
+                        val response = client.post("/api/v1/sykmeldt/oppfolgingsplaner/be-om-plan") {
+                            header(HttpHeaders.Authorization, "Bearer user-token")
+                            contentType(ContentType.Application.Json)
+                            setBody("""{"organisasjonsnummer":"123"}""")
+                        }
+
+                        response.status shouldBe HttpStatusCode.BadRequest
                     }
                 }
             }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederOppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederOppfolgingsplanApiV1Test.kt
@@ -36,6 +36,7 @@ import no.nav.syfo.defaultPersistedOppfolgingsplan
 import no.nav.syfo.dinesykmeldte.DineSykmeldteService
 import no.nav.syfo.dinesykmeldte.client.DineSykmeldteHttpClient
 import no.nav.syfo.dokarkiv.DokarkivService
+import no.nav.syfo.foresporsel.ForesporselService
 import no.nav.syfo.isdialogmelding.IsDialogmeldingService
 import no.nav.syfo.isdialogmelding.client.IsDialogmeldingClient
 import no.nav.syfo.istilgangskontroll.IsTilgangskontrollService
@@ -68,6 +69,7 @@ class VeilederOppfolgingsplanApiV1Test :
         val dokarkivServiceMock = mockk<DokarkivService>()
         val isTilgangskontrollClientMock = mockk<IIsTilgangskontrollClient>()
         val isTilgangskontrollServiceMock = IsTilgangskontrollService(isTilgangskontrollClientMock)
+        val foresporselServiceMock = mockk<ForesporselService>(relaxed = true)
         val environment: Environment = LocalEnvironment()
         val syfomodiapersonClientId = environment.syfomodiapersonClientId
 
@@ -108,6 +110,7 @@ class VeilederOppfolgingsplanApiV1Test :
                             isDialogmeldingService = IsDialogmeldingService(isDialogmeldingClientMock),
                             dokarkivService = dokarkivServiceMock,
                             isTilgangskontrollService = isTilgangskontrollServiceMock,
+                            foresporselService = foresporselServiceMock,
                             environment = environment,
                         )
                     }

--- a/src/test/kotlin/no/nav/syfo/sykmelding/db/SykmeldingsperiodeRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmelding/db/SykmeldingsperiodeRepositoryTest.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.sykmelding.db
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import no.nav.syfo.TestDB
@@ -93,6 +94,80 @@ class SykmeldingsperiodeRepositoryTest :
                 invalidatedRows shouldBe 2
                 persisted.shouldHaveSize(2)
                 persisted.all { it.invalidatedAt != null } shouldBe true
+            }
+        }
+
+        describe("findOrganisasjonerMedAktivSykmeldingsperiode") {
+            it("returns distinct active organisasjonsnumre within grace period") {
+                val today = LocalDate.now()
+
+                repository.storeSykmeldingsperioder(
+                    listOf(
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = "12345678901",
+                            organisasjonsnummer = "111111111",
+                            sykmeldingId = "sykmelding-4",
+                            fom = today.minusDays(10),
+                            tom = today.plusDays(5),
+                        ),
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = "12345678901",
+                            organisasjonsnummer = "222222222",
+                            sykmeldingId = "sykmelding-5",
+                            fom = today.minusDays(30),
+                            tom = today.minusDays(FORESPORSEL_GRACE_PERIOD_DAYS),
+                        ),
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = "12345678901",
+                            organisasjonsnummer = "111111111",
+                            sykmeldingId = "sykmelding-6",
+                            fom = today.minusDays(3),
+                            tom = today.plusDays(10),
+                        ),
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = "12345678901",
+                            organisasjonsnummer = "333333333",
+                            sykmeldingId = "sykmelding-7",
+                            fom = today.plusDays(1),
+                            tom = today.plusDays(20),
+                        ),
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = "12345678901",
+                            organisasjonsnummer = "444444444",
+                            sykmeldingId = "sykmelding-8",
+                            fom = today.minusDays(40),
+                            tom = today.minusDays(FORESPORSEL_GRACE_PERIOD_DAYS + 1),
+                        ),
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = "12345678902",
+                            organisasjonsnummer = "555555555",
+                            sykmeldingId = "sykmelding-9",
+                            fom = today.minusDays(10),
+                            tom = today.plusDays(10),
+                        ),
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = "12345678901",
+                            organisasjonsnummer = "666666666",
+                            sykmeldingId = "sykmelding-10",
+                            fom = today.minusDays(10),
+                            tom = today.plusDays(10),
+                        ),
+                    ),
+                )
+                repository.invalidateSykmelding("sykmelding-10")
+
+                val aktiveOrganisasjoner = repository.findOrganisasjonerMedAktivSykmeldingsperiode("12345678901")
+
+                aktiveOrganisasjoner shouldContainExactlyInAnyOrder listOf(
+                    "111111111",
+                    "222222222",
+                )
+            }
+
+            it("returns empty list when no active periods exist") {
+                val aktiveOrganisasjoner = repository.findOrganisasjonerMedAktivSykmeldingsperiode("12345678901")
+
+                aktiveOrganisasjoner shouldBe emptyList()
             }
         }
     })


### PR DESCRIPTION
## Beskrivelse

Denne PR-en innfører støtte for at sykmeldte kan be arbeidsgiver om å opprette en oppfølgingsplan.

Løsningen legger til nye API-er for oversikten til sykmeldt, persistens av forespørsler, statusberegning per arbeidsforhold og utsending av varsel ved vellykket forespørsel. I tillegg er nødvendige integrasjoner, OpenAPI-dokumentasjon og NAIS-konfigurasjon på plass.

> **⚠️ Denne PR-en er et utkast for overlevering.** Koden er skrevet med AI-assistanse og trenger manuell gjennomgang, testing og eventuell tilpasning før merge.

## Sammenheng

- Del av epic: #273 (Forespørsel om oppfølgingsplan fra sykmeldt)
- Frontend-PR: [syfo-oppfolgingsplan-frontend#808](https://github.com/navikt/syfo-oppfolgingsplan-frontend/pull/808)
- Esyfovarsel-endringer (ny `HendelseType`): ikke påbegynt (#956 i esyfovarsel)

## Endringer

### API og kontrakter
- `GET /api/v1/sykmeldt/oppfolgingsplaner/oversikt` — utvidet med `sykmeldteArbeidsforhold`-liste
- `POST /api/v1/sykmeldt/oppfolgingsplaner/be-om-plan` — ny forespørsel-innsending
- OpenAPI-spesifikasjon i `src/main/resources/openapi/sykmeldt.yaml`

### Domene og forretningslogikk
- `ForesporselService` — beregner status per arbeidsforhold:
  - `CAN_REQUEST` — kan sende forespørsel
  - `ALREADY_REQUESTED` — har aktiv forespørsel til gjeldende NL
  - `HAS_ACTIVE_PLAN` — har allerede en aktiv oppfølgingsplan
  - `MISSING_NARMESTELEDER` — ingen NL registrert
  - `NARMESTELEDER_UNKNOWN` — klarte ikke hente NL-info
- 24 timers guard på POST (cooldown, ikke unik DB-constraint)
- Best-effort Kafka-varsel: forespørsel lagres først, varsel sendes etterpå

### Database
- Flyway-migrering `V15__create_foresporsel_oppfolgingsplan_table.sql`
- `ForesporselOppfolgingsplanRepository` med parametriserte queries

### Integrasjoner og infrastruktur
- `IsnarmestelederClient` — oppslag mot isnarmesteleder
- Texas-oppsett for token exchange
- `nais-dev.yaml` / `nais-prod.yaml` — accessPolicy mot isnarmesteleder
- Ny `HendelseType` i `EsyfoVarselDTO.kt` for Kafka-varsel

## Viktige designvalg

| Valg | Begrunnelse |
|------|-------------|
| Status per orgnr, ikke per NL | Beholder status ved NL-bytte |
| 24t guard på POST | Tillater ny forespørsel etter cooldown |
| Best-effort Kafka-varsel | DB-lagring prioriteres, varsel feiler stille |
| Backend returnerer full arbeidsforhold-liste | Frontend styrer visningslogikk |

## Testing

- `ForesporselServiceTest` — statusberegning, edge cases, NL-bytte
- `ForesporselOppfolgingsplanRepositoryTest` — CRUD, duplikatsjekk
- `IsnarmestelederClientTest` — integrasjon mot isnarmesteleder
- `SykmeldingsperiodeRepositoryTest` — aktiv sykmelding-sjekk
- `OppfolgingsplanApiV1Test` — API-integrasjonstester
- Alle tester bruker Testcontainers PostgreSQL

## Hva gjenstår

- [ ] Manuell gjennomgang av koden
- [ ] Verifiser at `esyfovarsel` støtter den nye `HendelseType`-verdien (issue navikt/esyfovarsel#956)
- [ ] Test i dev-miljø mot isnarmesteleder
- [ ] Vurder om 24t cooldown er riktig varighet
- [ ] Koden kompilerer og alle tester passerer (`./gradlew build`)

## Sjekkliste

- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
- [x] Parametriserte queries (ingen string-interpolasjon i SQL)
- [x] Flyway-migrering versjonert korrekt
- [ ] Koden gjennomgått manuelt
- [ ] Testet i dev-miljø