### PR TITLE
chore(deps): align netty dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ val ktorVersion = "3.4.3"
 val logbackVersion = "1.5.32"
 val logstashEncoderVersion = "9.0"
 val micrometerVersion = "1.16.5"
+val nettyVersion = "4.2.13.Final"
 val mockkVersion = "1.14.9"
 val postgresVersion = "42.7.10"
 val testcontainersVersion = "1.21.4"
@@ -32,6 +33,8 @@ repositories {
 }
 
 dependencies {
+    implementation(platform("io.netty:netty-bom:$nettyVersion"))
+
     implementation("io.ktor:ktor-server-core")
     implementation("io.ktor:ktor-server-auth")
     implementation("io.ktor:ktor-server-auth-jwt")


### PR DESCRIPTION
## Beskrivelse

Legger til Netty BOM for å aligne Netty-avhengigheter til `4.2.13.Final` uten å oppgradere Ktor fra `3.4.3`.

Dette lukker sårbarhetene som kommer via `netty-codec-http`, `netty-codec-http2`, `netty-codec-compression` og `netty-transport-native-epoll` på `4.2.12.Final`, samtidig som vi unngår Ktor `3.5.0` på grunn av kjente performance-/timeout-problemer.

## Endringer

- `build.gradle.kts`: lagt til `nettyVersion = "4.2.13.Final"`
- `build.gradle.kts`: lagt til `implementation(platform("io.netty:netty-bom:$nettyVersion"))`

## Issue

Ingen issue. Sikkerhetsoppdatering for rapporterte Netty-CVE-er.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil (`compileKotlin`, `ktlintCheck`)
- [x] Endringene er testet automatisk med `dependencyInsight` for berørte Netty-artifacts
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

## Verifisering

- `./gradlew --no-daemon --console=plain compileKotlin`
- `./gradlew --no-daemon --console=plain ktlintCheck`
- `./gradlew --no-daemon --console=plain dependencyInsight --configuration runtimeClasspath --dependency <netty-artifact>` for:
  - `io.netty:netty-codec-http` → `4.2.13.Final`
  - `io.netty:netty-codec-http2` → `4.2.13.Final`
  - `io.netty:netty-codec-compression` → `4.2.13.Final`
  - `io.netty:netty-transport-native-epoll` → `4.2.13.Final`

Merk: Full `./gradlew build` ble forsøkt, men lokale Testcontainers-tester feilet fordi Docker/Testcontainers ikke kunne initialiseres i miljøet.
