### PR TITLE
story: Lagre ønske om evalueringsvarsel

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ For å kjøre Kafka-lokalt trenger containerplattformen ofte litt ekstra ressurs
 colima start --arch aarch64 --memory 8 --cpu 4
 ```
 
-- Kafka UI: http://localhost:9000
+- Kafka UI: http://localhost:9080
 - Lokal PDF-generator: klon [syfooppdfgen](https://github.com/navikt/syfooppdfgen) og følg instruksjonene der
 - HTTP request-filer: ferdige forespørsler for IntelliJ HTTP Client i [`src/test/http`](src/test/http/README.md)
 - Lokal tokenhenting: `fetch-token-for-local-dev.sh` henter et lokalt testtoken via fake ID-porten og Texas

--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -74,7 +74,7 @@ services:
     image: provectuslabs/kafka-ui:latest
     container_name: kafka-ui
     ports:
-      - "9000:8080" # Access Kafka-UI on http://localhost:9000
+      - "9080:8080" # Access Kafka-UI on http://localhost:9000
     environment:
       KAFKA_CLUSTERS_0_NAME: 'Local Kafka Cluster'
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: 'broker:29092'

--- a/src/main/kotlin/no/nav/syfo/application/auth/ClientAuthorizationPlugin.kt
+++ b/src/main/kotlin/no/nav/syfo/application/auth/ClientAuthorizationPlugin.kt
@@ -25,9 +25,7 @@ val ClientAuthorizationPlugin = createRouteScopedPlugin(
         isProdEnv() -> listOf(clientId)
         isLocalEnv() ->  listOf(
             clientId,
-            "dev-gcp:nais:tokenx-token-generator",
-            "dev-gcp:nais:azure-token-generator",
-            "notfound"
+            "local:fakedings"
         )
         else -> listOf(
             clientId,

--- a/src/main/kotlin/no/nav/syfo/application/auth/ClientAuthorizationPlugin.kt
+++ b/src/main/kotlin/no/nav/syfo/application/auth/ClientAuthorizationPlugin.kt
@@ -5,6 +5,7 @@ import io.ktor.server.application.createRouteScopedPlugin
 import io.ktor.server.auth.principal
 import io.ktor.server.request.uri
 import no.nav.syfo.application.exception.ApiErrorException
+import no.nav.syfo.application.isLocalEnv
 import no.nav.syfo.application.isProdEnv
 import no.nav.syfo.util.logger
 
@@ -20,10 +21,19 @@ val ClientAuthorizationPlugin = createRouteScopedPlugin(
 ) {
     val clientId = pluginConfig.allowedClientId
 
-    val allowedClients = if (isProdEnv()) {
-        listOf(clientId)
-    } else {
-        listOf(clientId, "dev-gcp:nais:tokenx-token-generator", "dev-gcp:nais:azure-token-generator")
+    val allowedClients = when {
+        isProdEnv() -> listOf(clientId)
+        isLocalEnv() ->  listOf(
+            clientId,
+            "dev-gcp:nais:tokenx-token-generator",
+            "dev-gcp:nais:azure-token-generator",
+            "notfound"
+        )
+        else -> listOf(
+            clientId,
+            "dev-gcp:nais:tokenx-token-generator",
+            "dev-gcp:nais:azure-token-generator"
+        )
     }
 
     onCall { call ->

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
@@ -38,11 +38,13 @@ fun DatabaseInterface.persistOppfolgingsplanAndDeleteUtkast(
             stillingsprosent,
             content,
             evalueringsdato,
+            evaluering_paaminnelse,
+            evaluering_paaminnelse_outbox_at,
             skal_deles_med_lege,
             skal_deles_med_veileder,
             utkast_created_at,
             created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
         RETURNING uuid
     """.trimIndent()
 
@@ -74,12 +76,14 @@ fun DatabaseInterface.persistOppfolgingsplanAndDeleteUtkast(
             it.setBigDecimal(8, stillingsprosent)
             it.setObject(9, createOppfolgingsplanRequest.content.toJsonString(), Types.OTHER)
             it.setDate(10, Date.valueOf(createOppfolgingsplanRequest.evalueringsdato.toString()))
-            it.setBoolean(11, false)
-            it.setBoolean(12, false)
+            it.setBoolean(11, createOppfolgingsplanRequest.evalueringPaaminnelse)
+            it.setNull(12, Types.TIMESTAMP_WITH_TIMEZONE)
+            it.setBoolean(13, false)
+            it.setBoolean(14, false)
             if (utkastCreatedAt != null) {
-                it.setTimestamp(13, Timestamp.from(utkastCreatedAt))
+                it.setTimestamp(15, Timestamp.from(utkastCreatedAt))
             } else {
-                it.setNull(13, Types.TIMESTAMP)
+                it.setNull(15, Types.TIMESTAMP)
             }
             val resultSet = it.executeQuery()
             resultSet.next()
@@ -409,6 +413,8 @@ fun ResultSet.mapToOppfolgingsplan(): PersistedOppfolgingsplan = PersistedOppfol
     stillingsprosent = this.getBigDecimal("stillingsprosent"),
     content = FormSnapshot.jsonToFormSnapshot(getString("content")),
     evalueringsdato = LocalDate.parse(this.getString("evalueringsdato")),
+    evalueringPaaminnelse = this.getBoolean("evaluering_paaminnelse"),
+    evalueringPaaminnelseOutboxAt = this.getTimestamp("evaluering_paaminnelse_outbox_at")?.toInstant(),
     skalDelesMedLege = this.getBoolean("skal_deles_med_lege"),
     skalDelesMedVeileder = this.getBoolean("skal_deles_med_veileder"),
     deltMedLegeTidspunkt = this.getTimestamp("delt_med_lege_tidspunkt")?.toInstant(),

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/domain/PersistedOppfolgingsplan.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/domain/PersistedOppfolgingsplan.kt
@@ -25,6 +25,8 @@ data class PersistedOppfolgingsplan(
     val stillingsprosent: BigDecimal? = null,
     val content: FormSnapshot,
     val evalueringsdato: LocalDate,
+    val evalueringPaaminnelse: Boolean = false,
+    val evalueringPaaminnelseOutboxAt: Instant? = null,
     val skalDelesMedLege: Boolean,
     val skalDelesMedVeileder: Boolean,
     val deltMedLegeTidspunkt: Instant? = null,

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/OppfolgingsplanResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/OppfolgingsplanResponse.kt
@@ -29,6 +29,8 @@ data class OppfolgingsplanResponse(
 data class CreateOppfolgingsplanRequest(
     val content: FormSnapshot,
     val evalueringsdato: LocalDate,
+    val evalueringPaaminnelse: Boolean = false,
+
 )
 
 data class DelMedLegeResponse(

--- a/src/main/resources/db/migration/V20__add_evaluering_paaminnelse.sql
+++ b/src/main/resources/db/migration/V20__add_evaluering_paaminnelse.sql
@@ -1,0 +1,3 @@
+ALTER TABLE oppfolgingsplan
+    ADD COLUMN evaluering_paaminnelse BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN evaluering_paaminnelse_outbox_at TIMESTAMPTZ;

--- a/src/main/resources/openapi/arbeidsgiver.yaml
+++ b/src/main/resources/openapi/arbeidsgiver.yaml
@@ -515,6 +515,10 @@ components:
           format: date
           description: Dato for evaluering av oppfølgingsplanen
           example: "2025-12-28"
+        evalueringPaaminnelse:
+          type: boolean
+          description: Boolean som indikerer om arbeidsgiver ønsker påminnelse knyttet til evalueringsdatoen. Hvis feltet mangler tolkes det som false.
+          example: true
 
     CreateUtkastRequest:
       type: object
@@ -531,6 +535,7 @@ components:
             typiskArbeidshverdag: "Beskrivelse av arbeidsdag"
             arbeidsoppgaverSomKanUtfores: "Oppgaver som kan utføres"
             evalueringsDato: "2025-12-28"
+            evalueringPaaminnelse: "true"
 
     OppfolgingsplanOverviewResponse:
       type: object
@@ -750,6 +755,10 @@ components:
           type: string
           description: Versjon av snapshot-formatet
           example: "2.0.0"
+        evalueringPaaminnelse:
+          type: boolean
+          default: false
+          description: Om arbeidsgiver ønsker påminnelse knyttet til evalueringsdatoen. Hvis feltet mangler tolkes det som false.
         sections:
           type: array
           items:

--- a/src/test/http/1.auth.http
+++ b/src/test/http/1.auth.http
@@ -1,5 +1,5 @@
 ### GET idporten token from fakedings
-GET https://fakedings.intern.dev.nav.no/fake/idporten?pid={{pid}} HTTP/1.1
+GET https://fakedings.intern.dev.nav.no/fake/idporten?pid={{pid}}&client_id=local:fakedings HTTP/1.1
 
 > {%
     client.global.set("fakedings_token", response.body);

--- a/src/test/http/2.arbeidsgiver.http
+++ b/src/test/http/2.arbeidsgiver.http
@@ -3,29 +3,7 @@ PUT http://localhost:8080/api/v1/arbeidsgiver/{{narmestelederId}}/oppfolgingspla
 Content-Type: application/json
 Authorization: Bearer {{token}}
 
-{
-  "evalueringsdato": "2025-07-30",
-  "content": {
-    "formIdentifier": "syfo-oppfolgingsplan",
-    "formSemanticVersion": "1.0.0",
-    "formSnapshotVersion": "2.0.0",
-    "sections": [
-      {
-        "sectionId": "arbeidsdag",
-        "sectionTitle": "Arbeidsdag"
-      }
-    ],
-    "fieldSnapshots": [
-        {
-            "fieldId": "arbeidsdag_1",
-            "fieldType": "TEXT",
-            "label": "Beskriv en vanlig arbeidsdag",
-            "value": "Her beskrives en vanlig arbeidsdag for den sykmeldte.",
-            "sectionId": "arbeidsdag"
-        }
-    ]
-  }
-}
+< ./payloads/oppfolginsplan.json
 
 ### Get oppfolgingsplan utkast
 GET http://localhost:8080/api/v1/arbeidsgiver/{{narmestelederId}}/oppfolgingsplaner/utkast HTTP/1.1
@@ -36,55 +14,7 @@ POST http://localhost:8080/api/v1/arbeidsgiver/{{narmestelederId}}/oppfolgingspl
 Content-Type: application/json
 Authorization: Bearer {{token}}
 
-{
-  "evalueringsdato": "2025-09-30",
-  "skalDelesMedLege": false,
-  "skalDelesMedVeileder": false,
-  "content": {
-    "formIdentifier": "syfo-oppfolgingsplan",
-    "formSemanticVersion": "1.0.0",
-    "formSnapshotVersion": "2.0.0",
-    "sections": [
-      {
-        "sectionId": "arbeidsoppgaver",
-        "sectionTitle": "Arbeidsoppgaver"
-      },
-      {
-        "sectionId": "oppfolging",
-        "sectionTitle": "Oppfølging og medvirkning"
-      }
-    ],
-    "fieldSnapshots": [
-      {
-        "fieldId": "arbeidsoppgaver_1",
-        "fieldType": "TEXT",
-        "label": "Hvordan ser en vanlig arbeidsdag ut?",
-        "description": "Beskriv en vanlig arbeidsdag og hvilke oppgaver arbeidstaker gjør på jobben.",
-        "value": "Jeg beskriver en vanlig arbeidsdag for den sykmeldte.",
-        "sectionId": "arbeidsoppgaver"
-      },
-      {
-        "fieldId": "harAnsattDeltatt",
-        "fieldType": "RADIO_GROUP",
-        "label": "Har den ansatte deltatt i utarbeidelsen av planen?",
-        "description": "Hvis du svarer nei blir du bedt om en begrunnelse.",
-        "sectionId": "oppfolging",
-        "options": [
-          {
-            "optionId": "deltattJa",
-            "optionLabel": "Ja",
-            "wasSelected": "true"
-          },
-          {
-            "optionId": "deltattNei",
-            "optionLabel": "Nei",
-            "wasSelected": "false"
-          }
-        ]
-      }
-    ]
-  }
-}
+< ./payloads/oppfolginsplan.json
 
 ### GET Oversikt
 GET http://localhost:8080/api/v1/arbeidsgiver/{{narmestelederId}}/oppfolgingsplaner/oversikt HTTP/1.1

--- a/src/test/http/payloads/oppfolginsplan.json
+++ b/src/test/http/payloads/oppfolginsplan.json
@@ -1,0 +1,69 @@
+{
+  "content": {
+    "formIdentifier": "oppfolgingsplan",
+    "formSemanticVersion": "1.0.0",
+    "formSnapshotVersion": "2.0.0",
+    "sections": [
+      {
+        "fields": [
+          {
+            "description": "Beskriv en vanlig arbeidsdag og hvilke oppgaver arbeidstaker gjør på jobben",
+            "fieldId": "vanligArbeidsdag",
+            "fieldType": "TEXT",
+            "label": "Hvordan ser en vanlig arbeidsdag ut?",
+            "value": "Jeg skriver litt om min vanlige arbeidsdag her",
+            "wasRequired": true
+          },
+          {
+            "description": "Hvilke ordinære arbeidsoppgaver kan forstatt utføres?",
+            "fieldId": "ordinæreArbeidsoppgaver",
+            "fieldType": "TEXT",
+            "label": "Hvilke ordinære arbeidsoppgaver kan forstatt utføres?",
+            "value": "Jeg skriver litt om mine ordinære arbeidsoppgaver her",
+            "wasRequired": true
+          }
+        ],
+        "sectionId": "arbeidsoppgaver",
+        "sectionTitle": "Arbeidsoppgaver"
+      },
+      {
+        "fields": [
+          {
+            "description": "Dette er en beskrivelse av radio gruppen",
+            "fieldId": "arbeidsgiver",
+            "fieldType": "RADIO_GROUP",
+            "label": "Dette er tittelen på en radio gruppe",
+            "options": [
+              {
+                "optionId": "option1",
+                "optionLabel": "Dette er option 1"
+              },
+              {
+                "optionId": "option2",
+                "optionLabel": "Dette er option 2"
+              },
+              {
+                "optionId": "option3",
+                "optionLabel": "Dette er option 3"
+              }
+            ],
+            "selectedOptionId": "option2",
+            "wasRequired": true
+          },
+          {
+            "description": "Dato for når oppfølgingsplanen skal evalueres",
+            "fieldId": "evalueringsDato",
+            "fieldType": "DATE",
+            "label": "Evalueringsdato",
+            "value": "2026-07-12",
+            "wasRequired": true
+          }
+        ],
+        "sectionId": "tilpasninger",
+        "sectionTitle": "Tilpasninger"
+      }
+    ]
+  },
+  "evalueringsdato": "2026-07-12",
+  "evalueringPaaminnelse": true
+}

--- a/src/test/kotlin/no/nav/syfo/TestDb.kt
+++ b/src/test/kotlin/no/nav/syfo/TestDb.kt
@@ -117,13 +117,15 @@ fun DatabaseInterface.persistOppfolgingsplan(
             stillingsprosent,
             content,
             evalueringsdato,
+            evaluering_paaminnelse,
+            evaluering_paaminnelse_outbox_at,
             skal_deles_med_lege,
             skal_deles_med_veileder,
             created_at,
             skjult_fra,
             feilregistrert,
             feilregistrert_aarsak
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         RETURNING uuid
     """.trimIndent()
 
@@ -140,20 +142,26 @@ fun DatabaseInterface.persistOppfolgingsplan(
             it.setBigDecimal(9, persistedOppfolgingsplan.stillingsprosent)
             it.setObject(10, persistedOppfolgingsplan.content.toJsonString(), Types.OTHER)
             it.setDate(11, Date.valueOf(persistedOppfolgingsplan.evalueringsdato.toString()))
-            it.setBoolean(12, persistedOppfolgingsplan.skalDelesMedLege)
-            it.setBoolean(13, persistedOppfolgingsplan.skalDelesMedVeileder)
-            it.setTimestamp(14, Timestamp.from(persistedOppfolgingsplan.createdAt))
-            if (persistedOppfolgingsplan.skjultFra != null) {
-                it.setTimestamp(15, Timestamp.from(persistedOppfolgingsplan.skjultFra))
+            it.setBoolean(12, persistedOppfolgingsplan.evalueringPaaminnelse)
+            if (persistedOppfolgingsplan.evalueringPaaminnelseOutboxAt != null) {
+                it.setTimestamp(13, Timestamp.from(persistedOppfolgingsplan.evalueringPaaminnelseOutboxAt))
             } else {
-                it.setNull(15, Types.TIMESTAMP_WITH_TIMEZONE)
+                it.setNull(13, Types.TIMESTAMP_WITH_TIMEZONE)
+            }
+            it.setBoolean(14, persistedOppfolgingsplan.skalDelesMedLege)
+            it.setBoolean(15, persistedOppfolgingsplan.skalDelesMedVeileder)
+            it.setTimestamp(16, Timestamp.from(persistedOppfolgingsplan.createdAt))
+            if (persistedOppfolgingsplan.skjultFra != null) {
+                it.setTimestamp(17, Timestamp.from(persistedOppfolgingsplan.skjultFra))
+            } else {
+                it.setNull(17, Types.TIMESTAMP_WITH_TIMEZONE)
             }
             if (persistedOppfolgingsplan.feilregistrert != null) {
-                it.setTimestamp(16, Timestamp.from(persistedOppfolgingsplan.feilregistrert))
+                it.setTimestamp(18, Timestamp.from(persistedOppfolgingsplan.feilregistrert))
             } else {
-                it.setNull(16, Types.TIMESTAMP_WITH_TIMEZONE)
+                it.setNull(18, Types.TIMESTAMP_WITH_TIMEZONE)
             }
-            it.setString(17, persistedOppfolgingsplan.feilregistrertAarsak)
+            it.setString(19, persistedOppfolgingsplan.feilregistrertAarsak)
             val resultSet = it.executeQuery()
             connection.commit()
             resultSet.next()

--- a/src/test/kotlin/no/nav/syfo/TestUtils.kt
+++ b/src/test/kotlin/no/nav/syfo/TestUtils.kt
@@ -52,6 +52,7 @@ fun defaultUtkastRequest(mutate: MutableMap<String, String?>.() -> Unit = {}): L
 fun defaultOppfolgingsplan() = CreateOppfolgingsplanRequest(
     content = defaultFormSnapshot(),
     evalueringsdato = LocalDate.now().plus(30, ChronoUnit.DAYS),
+    evalueringPaaminnelse = false,
 )
 
 fun defaultPersistedOppfolgingsplan() = PersistedOppfolgingsplan(
@@ -64,6 +65,8 @@ fun defaultPersistedOppfolgingsplan() = PersistedOppfolgingsplan(
     stillingstittel = "Systemutvikler",
     stillingsprosent = BigDecimal("100.00"),
     content = defaultFormSnapshot(),
+    evalueringPaaminnelse = false,
+    evalueringPaaminnelseOutboxAt = null,
     skalDelesMedLege = false,
     skalDelesMedVeileder = false,
     uuid = UUID.randomUUID(),

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
@@ -491,6 +491,8 @@ class OppfolgingsplanApiV1Test :
                     persisted.first().organisasjonsnummer shouldBe sykmeldt.orgnummer
                     persisted.first().content.toString() shouldBe oppfolgingsplan.content.toString()
                     persisted.first().evalueringsdato.toString() shouldBe oppfolgingsplan.evalueringsdato.toString()
+                    persisted.first().evalueringPaaminnelse shouldBe false
+                    persisted.first().evalueringPaaminnelseOutboxAt shouldBe null
                     persisted.first().sykmeldtFullName shouldBe "Navn Sykmeldt"
                     persisted.first().organisasjonsnavn shouldBe "Test AS"
                     persisted.first().stillingstittel shouldBe "Systemutvikler"

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanSchemaTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanSchemaTest.kt
@@ -1,0 +1,63 @@
+package no.nav.syfo.oppfolgingsplan.db
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import no.nav.syfo.TestDB
+
+class OppfolgingsplanSchemaTest :
+    DescribeSpec({
+        describe("oppfolgingsplan schema") {
+            it("should add evaluering paaminnelse columns only on oppfolgingsplan") {
+                val oppfolgingsplanColumns = TestDB.database.connection.use { connection ->
+                    connection.metaData.getColumns(null, null, "oppfolgingsplan", null).use { resultSet ->
+                        buildList {
+                            while (resultSet.next()) {
+                                add(
+                                    ColumnMetadata(
+                                        name = resultSet.getString("COLUMN_NAME"),
+                                        isNullable = resultSet.getString("IS_NULLABLE") == "YES",
+                                        defaultValue = resultSet.getString("COLUMN_DEF"),
+                                    ),
+                                )
+                            }
+                        }
+                    }
+                }
+                val utkastColumns = TestDB.database.connection.use { connection ->
+                    connection.metaData.getColumns(null, null, "oppfolgingsplan_utkast", null).use { resultSet ->
+                        buildList {
+                            while (resultSet.next()) {
+                                add(resultSet.getString("COLUMN_NAME"))
+                            }
+                        }
+                    }
+                }
+
+                oppfolgingsplanColumns.map { it.name }.filter { it.startsWith("evaluering_paaminnelse") }
+                    .shouldContainExactlyInAnyOrder(
+                        "evaluering_paaminnelse",
+                        "evaluering_paaminnelse_outbox_at",
+                    )
+                utkastColumns shouldNotContain "evaluering_paaminnelse"
+                utkastColumns shouldNotContain "evaluering_paaminnelse_outbox_at"
+
+                oppfolgingsplanColumns.find { it.name == "evaluering_paaminnelse" }.shouldNotBeNull().apply {
+                    isNullable shouldBe false
+                    defaultValue shouldBe "false"
+                }
+
+                oppfolgingsplanColumns.find { it.name == "evaluering_paaminnelse_outbox_at" }.shouldNotBeNull().apply {
+                    isNullable shouldBe true
+                }
+            }
+        }
+    })
+
+private data class ColumnMetadata(
+    val name: String,
+    val isNullable: Boolean,
+    val defaultValue: String?,
+)


### PR DESCRIPTION
## Beskrivelse

Denne PR-en legger til støtte for å lagre ønske om evalueringspåminnelse for oppfølgingsplaner.

Ønsket kan ligge i eksisterende utkast-`content`, uten nye kolonner på `oppfolgingsplan_utkast`. Når utkastet blir til en ferdig oppfølgingsplan, lagres verdien i nye kolonner på `oppfolgingsplan`.

`evaluering_paaminnelse_outbox_at` opprettes som nullable felt, men settes ikke i denne PR-en. En senere jobb skal vurdere om varsel skal sendes, opprette outbox-rad og sette timestamp.

## Endringer

- Flyway V20: lagt til `evaluering_paaminnelse` og nullable `evaluering_paaminnelse_outbox_at` på `oppfolgingsplan`.
- DAO/domain/responsmodell: lagrer og leser evalueringspåminnelse for ferdige oppfølgingsplaner.
- OpenAPI: dokumenterer `evalueringPaaminnelse` i `FormSnapshot`, og at utkast kan sende verdien i eksisterende `content` som string.
- Tester: dekker schema, bakoverkompatibel JSON-deserialisering og lagring av valgt påminnelse.
- Test-HTTP/payload: oppdatert lokal testpayload for opprettelse av oppfølgingsplan.
- Dev-oppsett: justert lokal auth/test-konfig for enklere bruk mot testendepunktene.

## Issue

Closes #332

Del av epic: #330

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet automatisk med `./gradlew --no-daemon build`
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

