### PR TITLE
revert(deps): roll back ktor 3.5.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,8 +4,9 @@ val flywayVersion = "12.7.0"
 val hikariVersion = "7.0.2"
 val kafkaVersion = "4.3.0"
 val koinVersion = "4.2.1"
+val kotestExtensionsVersion = "2.0.0"
 val kotestVersion = "6.1.11"
-val ktorVersion = "3.5.0"
+val ktorVersion = "3.4.3"
 val logbackVersion = "1.5.34"
 val logstashEncoderVersion = "9.0"
 val micrometerVersion = "1.16.5"
@@ -17,7 +18,7 @@ val valkeyVersion = "5.5.0"
 
 plugins {
     kotlin("jvm") version "2.3.21"
-    id("io.ktor.plugin") version "3.5.0"
+    id("io.ktor.plugin") version "3.4.3"
     id("com.gradleup.shadow") version "9.4.2"
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
     id("org.jetbrains.kotlin.plugin.serialization") version "2.3.21"
@@ -85,11 +86,11 @@ dependencies {
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
     testImplementation("io.kotest:kotest-property:$kotestVersion")
-    testImplementation("io.kotest:kotest-assertions-ktor:$kotestVersion")
+    testImplementation("io.kotest.extensions:kotest-assertions-ktor:$kotestExtensionsVersion")
     testImplementation("io.mockk:mockk:$mockkVersion")
     testImplementation("io.insert-koin:koin-test:$koinVersion")
     testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
-    testImplementation("io.kotest:kotest-extensions-koin:$kotestVersion")
+    testImplementation("io.kotest.extensions:kotest-extensions-koin:1.3.0")
     testImplementation("org.wiremock:wiremock:3.13.2")
     testImplementation("org.testcontainers:testcontainers:$testcontainersVersion")
     testImplementation("org.testcontainers:postgresql:$testcontainersVersion")


### PR DESCRIPTION
## Beskrivelse

Ruller tilbake Ktor 3.5.0-endringen etter plugin-feil observert etter merge. Dette setter repoet tilbake til siste kjente fungerende Ktor-oppsett på 3.4.3.

## Endringer

- `build.gradle.kts`: setter `ktorVersion` tilbake til `3.4.3`
- `build.gradle.kts`: setter `io.ktor.plugin` tilbake til `3.4.3`
- `build.gradle.kts`: gjeninnfører tidligere Kotest-extension-koordinater som hørte til dette oppsettet

## Issue

Ingen egen issue opprettet. Endringen gjøres for å rydde opp etter merge av Ktor 3.5.0 som ga plugin-problemer.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)