### PR TITLE
docs(readme): oppdater README basert på faktisk repo-innhold

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Tjenesten bruker Kafka i begge retninger:
 
 Innkommende kall er låst ned med `accessPolicy` i NAIS og sjekkes også i applikasjonen.
 
-- `syfo-oppfolgingsplan-frontend` kaller arbeidsgiver- og sykmeldt-API med TokenX
+- `syfo-oppfolgingsplan-frontend` kaller arbeidsgiver- og sykmeldt-API med TokenX (ID-porten)
 - `syfomodiaperson` kaller veileder-API med Azure AD
 - Texas brukes til token introspeksjon og token exchange
 - i dev er også `tokenx-token-generator` og `azure-token-generator` tillatt inn mot appen

--- a/README.md
+++ b/README.md
@@ -1,131 +1,227 @@
-# syfo-oppfolgingsplan-backend
+# Oppfølgingsplan-backend
 
-Backend-tjeneste for oppfølgingsplaner i sykefraværsoppfølgingen. Tjenesten håndterer oppfølgingsplaner mellom sykmeldte
-og deres arbeidsgivere, og lar veiledere i Nav hente planene.
+[![CI](https://github.com/navikt/syfo-oppfolgingsplan-backend/actions/workflows/build-and-deploy.yaml/badge.svg)](https://github.com/navikt/syfo-oppfolgingsplan-backend/actions/workflows/build-and-deploy.yaml)
+![Kotlin](https://img.shields.io/badge/Kotlin-2.3.21-7F52FF?logo=kotlin&logoColor=white)
+![Ktor](https://img.shields.io/badge/Ktor-3.4.3-087CFA?logo=ktor&logoColor=white)
+![PostgreSQL](https://img.shields.io/badge/PostgreSQL-17-4169E1?logo=postgresql&logoColor=white)
+![Kafka](https://img.shields.io/badge/Kafka-clients-231F20?logo=apachekafka&logoColor=white)
 
-## Forutsetninger
+Backend-tjeneste for oppfølgingsplaner i sykefraværsoppfølgingen.
 
-- **JDK 21** eller nyere
-- **Docker** for lokal utvikling
-- **Gradle** (wrapper inkludert)
+Tjenesten brukes av:
 
-## Lokal utvikling
+- **arbeidsgiver og nærmeste leder** som oppretter, lagrer og deler oppfølgingsplaner
+- **sykmeldt** som henter egne planer
+- **veileder i Nav** som kan hente delte planer i `syfomodiaperson`
 
-- Kjør `./gradlew build` for å bygge prosjektet og sikre at alle avhengigheter er på plass.
-- Start lokal Postgres, Texas og mock-oauth2-server med `docker compose up`.
-- Start applikasjonen lokalt med `./gradlew run`.
-- Trenger du et token for sikrede endepunkter, kjør `./fetch-token-for-local-dev.sh`. Auth-serveren returnerer alltid et
-  token med claimene definert i `docker-compose.yml`.
+Planene gjelder samarbeid mellom sykmeldt og arbeidsgiver eller nærmeste leder. Når en plan deles med Nav, kan veileder hente den.
 
-## API-dokumentasjon (Swagger)
+## Oversikt
 
-### Lokal utvikling
+```mermaid
+flowchart LR
+    frontend[syfo-oppfolgingsplan-frontend<br/>arbeidsgiver og sykmeldt]
+    modiaperson[syfomodiaperson<br/>veileder]
+    backend[syfo-oppfolgingsplan-backend<br/>Ktor API]
+    texas[Texas]
+    postgres[(PostgreSQL)]
+    valkey[(Valkey)]
+    sykmelding[(teamsykmelding.syfo-sendt-sykmelding)]
+    varselbus[(team-esyfo.varselbus)]
+    dinesykmeldte[dinesykmeldte-backend]
+    tilgang[istilgangskontroll]
+    dialog[isdialogmelding]
+    dokarkiv[Dokarkiv]
+    dokumentporten[syfo-dokumentporten]
+    pdfgen[syfooppdfgen]
+    pdl[PDL]
+    aareg[Aareg]
 
-Swagger UI er tilgjengelig på:
+    frontend -->|TokenX| texas
+    modiaperson -->|Azure AD| texas
+    texas --> backend
+    backend --> postgres
+    backend --> valkey
+    sykmelding -->|konsumerer| backend
+    backend -->|produserer varsler| varselbus
+    backend --> dinesykmeldte
+    backend --> tilgang
+    backend --> dialog
+    backend --> dokarkiv
+    backend --> dokumentporten
+    backend --> pdfgen
+    backend --> pdl
+    backend --> aareg
+```
+
+## Arkitektur og integrasjoner
+
+Applikasjonen er en Kotlin- og Ktor-tjeneste som starter Netty på port 8080. Den setter opp avhengigheter, bakgrunnsoppgaver, routing og lifecycle hooks i `App.kt`.
+
+Den viktigste flyten er:
+
+- henter sykmeldt- og lederdata fra `dinesykmeldte-backend`
+- lagrer oppfølgingsplaner og utkast i PostgreSQL
+- bruker Valkey som cache
+- genererer PDF via `syfooppdfgen`
+- sender plan til lege via `isdialogmelding`
+- arkiverer plan delt med Nav via Dokarkiv
+- sender dokumenter videre via `syfo-dokumentporten`
+- bruker PDL og Aareg som oppslag
+
+### Bakgrunnsoppgaver
+
+- `SendOppfolgingsplanTask` sender klare planer videre til Dokumentporten
+- `CleanupUtkastTask` hard-sletter utkast eldre enn 4 måneder
+- `SykmeldingsperiodeConsumer` lagrer relevante sykmeldingsperioder og håndterer tombstones
+
+## API-oversikt
+
+For domene-API-et er listen under et utvalg av sentrale endepunkter, ikke en fullstendig kontrakt.
+
+### Arbeidsgiver
+
+Base path: `/api/v1/arbeidsgiver/{narmesteLederId}/oppfolgingsplaner`
+
+- **POST** `/` oppretter oppfølgingsplan
+- **GET** `/oversikt` henter oversikt over planer for sykmeldt
+- **GET** `/aktiv-plan` henter aktiv plan
+- **GET** `/{uuid}` henter én plan
+- **POST** `/{uuid}/del-med-lege` deler plan med lege
+- **POST** `/{uuid}/del-med-veileder` deler plan med Nav
+- **GET** `/{uuid}/pdf` henter PDF
+
+Utkast ligger under `/api/v1/arbeidsgiver/{narmesteLederId}/oppfolgingsplaner/utkast`:
+
+- **PUT** `/` lagrer utkast
+- **GET** `/` henter utkast
+- **DELETE** `/` sletter utkast
+
+### Sykmeldt
+
+Base path: `/api/v1/sykmeldt/oppfolgingsplaner`
+
+- **GET** `/oversikt` henter oversikt over egne planer
+- **GET** `/{uuid}` henter én plan
+- **GET** `/{uuid}/pdf` henter PDF
+
+### Veileder
+
+Base path: `/api/v1/veileder/oppfolgingsplaner`
+
+- **POST** `/query` henter planer for en sykmeldt
+- **GET** `/{uuid}` henter PDF for plan som er delt med Nav
+
+Veiledertilgang sjekkes mot `istilgangskontroll`.
+
+## Kafka
+
+Tjenesten bruker Kafka i begge retninger:
+
+- **konsumerer** `teamsykmelding.syfo-sendt-sykmelding` med consumer group `syfo-oppfolgingsplan-backend-sykmeldingsperiode-v2`
+- **produserer** varsler til `team-esyfo.varselbus` når en oppfølgingsplan opprettes
+
+## Database og cache
+
+- PostgreSQL kjøres i NAIS GCP SQL med Flyway-migreringer
+- Valkey brukes med readwrite-tilgang i både dev og prod
+
+## Autentisering og klienter
+
+Innkommende kall er låst ned med `accessPolicy` i NAIS og sjekkes også i applikasjonen.
+
+- `syfo-oppfolgingsplan-frontend` kaller arbeidsgiver- og sykmeldt-API med TokenX
+- `syfomodiaperson` kaller veileder-API med Azure AD
+- Texas brukes til token introspeksjon og token exchange
+- i dev er også `tokenx-token-generator` og `azure-token-generator` tillatt inn mot appen
+
+Utgående kall går blant annet til `syfo-dokumentporten`, `syfooppdfgen`, `dinesykmeldte-backend`, `isdialogmelding`, `istilgangskontroll`, Dokarkiv, PDL og Aareg. Disse er åpnet i NAIS-manifestene.
+
+## Miljøer og Swagger
+
+- **dev:** https://syfo-oppfolgingsplan-backend.intern.dev.nav.no
+- **prod:** https://syfo-oppfolgingsplan-backend.intern.nav.no
+
+Swagger er tilgjengelig lokalt og i dev, men ikke i prod. Applikasjonen eksponerer Swagger bare når `!isProdEnv()`.
+
+### Swagger lokalt
 
 - **Arbeidsgiver:** http://localhost:8080/swagger/arbeidsgiver
 - **Sykmeldt:** http://localhost:8080/swagger/sykmeldt
 - **Veileder:** http://localhost:8080/swagger/veileder
 
-### Dev-miljø
+### Swagger i dev
 
 - **Arbeidsgiver:** https://syfo-oppfolgingsplan-backend.intern.dev.nav.no/swagger/arbeidsgiver
 - **Sykmeldt:** https://syfo-oppfolgingsplan-backend.intern.dev.nav.no/swagger/sykmeldt
 - **Veileder:** https://syfo-oppfolgingsplan-backend.intern.dev.nav.no/swagger/veileder
 
-OpenAPI-spesifikasjonene finnes i `src/main/resources/openapi/`.
+OpenAPI-filene ligger i `src/main/resources/openapi/`.
 
-## Utkast-cleanup
+## Lokal infrastruktur
 
-- Oppfølgingsplanutkast hard-slettes av en daglig bakgrunnstask (`CleanupUtkastTask`) når utkastet er eldre enn 4 måneder.
-- Begge bakgrunnstaskene (`CleanupUtkastTask` og `SendOppfolgingsplanTask`) bruker `RecurringTask`-baseklassen med leader election, feilhåndtering og graceful shutdown.
-- API-responsene for utkast eksponerer `utkastUtloperDato` (Europe/Oslo). Feltet er informativt og beregnes fra `updated_at`.
+Lokal infrastruktur består av Postgres, Valkey, mock-oauth2-server, Texas og Kafka-oppsett.
 
-## Docker compose
+Bruk `mise run docker-up` for å starte tjenestene og `mise run docker-down` for å stoppe dem. Kjør `mise tasks` for å se flere oppgaver.
 
-### Størrelse på containerplattform
+For å kjøre Kafka-lokalt trenger containerplattformen ofte litt ekstra ressurser. For Colima kan dette være et greit utgangspunkt:
 
-For å kjøre Kafka++ må containerplattformen (Rancher Desktop, Colima osv.) få utvidede ressurser.
-
-Forslag for Colima:
-
-```
+```bash
 colima start --arch aarch64 --memory 8 --cpu 4
 ```
 
-Vi har en `docker-compose.yml` for Postgres, Texas og fake authserver, og en `docker-compose.kafka.yml` for
-Kafka-broker, schema registry og kafka-io.
-
-Start begge med:
-
-```
-docker-compose \
-  -f docker-compose.yml \
-  -f docker-compose.kafka.yml \
-  up \
-  db authserver texas broker kafka-ui valkey \
-  -d
-```
-
-Stopp dem med:
-
-```
-docker-compose \
-  -f docker-compose.yml \
-  -f docker-compose.kafka.yml \
-  down
-```
-
-Du kan også kjøre pdf-generatoren lokalt ved å klone [syfooppdfgen-repoet](https://github.com/navikt/syfooppdfgen) og
-følge instruksjonene der.
-
-### Kafka-ui
-
-Bruk http://localhost:9000 for å inspisere konsumere og topics, samt publisere eller lese meldinger.
-
-### Ferdiglagde API-forespørsler
-
-Det finnes HTTP-forespørsler for testing beskrevet i `src/test/http/README.md`.
-
-## Fjern-debugging i nais-clusteret
-
-Det er mulig å aktivere fjern-debugging for apper i nais-clusteret. Generell beskrivelse finnes i repoet `utvikling`
-på https://github.com/navikt/utvikling/blob/main/docs/teknisk/Remote_debug_i_Intellij.md.
-
-### Justeringer i deployment
-
-I `nais/nais-dev.yaml` må du:
-
-1. Legge til `JAVA_TOOL_OPTIONS` under `env`:
-
-```
-    - name: JAVA_TOOL_OPTIONS
-      value: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
-```
-
-2. Gjøre liveness-proben mer tilgivende for debugging ved å justere `periodSeconds` og/eller `failureThreshold`, f.eks.:
-
-```
-  liveness:
-    path: /internal/is_alive
-    initialDelay: 10
-    timeout: 5
-    periodSeconds: 60
-    failureThreshold: 10
-```
-
-Opprett tunnel til port 5005 med:
-
-```
-kubectx dev-gcp
-kubectl port-forward deployment/syfo-oppfolgingsplan-backend -n team-esyfo 5005:5005
-```
+- Kafka UI: http://localhost:9000
+- Lokal PDF-generator: klon [syfooppdfgen](https://github.com/navikt/syfooppdfgen) og følg instruksjonene der
+- HTTP request-filer: ferdige forespørsler for IntelliJ HTTP Client i [`src/test/http`](src/test/http/README.md)
+- Lokal tokenhenting: `fetch-token-for-local-dev.sh` henter et lokalt testtoken via fake ID-porten og Texas
 
 ## Autentisering i dev
 
 Token for sykmeldt eller nærmeste leder:
+
 https://tokenx-token-generator.intern.dev.nav.no/api/obo?aud=dev-gcp:team-esyfo:syfo-oppfolgingsplan-backend
 
 Token for veileder:
-https://azure-token-generator.intern.dev.nav.no/api/obo?aud=dev-gcp:team-esyfo:syfo-oppfolgingsplan-backend (krever
-veileder-bruker fra Ida).
+
+https://azure-token-generator.intern.dev.nav.no/api/obo?aud=dev-gcp:team-esyfo:syfo-oppfolgingsplan-backend
+
+Azure-token-generatoren krever veileder-bruker fra Ida.
+
+## Fjern-debugging i NAIS
+
+Det er mulig å aktivere fjern-debugging i NAIS. Generell beskrivelse finnes i [`utvikling`](https://github.com/navikt/utvikling/blob/main/docs/teknisk/Remote_debug_i_Intellij.md).
+
+I `nais/nais-dev.yaml` kan du legge til `JAVA_TOOL_OPTIONS` under `env`:
+
+```yaml
+- name: JAVA_TOOL_OPTIONS
+  value: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
+```
+
+Du kan også gjøre liveness-proben mer tilgivende under debugging:
+
+```yaml
+liveness:
+  path: /internal/is_alive
+  initialDelay: 10
+  timeout: 5
+  periodSeconds: 60
+  failureThreshold: 10
+```
+
+Opprett tunnel til port 5005:
+
+```bash
+kubectx dev-gcp
+kubectl port-forward deployment/syfo-oppfolgingsplan-backend -n team-esyfo 5005:5005
+```
+
+## Utvikling
+
+Bruk `mise tasks` for å se oppdaterte oppgaver for bygg, test, lokal infrastruktur og andre hjelpemidler.
+
+Swagger, HTTP request-filer og tokenhjelpere gjør det enklere å teste API-et manuelt.
+
+## For Nav-ansatte
+
+Spørsmål om tjenesten kan tas i [#esyfo på Slack](https://nav-it.slack.com/archives/C012X796B4L).


### PR DESCRIPTION
## Beskrivelse

Oppdaterer README slik at den beskriver repoets faktiske ansvar, integrasjoner og lokal utvikling.

## Endringer

- `README.md`: la til formål, arkitekturdiagram, API-oversikt, Kafka, database/cache, auth, miljøer og Swagger
- `README.md`: forenklet lokal infrastruktur og utvikling med `mise tasks`, `mise run docker-up` og `mise run docker-down`
- `README.md`: beholdt relevante lokale utviklingsdetaljer som Kafka UI, HTTP request-filer, tokenhenting og fjern-debugging

## Issue

Closes #271

## Sjekkliste

- [ ] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

Merknad: Full build/lint er ikke kjørt fordi endringen kun gjelder dokumentasjon.
