### PR TITLE
feat(paaminnelse): ta imot frivillig påminnelse

### DIFF
--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -67,7 +67,7 @@ spec:
     inbound:
       rules:
         - application: syfo-oppfolgingsplan-frontend
-        - application: dinesykmeldte-backend
+        - application: dinesykmeldte
         - application: tokenx-token-generator
           namespace: nais
         - application: azure-token-generator
@@ -121,7 +121,7 @@ spec:
       value: dev-fss.arbeidsforhold.aareg-services-nais
     - name: SYFOMODIAPERSON_CLIENT_ID
       value: dev-gcp:teamsykefravr:syfomodiaperson
-    - name: DINESYKMELDTE_BACKEND_CLIENT_ID
-      value: dev-gcp:team-esyfo:dinesykmeldte-backend
+    - name: DINESYKMELDTE_CLIENT_ID
+      value: dev-gcp:team-esyfo:dinesykmeldte
     - name: SYFO_OPPFOLGINGSPLAN_FRONTEND_CLIENT_ID
       value: dev-gcp:team-esyfo:syfo-oppfolgingsplan-frontend

--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -67,6 +67,7 @@ spec:
     inbound:
       rules:
         - application: syfo-oppfolgingsplan-frontend
+        - application: dinesykmeldte-backend
         - application: tokenx-token-generator
           namespace: nais
         - application: azure-token-generator
@@ -120,5 +121,7 @@ spec:
       value: dev-fss.arbeidsforhold.aareg-services-nais
     - name: SYFOMODIAPERSON_CLIENT_ID
       value: dev-gcp:teamsykefravr:syfomodiaperson
+    - name: DINESYKMELDTE_BACKEND_CLIENT_ID
+      value: dev-gcp:team-esyfo:dinesykmeldte-backend
     - name: SYFO_OPPFOLGINGSPLAN_FRONTEND_CLIENT_ID
       value: dev-gcp:team-esyfo:syfo-oppfolgingsplan-frontend

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -67,7 +67,7 @@ spec:
     inbound:
       rules:
         - application: syfo-oppfolgingsplan-frontend
-        - application: dinesykmeldte-backend
+        - application: dinesykmeldte
         - application: syfomodiaperson
           namespace: teamsykefravr
     outbound:
@@ -75,7 +75,7 @@ spec:
         - application: syfo-dokumentporten
         - application: syfooppdfgen
         - application: dinesykmeldte-backend
-        - application: isdialogmelding
+        - application: isdialogmeldingdinesykmeldte-backend
           namespace: teamsykefravr
         - application: istilgangskontroll
           namespace: teamsykefravr
@@ -117,7 +117,7 @@ spec:
       value: prod-fss.arbeidsforhold.aareg-services-nais
     - name: SYFOMODIAPERSON_CLIENT_ID
       value: prod-gcp:teamsykefravr:syfomodiaperson
-    - name: DINESYKMELDTE_BACKEND_CLIENT_ID
-      value: prod-gcp:team-esyfo:dinesykmeldte-backend
+    - name: DINESYKMELDTE_CLIENT_ID
+      value: prod-gcp:team-esyfo:dinesykmeldte
     - name: SYFO_OPPFOLGINGSPLAN_FRONTEND_CLIENT_ID
       value: prod-gcp:team-esyfo:syfo-oppfolgingsplan-frontend

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -75,7 +75,7 @@ spec:
         - application: syfo-dokumentporten
         - application: syfooppdfgen
         - application: dinesykmeldte-backend
-        - application: isdialogmeldingdinesykmeldte-backend
+        - application: isdialogmelding
           namespace: teamsykefravr
         - application: istilgangskontroll
           namespace: teamsykefravr

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -67,6 +67,7 @@ spec:
     inbound:
       rules:
         - application: syfo-oppfolgingsplan-frontend
+        - application: dinesykmeldte-backend
         - application: syfomodiaperson
           namespace: teamsykefravr
     outbound:
@@ -116,5 +117,7 @@ spec:
       value: prod-fss.arbeidsforhold.aareg-services-nais
     - name: SYFOMODIAPERSON_CLIENT_ID
       value: prod-gcp:teamsykefravr:syfomodiaperson
+    - name: DINESYKMELDTE_BACKEND_CLIENT_ID
+      value: prod-gcp:team-esyfo:dinesykmeldte-backend
     - name: SYFO_OPPFOLGINGSPLAN_FRONTEND_CLIENT_ID
       value: prod-gcp:team-esyfo:syfo-oppfolgingsplan-frontend

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -26,6 +26,7 @@ interface Environment {
     val kafka: KafkaEnv
     val electorPath: String
     val syfomodiapersonClientId: String
+    val dinesykmeldteBackendClientId: String
     val syfoOppfolgingsplanFrontendClientId: String
 }
 
@@ -70,6 +71,7 @@ data class NaisEnvironment(
     override val kafka: KafkaEnv = KafkaEnv.createFromEnvVars(),
     override val electorPath: String = getEnvVar("ELECTOR_PATH"),
     override val syfomodiapersonClientId: String = getEnvVar("SYFOMODIAPERSON_CLIENT_ID"),
+    override val dinesykmeldteBackendClientId: String = getEnvVar("DINESYKMELDTE_BACKEND_CLIENT_ID"),
     override val syfoOppfolgingsplanFrontendClientId: String = getEnvVar("SYFO_OPPFOLGINGSPLAN_FRONTEND_CLIENT_ID"),
 ) : Environment
 
@@ -121,5 +123,6 @@ data class LocalEnvironment(
     override val kafka: KafkaEnv = KafkaEnv.createForLocal(),
     override val electorPath: String = "/elector",
     override val syfomodiapersonClientId: String = "dev-gcp:teamsykefravr:syfomodiaperson",
+    override val dinesykmeldteBackendClientId: String = "dev-gcp:team-esyfo:dinesykmeldte-backend",
     override val syfoOppfolgingsplanFrontendClientId: String = "dev-gcp:team-esyfo:syfo-oppfolgingsplan-frontend",
 ) : Environment

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -26,7 +26,7 @@ interface Environment {
     val kafka: KafkaEnv
     val electorPath: String
     val syfomodiapersonClientId: String
-    val dinesykmeldteBackendClientId: String
+    val dinesykmeldteClientId: String
     val syfoOppfolgingsplanFrontendClientId: String
 }
 
@@ -71,7 +71,7 @@ data class NaisEnvironment(
     override val kafka: KafkaEnv = KafkaEnv.createFromEnvVars(),
     override val electorPath: String = getEnvVar("ELECTOR_PATH"),
     override val syfomodiapersonClientId: String = getEnvVar("SYFOMODIAPERSON_CLIENT_ID"),
-    override val dinesykmeldteBackendClientId: String = getEnvVar("DINESYKMELDTE_BACKEND_CLIENT_ID"),
+    override val dinesykmeldteClientId: String = getEnvVar("DINESYKMELDTE_CLIENT_ID"),
     override val syfoOppfolgingsplanFrontendClientId: String = getEnvVar("SYFO_OPPFOLGINGSPLAN_FRONTEND_CLIENT_ID"),
 ) : Environment
 
@@ -123,6 +123,6 @@ data class LocalEnvironment(
     override val kafka: KafkaEnv = KafkaEnv.createForLocal(),
     override val electorPath: String = "/elector",
     override val syfomodiapersonClientId: String = "dev-gcp:teamsykefravr:syfomodiaperson",
-    override val dinesykmeldteBackendClientId: String = "dev-gcp:team-esyfo:dinesykmeldte-backend",
+    override val dinesykmeldteClientId: String = "dev-gcp:team-esyfo:dinesykmeldte",
     override val syfoOppfolgingsplanFrontendClientId: String = "dev-gcp:team-esyfo:syfo-oppfolgingsplan-frontend",
 ) : Environment

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -12,8 +12,10 @@ import no.nav.syfo.dinesykmeldte.DineSykmeldteService
 import no.nav.syfo.dokarkiv.DokarkivService
 import no.nav.syfo.isdialogmelding.IsDialogmeldingService
 import no.nav.syfo.istilgangskontroll.IsTilgangskontrollService
+import no.nav.syfo.oppfolgingsplan.api.v1.narmesteleder.registerPaaminnelseApi
 import no.nav.syfo.oppfolgingsplan.api.v1.registerApiV1
 import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
+import no.nav.syfo.oppfolgingsplan.service.PaaminnelseService
 import no.nav.syfo.pdfgen.PdfGenService
 import no.nav.syfo.plugins.installCallId
 import no.nav.syfo.plugins.installContentNegotiation
@@ -27,6 +29,7 @@ fun Application.configureRouting() {
     val texasHttpClient by inject<TexasHttpClient>()
     val dineSykmeldteService by inject<DineSykmeldteService>()
     val oppfolgingsplanService by inject<OppfolgingsplanService>()
+    val paaminnelseService by inject<PaaminnelseService>()
     val pdfGenService by inject<PdfGenService>()
     val isDialogmeldingService by inject<IsDialogmeldingService>()
     val isTilgangskontrollService by inject<IsTilgangskontrollService>()
@@ -40,6 +43,7 @@ fun Application.configureRouting() {
     routing {
         if (!isProdEnv()) {
             swaggerUI(path = "swagger/arbeidsgiver", swaggerFile = "openapi/arbeidsgiver.yaml")
+            swaggerUI(path = "swagger/paaminnelse", swaggerFile = "openapi/paaminnelse.yaml")
             swaggerUI(path = "swagger/sykmeldt", swaggerFile = "openapi/sykmeldt.yaml")
             swaggerUI(path = "swagger/veileder", swaggerFile = "openapi/veileder.yaml")
         }
@@ -53,6 +57,12 @@ fun Application.configureRouting() {
             isDialogmeldingService = isDialogmeldingService,
             isTilgangskontrollService = isTilgangskontrollService,
             dokarkivService = dokarkivService,
+            environment = environment,
+        )
+        registerPaaminnelseApi(
+            dineSykmeldteService = dineSykmeldteService,
+            texasHttpClient = texasHttpClient,
+            paaminnelseService = paaminnelseService,
             environment = environment,
         )
     }

--- a/src/main/kotlin/no/nav/syfo/application/auth/ClientAuthorizationPlugin.kt
+++ b/src/main/kotlin/no/nav/syfo/application/auth/ClientAuthorizationPlugin.kt
@@ -23,14 +23,11 @@ val ClientAuthorizationPlugin = createRouteScopedPlugin(
 
     val allowedClients = when {
         isProdEnv() -> listOf(clientId)
-        isLocalEnv() ->  listOf(
-            clientId,
-            "local:fakedings"
-        )
+        isLocalEnv() -> listOf(clientId, "local:fakedings")
         else -> listOf(
             clientId,
             "dev-gcp:nais:tokenx-token-generator",
-            "dev-gcp:nais:azure-token-generator"
+            "dev-gcp:nais:azure-token-generator",
         )
     }
 

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/OppfolginsplanAPiMetrics.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/OppfolginsplanAPiMetrics.kt
@@ -10,6 +10,8 @@ const val OPPFOLGINGSPLAN_SHARED_WITH_NAV = "${METRICS_NS}_oppfolgingsplan_share
 const val OPPFOLGINGSPLAN_DRAFT_MANUALLY_DELETED = "${METRICS_NS}_oppfolgingsplan_draft_manually_deleted"
 const val OPPFOLGINGSPLAN_DRAFT_AUTO_DELETED = "${METRICS_NS}_oppfolgingsplan_draft_auto_deleted"
 const val OPPFOLGINGSPLAN_SOFT_DELETED = "${METRICS_NS}_oppfolgingsplan_soft_deleted"
+const val PAAMINNELSE_BESTILT = "${METRICS_NS}_paaminnelse_bestilt"
+const val PAAMINNELSE_AVBESTILT = "${METRICS_NS}_paaminnelse_avbestilt"
 
 val COUNT_OPPFOLGINGSPLAN_CREATED: Counter = Counter.builder(OPPFOLGINGSPLAN_CREATED)
     .description("Counts the number of created oppfolgingsplans")
@@ -28,4 +30,10 @@ val COUNT_OPPFOLGINGSPLAN_DRAFT_AUTO_DELETED: Counter = Counter.builder(OPPFOLGI
     .register(METRICS_REGISTRY)
 val COUNT_OPPFOLGINGSPLAN_SOFT_DELETED: Counter = Counter.builder(OPPFOLGINGSPLAN_SOFT_DELETED)
     .description("Counts the number of oppfolgingsplaner soft-deleted by cleanup task")
+    .register(METRICS_REGISTRY)
+val COUNT_PAAMINNELSE_BESTILT: Counter = Counter.builder(PAAMINNELSE_BESTILT)
+    .description("Counts the number of times a paaminnelse is ordered")
+    .register(METRICS_REGISTRY)
+val COUNT_PAAMINNELSE_AVBESTILT: Counter = Counter.builder(PAAMINNELSE_AVBESTILT)
+    .description("Counts the number of times a paaminnelse is cancelled")
     .register(METRICS_REGISTRY)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/AuthorizeLeaderAccessToSykmeldtPlugin.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/AuthorizeLeaderAccessToSykmeldtPlugin.kt
@@ -38,7 +38,6 @@ val AuthorizeLeaderAccessToSykmeldtPlugin = createRouteScopedPlugin(
                 )
 
             val narmesteLederId = call.parameters["narmesteLederId"]
-                ?: call.parameters["narmestelederId"]
                 ?: throw ApiErrorException.BadRequest("Missing narmesteLederId parameter in request")
 
             val innloggetBruker = call.principal<BrukerPrincipal>()

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/AuthorizeLeaderAccessToSykmeldtPlugin.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/AuthorizeLeaderAccessToSykmeldtPlugin.kt
@@ -38,6 +38,7 @@ val AuthorizeLeaderAccessToSykmeldtPlugin = createRouteScopedPlugin(
                 )
 
             val narmesteLederId = call.parameters["narmesteLederId"]
+                ?: call.parameters["narmestelederId"]
                 ?: throw ApiErrorException.BadRequest("Missing narmesteLederId parameter in request")
 
             val innloggetBruker = call.principal<BrukerPrincipal>()

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/PaaminnelseApi.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/PaaminnelseApi.kt
@@ -1,0 +1,69 @@
+package no.nav.syfo.oppfolgingsplan.api.v1.narmesteleder
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import no.nav.syfo.application.Environment
+import no.nav.syfo.application.auth.ClientAuthorizationPlugin
+import no.nav.syfo.dinesykmeldte.DineSykmeldteService
+import no.nav.syfo.oppfolgingsplan.api.v1.COUNT_PAAMINNELSE_AVBESTILT
+import no.nav.syfo.oppfolgingsplan.api.v1.COUNT_PAAMINNELSE_BESTILT
+import no.nav.syfo.oppfolgingsplan.api.v1.arbeidsgiver.AuthorizeLeaderAccessToSykmeldtPlugin
+import no.nav.syfo.oppfolgingsplan.api.v1.arbeidsgiver.CALL_ATTRIBUTE_SYKMELDT
+import no.nav.syfo.oppfolgingsplan.service.PaaminnelseService
+import no.nav.syfo.texas.TexasTokenXAuthPlugin
+import no.nav.syfo.texas.client.TexasHttpClient
+
+fun Route.registerPaaminnelseApi(
+    dineSykmeldteService: DineSykmeldteService,
+    texasHttpClient: TexasHttpClient,
+    paaminnelseService: PaaminnelseService,
+    environment: Environment,
+) {
+    route("/api/v1/narmesteleder/{narmesteLederId}/oppfolgingsplaner/paaminnelse") {
+        install(TexasTokenXAuthPlugin) {
+            client = texasHttpClient
+        }
+        install(ClientAuthorizationPlugin) {
+            allowedClientId = environment.dinesykmeldteBackendClientId
+        }
+        install(AuthorizeLeaderAccessToSykmeldtPlugin) {
+            this.texasHttpClient = texasHttpClient
+            this.dineSykmeldteService = dineSykmeldteService
+        }
+
+        get {
+            val sykmeldt = call.attributes[CALL_ATTRIBUTE_SYKMELDT]
+            call.respond(
+                HttpStatusCode.OK,
+                paaminnelseService.getPaaminnelseStatus(sykmeldt),
+            )
+        }
+
+        post {
+            val sykmeldt = call.attributes[CALL_ATTRIBUTE_SYKMELDT]
+
+            val response = paaminnelseService.bestillPaaminnelse(
+                sykmeldt = sykmeldt,
+            )
+
+            COUNT_PAAMINNELSE_BESTILT.increment()
+            call.respond(HttpStatusCode.OK, response)
+        }
+
+        delete {
+            val sykmeldt = call.attributes[CALL_ATTRIBUTE_SYKMELDT]
+
+            val response = paaminnelseService.avbestillPaaminnelse(
+                sykmeldt = sykmeldt,
+            )
+
+            COUNT_PAAMINNELSE_AVBESTILT.increment()
+            call.respond(HttpStatusCode.OK, response)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/PaaminnelseApi.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/PaaminnelseApi.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.oppfolgingsplan.api.v1.narmesteleder
 
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.delete
@@ -46,13 +47,16 @@ fun Route.registerPaaminnelseApi(
 
         post {
             val sykmeldt = call.attributes[CALL_ATTRIBUTE_SYKMELDT]
+            if (sykmeldt.aktivSykmelding == true) {
+                val response = paaminnelseService.bestillPaaminnelse(
+                    sykmeldt = sykmeldt,
+                )
 
-            val response = paaminnelseService.bestillPaaminnelse(
-                sykmeldt = sykmeldt,
-            )
-
-            COUNT_PAAMINNELSE_BESTILT.increment()
-            call.respond(HttpStatusCode.OK, response)
+                COUNT_PAAMINNELSE_BESTILT.increment()
+                call.respond(HttpStatusCode.OK, response)
+            } else {
+                throw BadRequestException("Kan ikke bestille påminnelse for sykmeldt uten aktiv sykmelding")
+            }
         }
 
         delete {

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/PaaminnelseApi.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/PaaminnelseApi.kt
@@ -48,7 +48,7 @@ fun Route.registerPaaminnelseApi(
         post {
             val sykmeldt = call.attributes[CALL_ATTRIBUTE_SYKMELDT]
             if (sykmeldt.aktivSykmelding == true) {
-                val response = paaminnelseService.bestillPaaminnelse(
+                val response = paaminnelseService.activatePaaminnelse(
                     sykmeldt = sykmeldt,
                 )
 
@@ -62,7 +62,7 @@ fun Route.registerPaaminnelseApi(
         delete {
             val sykmeldt = call.attributes[CALL_ATTRIBUTE_SYKMELDT]
 
-            val response = paaminnelseService.avbestillPaaminnelse(
+            val response = paaminnelseService.deactivatePaaminnelse(
                 sykmeldt = sykmeldt,
             )
 

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/PaaminnelseApi.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/PaaminnelseApi.kt
@@ -30,7 +30,7 @@ fun Route.registerPaaminnelseApi(
             client = texasHttpClient
         }
         install(ClientAuthorizationPlugin) {
-            allowedClientId = environment.dinesykmeldteBackendClientId
+            allowedClientId = environment.dinesykmeldteClientId
         }
         install(AuthorizeLeaderAccessToSykmeldtPlugin) {
             this.texasHttpClient = texasHttpClient

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/PaaminnelseApi.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/PaaminnelseApi.kt
@@ -1,7 +1,6 @@
 package no.nav.syfo.oppfolgingsplan.api.v1.narmesteleder
 
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.delete
@@ -47,16 +46,12 @@ fun Route.registerPaaminnelseApi(
 
         post {
             val sykmeldt = call.attributes[CALL_ATTRIBUTE_SYKMELDT]
-            if (sykmeldt.aktivSykmelding == true) {
-                val response = paaminnelseService.activatePaaminnelse(
-                    sykmeldt = sykmeldt,
-                )
+            val response = paaminnelseService.activatePaaminnelse(
+                sykmeldt = sykmeldt,
+            )
 
-                COUNT_PAAMINNELSE_BESTILT.increment()
-                call.respond(HttpStatusCode.OK, response)
-            } else {
-                throw BadRequestException("Kan ikke bestille påminnelse for sykmeldt uten aktiv sykmelding")
-            }
+            COUNT_PAAMINNELSE_BESTILT.increment()
+            call.respond(HttpStatusCode.OK, response)
         }
 
         delete {

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/PaaminnelseDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/PaaminnelseDAO.kt
@@ -1,0 +1,75 @@
+package no.nav.syfo.oppfolgingsplan.db
+
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.dinesykmeldte.client.Sykmeldt
+import no.nav.syfo.oppfolgingsplan.db.domain.PersistedPaaminnelse
+import java.sql.ResultSet
+
+fun DatabaseInterface.upsertPaaminnelse(
+    sykmeldt: Sykmeldt,
+    bestilt: Boolean,
+): PersistedPaaminnelse {
+    val statement =
+        """
+        INSERT INTO paaminnelse (
+            organisasjonsnummer,
+            sykmeldt_fnr,
+            bestilt,
+            created_at,
+            updated_at
+        ) VALUES (?, ?, ?, NOW(), NOW())
+        ON CONFLICT (sykmeldt_fnr, organisasjonsnummer) DO UPDATE SET
+            bestilt = EXCLUDED.bestilt,
+            updated_at = NOW()
+        RETURNING *
+        """.trimIndent()
+
+    connection.use { connection ->
+        connection.prepareStatement(statement).use { preparedStatement ->
+            preparedStatement.setString(1, sykmeldt.orgnummer)
+            preparedStatement.setString(2, sykmeldt.fnr)
+            preparedStatement.setBoolean(3, bestilt)
+
+            val resultSet = preparedStatement.executeQuery()
+            connection.commit()
+            resultSet.next()
+
+            return resultSet.toPersistedPaaminnelse()
+        }
+    }
+}
+
+fun DatabaseInterface.findPaaminnelseBy(
+    sykmeldtFnr: String,
+    organisasjonsnummer: String,
+): PersistedPaaminnelse? {
+    val statement =
+        """
+        SELECT *
+        FROM paaminnelse
+        WHERE sykmeldt_fnr = ?
+          AND organisasjonsnummer = ?
+        """.trimIndent()
+
+    connection.use { connection ->
+        connection.prepareStatement(statement).use { preparedStatement ->
+            preparedStatement.setString(1, sykmeldtFnr)
+            preparedStatement.setString(2, organisasjonsnummer)
+            val resultSet = preparedStatement.executeQuery()
+
+            return if (resultSet.next()) {
+                resultSet.toPersistedPaaminnelse()
+            } else {
+                null
+            }
+        }
+    }
+}
+
+private fun ResultSet.toPersistedPaaminnelse(): PersistedPaaminnelse = PersistedPaaminnelse(
+    organisasjonsnummer = getString("organisasjonsnummer"),
+    sykmeldtFnr = getString("sykmeldt_fnr"),
+    bestilt = getBoolean("bestilt"),
+    createdAt = getTimestamp("created_at").toInstant(),
+    updatedAt = getTimestamp("updated_at").toInstant(),
+)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/PaaminnelseDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/PaaminnelseDAO.kt
@@ -25,10 +25,11 @@ fun DatabaseInterface.upsertPaaminnelse(
         """.trimIndent()
 
     connection.use { connection ->
+        var idx = 0
         connection.prepareStatement(statement).use { preparedStatement ->
-            preparedStatement.setString(1, sykmeldt.orgnummer)
-            preparedStatement.setString(2, sykmeldt.fnr)
-            preparedStatement.setBoolean(3, bestilt)
+            preparedStatement.setString(++idx, sykmeldt.orgnummer)
+            preparedStatement.setString(++idx, sykmeldt.fnr)
+            preparedStatement.setBoolean(++idx, bestilt)
 
             val resultSet = preparedStatement.executeQuery()
             connection.commit()
@@ -52,9 +53,10 @@ fun DatabaseInterface.findPaaminnelseBy(
         """.trimIndent()
 
     connection.use { connection ->
+        var idx = 0
         connection.prepareStatement(statement).use { preparedStatement ->
-            preparedStatement.setString(1, sykmeldtFnr)
-            preparedStatement.setString(2, organisasjonsnummer)
+            preparedStatement.setString(++idx, sykmeldtFnr)
+            preparedStatement.setString(++idx, organisasjonsnummer)
             val resultSet = preparedStatement.executeQuery()
 
             return if (resultSet.next()) {

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/domain/PersistedPaaminnelse.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/domain/PersistedPaaminnelse.kt
@@ -1,0 +1,18 @@
+package no.nav.syfo.oppfolgingsplan.db.domain
+
+import no.nav.syfo.oppfolgingsplan.dto.PaaminnelseStatus
+import java.time.Instant
+
+data class PersistedPaaminnelse(
+    val organisasjonsnummer: String,
+    val sykmeldtFnr: String,
+    val bestilt: Boolean,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+)
+
+fun PersistedPaaminnelse?.toStatus(): PaaminnelseStatus = if (this?.bestilt == true) {
+    PaaminnelseStatus.BESTILT
+} else {
+    PaaminnelseStatus.TILGJENGELIG
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/PaaminnelseStatusDto.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/PaaminnelseStatusDto.kt
@@ -1,0 +1,14 @@
+package no.nav.syfo.oppfolgingsplan.dto
+
+import java.time.LocalDate
+
+enum class PaaminnelseStatus {
+    SKJULT,
+    TILGJENGELIG,
+    BESTILT,
+}
+
+data class PaaminnelseStatusDto(
+    val status: PaaminnelseStatus,
+    val synligFra: LocalDate? = null,
+)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/PaaminnelseService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/PaaminnelseService.kt
@@ -1,0 +1,74 @@
+package no.nav.syfo.oppfolgingsplan.service
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.dinesykmeldte.client.Sykmeldt
+import no.nav.syfo.oppfolgingsplan.db.domain.toStatus
+import no.nav.syfo.oppfolgingsplan.db.findAllOppfolgingsplanerBy
+import no.nav.syfo.oppfolgingsplan.db.findPaaminnelseBy
+import no.nav.syfo.oppfolgingsplan.db.upsertPaaminnelse
+import no.nav.syfo.oppfolgingsplan.dto.PaaminnelseStatus
+import no.nav.syfo.oppfolgingsplan.dto.PaaminnelseStatusDto
+import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
+import java.time.Clock
+import java.time.LocalDate
+
+class PaaminnelseService(
+    private val database: DatabaseInterface,
+    private val sykmeldingsperiodeRepository: SykmeldingsperiodeRepository,
+    private val clock: Clock = Clock.system(java.time.ZoneId.of("Europe/Oslo")),
+) {
+    suspend fun getPaaminnelseStatus(
+        sykmeldt: Sykmeldt,
+    ): PaaminnelseStatusDto = withContext(Dispatchers.IO) {
+        val synligFra = sykmeldingsperiodeRepository.findEarliestFom(
+            sykmeldtFnr = sykmeldt.fnr,
+            organisasjonsnummer = sykmeldt.orgnummer,
+        )
+
+        when {
+            sykmeldt.aktivSykmelding != true -> PaaminnelseStatusDto(PaaminnelseStatus.SKJULT, synligFra)
+            synligFra == null -> PaaminnelseStatusDto(PaaminnelseStatus.SKJULT)
+            database.findAllOppfolgingsplanerBy(sykmeldt.fnr, sykmeldt.orgnummer).isNotEmpty() ->
+                PaaminnelseStatusDto(PaaminnelseStatus.SKJULT, synligFra)
+            !erInnenforBestillingsvindu(synligFra) -> PaaminnelseStatusDto(PaaminnelseStatus.SKJULT, synligFra)
+            else -> PaaminnelseStatusDto(
+                status = database.findPaaminnelseBy(sykmeldt.fnr, sykmeldt.orgnummer).toStatus(),
+                synligFra = synligFra,
+            )
+        }
+    }
+
+    suspend fun bestillPaaminnelse(
+        sykmeldt: Sykmeldt,
+    ): PaaminnelseStatusDto = withContext(Dispatchers.IO) {
+        val synligFra = sykmeldingsperiodeRepository.findEarliestFom(
+            sykmeldtFnr = sykmeldt.fnr,
+            organisasjonsnummer = sykmeldt.orgnummer,
+        )
+        database.upsertPaaminnelse(
+            sykmeldt = sykmeldt,
+            bestilt = true,
+        )
+        PaaminnelseStatusDto(PaaminnelseStatus.BESTILT, synligFra)
+    }
+
+    suspend fun avbestillPaaminnelse(
+        sykmeldt: Sykmeldt,
+    ): PaaminnelseStatusDto = withContext(Dispatchers.IO) {
+        val synligFra = sykmeldingsperiodeRepository.findEarliestFom(
+            sykmeldtFnr = sykmeldt.fnr,
+            organisasjonsnummer = sykmeldt.orgnummer,
+        )
+        database.upsertPaaminnelse(
+            sykmeldt = sykmeldt,
+            bestilt = false,
+        )
+        PaaminnelseStatusDto(PaaminnelseStatus.TILGJENGELIG, synligFra)
+    }
+
+    internal fun erInnenforBestillingsvindu(
+        synligFra: LocalDate,
+    ): Boolean = LocalDate.now(clock).isBefore(synligFra.plusWeeks(4))
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/PaaminnelseService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/PaaminnelseService.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.oppfolgingsplan.service
 
+import io.ktor.server.plugins.BadRequestException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import no.nav.syfo.application.database.DatabaseInterface
@@ -22,14 +23,48 @@ class PaaminnelseService(
     suspend fun getPaaminnelseStatus(
         sykmeldt: Sykmeldt,
     ): PaaminnelseStatusDto = withContext(Dispatchers.IO) {
-        val today = LocalDate.now(clock)
+        getPaaminnelseStatusInternal(sykmeldt, LocalDate.now(clock))
+    }
+
+    suspend fun activatePaaminnelse(
+        sykmeldt: Sykmeldt,
+    ): PaaminnelseStatusDto = withContext(Dispatchers.IO) {
+        val status = getPaaminnelseStatusInternal(sykmeldt, LocalDate.now(clock))
+        requireVisiblePaaminnelseStatus(status)
+        database.upsertPaaminnelse(
+            sykmeldt = sykmeldt,
+            bestilt = true,
+        )
+        PaaminnelseStatusDto(PaaminnelseStatus.BESTILT, status.synligFra)
+    }
+
+    suspend fun deactivatePaaminnelse(
+        sykmeldt: Sykmeldt,
+    ): PaaminnelseStatusDto = withContext(Dispatchers.IO) {
+        val status = getPaaminnelseStatusInternal(sykmeldt, LocalDate.now(clock))
+        requireVisiblePaaminnelseStatus(status)
+        database.upsertPaaminnelse(
+            sykmeldt = sykmeldt,
+            bestilt = false,
+        )
+        PaaminnelseStatusDto(PaaminnelseStatus.TILGJENGELIG, status.synligFra)
+    }
+
+    internal fun erInnenforBestillingsvindu(
+        synligFra: LocalDate,
+    ): Boolean = LocalDate.now(clock).isBefore(synligFra.plusDays(PAAMINNELLSE_ETTER_DAGER))
+
+    private fun getPaaminnelseStatusInternal(
+        sykmeldt: Sykmeldt,
+        today: LocalDate,
+    ): PaaminnelseStatusDto {
         val synligFra = sykmeldingsperiodeRepository.findEarliestFom(
             sykmeldtFnr = sykmeldt.fnr,
             organisasjonsnummer = sykmeldt.orgnummer,
             today = today,
         )
 
-        when {
+        return when {
             sykmeldt.aktivSykmelding != true -> PaaminnelseStatusDto(PaaminnelseStatus.SKJULT, synligFra)
             synligFra == null -> PaaminnelseStatusDto(PaaminnelseStatus.SKJULT)
             database.findAllOppfolgingsplanerBy(sykmeldt.fnr, sykmeldt.orgnummer)
@@ -44,41 +79,11 @@ class PaaminnelseService(
         }
     }
 
-    suspend fun activatePaaminnelse(
-        sykmeldt: Sykmeldt,
-    ): PaaminnelseStatusDto = withContext(Dispatchers.IO) {
-        val today = LocalDate.now(clock)
-        val synligFra = sykmeldingsperiodeRepository.findEarliestFom(
-            sykmeldtFnr = sykmeldt.fnr,
-            organisasjonsnummer = sykmeldt.orgnummer,
-            today = today,
-        )
-        database.upsertPaaminnelse(
-            sykmeldt = sykmeldt,
-            bestilt = true,
-        )
-        PaaminnelseStatusDto(PaaminnelseStatus.BESTILT, synligFra)
+    private fun requireVisiblePaaminnelseStatus(status: PaaminnelseStatusDto) {
+        if (status.status == PaaminnelseStatus.SKJULT) {
+            throw BadRequestException("Kan ikke endre påminnelse når påminnelse er skjult")
+        }
     }
-
-    suspend fun deactivatePaaminnelse(
-        sykmeldt: Sykmeldt,
-    ): PaaminnelseStatusDto = withContext(Dispatchers.IO) {
-        val today = LocalDate.now(clock)
-        val synligFra = sykmeldingsperiodeRepository.findEarliestFom(
-            sykmeldtFnr = sykmeldt.fnr,
-            organisasjonsnummer = sykmeldt.orgnummer,
-            today = today,
-        )
-        database.upsertPaaminnelse(
-            sykmeldt = sykmeldt,
-            bestilt = false,
-        )
-        PaaminnelseStatusDto(PaaminnelseStatus.TILGJENGELIG, synligFra)
-    }
-
-    internal fun erInnenforBestillingsvindu(
-        synligFra: LocalDate,
-    ): Boolean = LocalDate.now(clock).isBefore(synligFra.plusDays(PAAMINNELLSE_ETTER_DAGER))
 
     private companion object {
         const val PAAMINNELLSE_ETTER_DAGER = 24L

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/PaaminnelseService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/PaaminnelseService.kt
@@ -34,6 +34,7 @@ class PaaminnelseService(
             synligFra == null -> PaaminnelseStatusDto(PaaminnelseStatus.SKJULT)
             database.findAllOppfolgingsplanerBy(sykmeldt.fnr, sykmeldt.orgnummer).isNotEmpty() ->
                 PaaminnelseStatusDto(PaaminnelseStatus.SKJULT, synligFra)
+
             !erInnenforBestillingsvindu(synligFra) -> PaaminnelseStatusDto(PaaminnelseStatus.SKJULT, synligFra)
             else -> PaaminnelseStatusDto(
                 status = database.findPaaminnelseBy(sykmeldt.fnr, sykmeldt.orgnummer).toStatus(),
@@ -42,7 +43,7 @@ class PaaminnelseService(
         }
     }
 
-    suspend fun bestillPaaminnelse(
+    suspend fun activatePaaminnelse(
         sykmeldt: Sykmeldt,
     ): PaaminnelseStatusDto = withContext(Dispatchers.IO) {
         val today = LocalDate.now(clock)
@@ -58,7 +59,7 @@ class PaaminnelseService(
         PaaminnelseStatusDto(PaaminnelseStatus.BESTILT, synligFra)
     }
 
-    suspend fun avbestillPaaminnelse(
+    suspend fun deactivatePaaminnelse(
         sykmeldt: Sykmeldt,
     ): PaaminnelseStatusDto = withContext(Dispatchers.IO) {
         val today = LocalDate.now(clock)
@@ -78,7 +79,7 @@ class PaaminnelseService(
         synligFra: LocalDate,
     ): Boolean = LocalDate.now(clock).isBefore(synligFra.plusDays(PAAMINNELLSE_ETTER_DAGER))
 
-    companion object {
+    private companion object {
         const val PAAMINNELLSE_ETTER_DAGER = 24L
     }
 }

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/PaaminnelseService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/PaaminnelseService.kt
@@ -22,9 +22,11 @@ class PaaminnelseService(
     suspend fun getPaaminnelseStatus(
         sykmeldt: Sykmeldt,
     ): PaaminnelseStatusDto = withContext(Dispatchers.IO) {
+        val today = LocalDate.now(clock)
         val synligFra = sykmeldingsperiodeRepository.findEarliestFom(
             sykmeldtFnr = sykmeldt.fnr,
             organisasjonsnummer = sykmeldt.orgnummer,
+            today = today,
         )
 
         when {
@@ -43,9 +45,11 @@ class PaaminnelseService(
     suspend fun bestillPaaminnelse(
         sykmeldt: Sykmeldt,
     ): PaaminnelseStatusDto = withContext(Dispatchers.IO) {
+        val today = LocalDate.now(clock)
         val synligFra = sykmeldingsperiodeRepository.findEarliestFom(
             sykmeldtFnr = sykmeldt.fnr,
             organisasjonsnummer = sykmeldt.orgnummer,
+            today = today,
         )
         database.upsertPaaminnelse(
             sykmeldt = sykmeldt,
@@ -57,9 +61,11 @@ class PaaminnelseService(
     suspend fun avbestillPaaminnelse(
         sykmeldt: Sykmeldt,
     ): PaaminnelseStatusDto = withContext(Dispatchers.IO) {
+        val today = LocalDate.now(clock)
         val synligFra = sykmeldingsperiodeRepository.findEarliestFom(
             sykmeldtFnr = sykmeldt.fnr,
             organisasjonsnummer = sykmeldt.orgnummer,
+            today = today,
         )
         database.upsertPaaminnelse(
             sykmeldt = sykmeldt,
@@ -70,5 +76,9 @@ class PaaminnelseService(
 
     internal fun erInnenforBestillingsvindu(
         synligFra: LocalDate,
-    ): Boolean = LocalDate.now(clock).isBefore(synligFra.plusWeeks(4))
+    ): Boolean = LocalDate.now(clock).isBefore(synligFra.plusDays(PAAMINNELLSE_ETTER_DAGER))
+
+    companion object {
+        const val PAAMINNELLSE_ETTER_DAGER = 24L
+    }
 }

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/PaaminnelseService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/PaaminnelseService.kt
@@ -32,7 +32,8 @@ class PaaminnelseService(
         when {
             sykmeldt.aktivSykmelding != true -> PaaminnelseStatusDto(PaaminnelseStatus.SKJULT, synligFra)
             synligFra == null -> PaaminnelseStatusDto(PaaminnelseStatus.SKJULT)
-            database.findAllOppfolgingsplanerBy(sykmeldt.fnr, sykmeldt.orgnummer).isNotEmpty() ->
+            database.findAllOppfolgingsplanerBy(sykmeldt.fnr, sykmeldt.orgnummer)
+                .any { it.createdAt >= synligFra.atStartOfDay(clock.zone).toInstant() } ->
                 PaaminnelseStatusDto(PaaminnelseStatus.SKJULT, synligFra)
 
             !erInnenforBestillingsvindu(synligFra) -> PaaminnelseStatusDto(PaaminnelseStatus.SKJULT, synligFra)

--- a/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
@@ -36,6 +36,7 @@ import no.nav.syfo.istilgangskontroll.IsTilgangskontrollService
 import no.nav.syfo.istilgangskontroll.client.FakeIsTilgangskontrollClient
 import no.nav.syfo.istilgangskontroll.client.IsTilgangskontrollClient
 import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
+import no.nav.syfo.oppfolgingsplan.service.PaaminnelseService
 import no.nav.syfo.oppfolgingsplan.task.CleanupUtkastTask
 import no.nav.syfo.oppfolgingsplan.task.SoftDeleteOppfolgingsplanerTask
 import no.nav.syfo.pdfgen.PdfGenService
@@ -205,6 +206,7 @@ private fun servicesModule() = module {
     single { PdlService(get()) }
     single { AaregService(get()) }
     single { OppfolgingsplanService(database = get(), esyfovarselProducer = get(), pdlService = get(), aaregService = get()) }
+    single { PaaminnelseService(database = get(), sykmeldingsperiodeRepository = get()) }
     single { PdfGenService(get(), get()) }
     single { SendOppfolgingsplanTask(get(), get()) }
     single { CleanupUtkastTask(get(), get()) }

--- a/src/main/kotlin/no/nav/syfo/sykmelding/db/SykmeldingsperiodeRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/db/SykmeldingsperiodeRepository.kt
@@ -92,6 +92,29 @@ class SykmeldingsperiodeRepository(
             }
         }
     }
+
+    fun findEarliestFom(
+        sykmeldtFnr: String,
+        organisasjonsnummer: String,
+    ): java.time.LocalDate? {
+        val statement = """
+            SELECT MIN(fom) AS earliest_fom
+            FROM sykmeldingsperiode
+            WHERE sykmeldt_fnr = ?
+              AND organisasjonsnummer = ?
+              AND invalidated_at IS NULL
+        """.trimIndent()
+
+        return database.connection.use { connection ->
+            connection.prepareStatement(statement).use { preparedStatement ->
+                preparedStatement.setString(1, sykmeldtFnr)
+                preparedStatement.setString(2, organisasjonsnummer)
+                preparedStatement.executeQuery().use { resultSet ->
+                    if (resultSet.next()) resultSet.getDate("earliest_fom")?.toLocalDate() else null
+                }
+            }
+        }
+    }
 }
 
 private fun ResultSet.toPersistedSykmeldingsperiode(): PersistedSykmeldingsperiode = PersistedSykmeldingsperiode(

--- a/src/main/kotlin/no/nav/syfo/sykmelding/db/SykmeldingsperiodeRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/db/SykmeldingsperiodeRepository.kt
@@ -6,6 +6,7 @@ import no.nav.syfo.sykmelding.db.domain.SykmeldingsperiodeToStore
 import java.sql.Date
 import java.sql.ResultSet
 import java.sql.Statement
+import java.time.LocalDate
 import java.util.UUID
 
 class SykmeldingsperiodeRepository(
@@ -96,24 +97,41 @@ class SykmeldingsperiodeRepository(
     fun findEarliestFom(
         sykmeldtFnr: String,
         organisasjonsnummer: String,
-    ): java.time.LocalDate? {
+        today: LocalDate,
+    ): LocalDate? {
+        val lookbackDate = today.minusDays(FIND_EARLIEST_FOM_LOOKBACK_DAYS.toLong())
         val statement = """
-            SELECT MIN(fom) AS earliest_fom
+            SELECT fom, tom
             FROM sykmeldingsperiode
             WHERE sykmeldt_fnr = ?
               AND organisasjonsnummer = ?
               AND invalidated_at IS NULL
+              AND fom <= ?
+              AND tom >= ?
+            ORDER BY tom DESC, fom DESC
         """.trimIndent()
 
-        return database.connection.use { connection ->
+        val sykmeldingsperioder = database.connection.use { connection ->
             connection.prepareStatement(statement).use { preparedStatement ->
                 preparedStatement.setString(1, sykmeldtFnr)
                 preparedStatement.setString(2, organisasjonsnummer)
+                preparedStatement.setDate(3, Date.valueOf(today))
+                preparedStatement.setDate(4, Date.valueOf(lookbackDate))
                 preparedStatement.executeQuery().use { resultSet ->
-                    if (resultSet.next()) resultSet.getDate("earliest_fom")?.toLocalDate() else null
+                    buildList {
+                        while (resultSet.next()) {
+                            add(resultSet.toSykmeldingsperiodeInterval())
+                        }
+                    }
                 }
             }
         }
+
+        return sykmeldingsperioder.findEarliestContinuousFom(today)
+    }
+
+    private companion object {
+        const val FIND_EARLIEST_FOM_LOOKBACK_DAYS = 50
     }
 }
 
@@ -127,3 +145,38 @@ private fun ResultSet.toPersistedSykmeldingsperiode(): PersistedSykmeldingsperio
     invalidatedAt = getTimestamp("invalidated_at")?.toInstant(),
     createdAt = getTimestamp("created_at").toInstant(),
 )
+
+private data class SykmeldingsperiodeInterval(
+    val fom: LocalDate,
+    val tom: LocalDate,
+)
+
+private fun ResultSet.toSykmeldingsperiodeInterval(): SykmeldingsperiodeInterval = SykmeldingsperiodeInterval(
+    fom = getDate("fom").toLocalDate(),
+    tom = getDate("tom").toLocalDate(),
+)
+
+private fun List<SykmeldingsperiodeInterval>.findEarliestContinuousFom(
+    today: LocalDate,
+): LocalDate? {
+    val periodsSortedForBackwardTraversal = sortedWith(
+        compareByDescending<SykmeldingsperiodeInterval> { it.tom }.thenByDescending { it.fom },
+    )
+
+    val activePeriods = periodsSortedForBackwardTraversal.filter { period ->
+        !period.fom.isAfter(today) && !period.tom.isBefore(today)
+    }
+    if (activePeriods.isEmpty()) {
+        return null
+    }
+
+    var earliestFom = activePeriods.minOf { it.fom }
+
+    for (period in periodsSortedForBackwardTraversal) {
+        if (period.fom.isBefore(earliestFom) && !period.tom.plusDays(1).isBefore(earliestFom)) {
+            earliestFom = period.fom
+        }
+    }
+
+    return earliestFom
+}

--- a/src/main/kotlin/no/nav/syfo/sykmelding/db/SykmeldingsperiodeRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/db/SykmeldingsperiodeRepository.kt
@@ -112,11 +112,12 @@ class SykmeldingsperiodeRepository(
         """.trimIndent()
 
         val sykmeldingsperioder = database.connection.use { connection ->
+            var idx = 0
             connection.prepareStatement(statement).use { preparedStatement ->
-                preparedStatement.setString(1, sykmeldtFnr)
-                preparedStatement.setString(2, organisasjonsnummer)
-                preparedStatement.setDate(3, Date.valueOf(today))
-                preparedStatement.setDate(4, Date.valueOf(lookbackDate))
+                preparedStatement.setString(++idx, sykmeldtFnr)
+                preparedStatement.setString(++idx, organisasjonsnummer)
+                preparedStatement.setDate(++idx, Date.valueOf(today))
+                preparedStatement.setDate(++idx, Date.valueOf(lookbackDate))
                 preparedStatement.executeQuery().use { resultSet ->
                     buildList {
                         while (resultSet.next()) {

--- a/src/main/resources/db/migration/V21__create_paaminnelse_table.sql
+++ b/src/main/resources/db/migration/V21__create_paaminnelse_table.sql
@@ -1,8 +1,0 @@
-CREATE TABLE paaminnelse (
-    organisasjonsnummer TEXT NOT NULL,
-    sykmeldt_fnr TEXT NOT NULL,
-    bestilt BOOLEAN NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    PRIMARY KEY (sykmeldt_fnr, organisasjonsnummer)
-);

--- a/src/main/resources/db/migration/V21__create_paaminnelse_table.sql
+++ b/src/main/resources/db/migration/V21__create_paaminnelse_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE paaminnelse (
+    organisasjonsnummer TEXT NOT NULL,
+    sykmeldt_fnr TEXT NOT NULL,
+    bestilt BOOLEAN NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (sykmeldt_fnr, organisasjonsnummer)
+);

--- a/src/main/resources/db/migration/V22__create_paaminnelse_table.sql
+++ b/src/main/resources/db/migration/V22__create_paaminnelse_table.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS paaminnelse;
+CREATE TABLE IF NOT EXISTS paaminnelse
+(
+    uuid                UUID PRIMARY KEY NOT NULL DEFAULT gen_random_uuid(),
+    organisasjonsnummer TEXT             NOT NULL,
+    sykmeldt_fnr        TEXT             NOT NULL,
+    bestilt             BOOLEAN          NOT NULL,
+    created_at          TIMESTAMPTZ      NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ      NOT NULL DEFAULT NOW(),
+    outbox_at           TIMESTAMPTZ               DEFAULT NULL,
+    UNIQUE (organisasjonsnummer, sykmeldt_fnr)
+);

--- a/src/main/resources/openapi/paaminnelse.yaml
+++ b/src/main/resources/openapi/paaminnelse.yaml
@@ -1,0 +1,114 @@
+openapi: "3.1.0"
+info:
+  title: "Oppfølgingsplan API - Påminnelse"
+  description: |
+    Intern kontrakt for dinesykmeldte-backend mot syfo-oppfolgingsplan-backend
+    for bestilling og lesing av påminnelse om oppfølgingsplan.
+  version: "1.0.0"
+servers:
+  - url: http://localhost:8080
+    description: Lokal utvikling
+  - url: https://syfo-oppfolgingsplan-backend.intern.dev.nav.no
+    description: Dev-miljø
+paths:
+  /api/v1/narmesteleder/{narmestelederId}/oppfolgingsplaner/paaminnelse:
+    get:
+      summary: Hent status for påminnelse
+      operationId: getPaaminnelseStatus
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/NarmestelederId'
+      responses:
+        '200':
+          description: Nåværende påminnelsesstatus
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaaminnelseStatusDto'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/SykmeldtNotFound'
+    post:
+      summary: Bestill påminnelse
+      operationId: bestillPaaminnelse
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/NarmestelederId'
+      responses:
+        '200':
+          description: Påminnelse bestilt
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaaminnelseStatusDto'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/SykmeldtNotFound'
+    delete:
+      summary: Avbestill påminnelse
+      operationId: avbestillPaaminnelse
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/NarmestelederId'
+      responses:
+        '200':
+          description: Påminnelse avbestilt
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaaminnelseStatusDto'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/SykmeldtNotFound'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    NarmestelederId:
+      name: narmestelederId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    Unauthorized:
+      description: Manglende eller ugyldig autentisering
+    Forbidden:
+      description: Ikke autorisert for relasjonen
+    SykmeldtNotFound:
+      description: Relasjonen finnes ikke eller er ikke tilgjengelig
+  schemas:
+    PaaminnelseStatus:
+      type: string
+      enum:
+        - SKJULT
+        - TILGJENGELIG
+        - BESTILT
+    PaaminnelseStatusDto:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          $ref: '#/components/schemas/PaaminnelseStatus'
+        synligFra:
+          type: string
+          format: date
+          nullable: true

--- a/src/main/resources/openapi/paaminnelse.yaml
+++ b/src/main/resources/openapi/paaminnelse.yaml
@@ -46,6 +46,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaaminnelseStatusDto'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -88,6 +90,8 @@ components:
         type: string
         format: uuid
   responses:
+    BadRequest:
+      description: Ugyldig forespørsel, for eksempel hvis det ikke er en aktiv sykmelding
     Unauthorized:
       description: Manglende eller ugyldig autentisering
     Forbidden:

--- a/src/main/resources/openapi/paaminnelse.yaml
+++ b/src/main/resources/openapi/paaminnelse.yaml
@@ -2,7 +2,7 @@ openapi: "3.1.0"
 info:
   title: "Oppfølgingsplan API - Påminnelse"
   description: |
-    Intern kontrakt for dinesykmeldte-backend mot syfo-oppfolgingsplan-backend
+    Intern kontrakt for dinesykmeldte mot syfo-oppfolgingsplan-backend
     for bestilling og lesing av påminnelse om oppfølgingsplan.
   version: "1.0.0"
 servers:

--- a/src/test/http/2.arbeidsgiver.http
+++ b/src/test/http/2.arbeidsgiver.http
@@ -35,3 +35,20 @@ Authorization: Bearer {{token}}
 ### GET Oppfolgingsplan by uuid
 GET http://localhost:8080/api/v1/arbeidsgiver/{{narmestelederId}}/oppfolgingsplaner/{{oppflgingsplanUuid}} HTTP/1.1
 Authorization: Bearer {{token}}
+
+
+### POST Påminnelse
+POST http://localhost:8080/api/v1/narmesteleder/{{narmestelederId}}/oppfolgingsplaner/paaminnelse HTTP/1.1
+Authorization: Bearer {{token}}
+
+### GET Påminnelse
+GET http://localhost:8080/api/v1/narmesteleder/{{narmestelederId}}/oppfolgingsplaner/paaminnelse HTTP/1.1
+Authorization: Bearer {{token}}
+
+### DELETE Påminnelse
+DELETE http://localhost:8080/api/v1/narmesteleder/{{narmestelederId}}/oppfolgingsplaner/paaminnelse HTTP/1.1
+Authorization: Bearer {{token}}
+
+### GET Påminnelse
+GET http://localhost:8080/api/v1/narmesteleder/{{narmestelederId}}/oppfolgingsplaner/paaminnelse HTTP/1.1
+Authorization: Bearer {{token}}

--- a/src/test/http/5.narmesteleder.http
+++ b/src/test/http/5.narmesteleder.http
@@ -1,0 +1,15 @@
+### POST Påminnelse
+POST http://localhost:8080/api/v1/narmesteleder/{{narmestelederId}}/oppfolgingsplaner/paaminnelse HTTP/1.1
+Authorization: Bearer {{token}}
+
+### GET Påminnelse
+GET http://localhost:8080/api/v1/narmesteleder/{{narmestelederId}}/oppfolgingsplaner/paaminnelse HTTP/1.1
+Authorization: Bearer {{token}}
+
+### DELETE Påminnelse
+DELETE http://localhost:8080/api/v1/narmesteleder/{{narmestelederId}}/oppfolgingsplaner/paaminnelse HTTP/1.1
+Authorization: Bearer {{token}}
+
+### GET Påminnelse
+GET http://localhost:8080/api/v1/narmesteleder/{{narmestelederId}}/oppfolgingsplaner/paaminnelse HTTP/1.1
+Authorization: Bearer {{token}}

--- a/src/test/kotlin/no/nav/syfo/TestDb.kt
+++ b/src/test/kotlin/no/nav/syfo/TestDb.kt
@@ -91,6 +91,7 @@ class TestDB private constructor() {
             it
                 .prepareStatement(
                     """
+                    DELETE FROM paaminnelse;
                     DELETE FROM sykmeldingsperiode;
                     DELETE FROM oppfolgingsplan_utkast;
                     DELETE FROM oppfolgingsplan;

--- a/src/test/kotlin/no/nav/syfo/aareg/client/AaregClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/aareg/client/AaregClientTest.kt
@@ -26,7 +26,7 @@ class AaregClientTest :
         val wireMockServer = WireMockServer(options().dynamicPort())
 
         beforeTest {
-            clearAllMocks()
+            clearAllMocks(currentThreadOnly = true)
             wireMockServer.start()
         }
 

--- a/src/test/kotlin/no/nav/syfo/dinesykmeldte/DineSykmeldteServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/dinesykmeldte/DineSykmeldteServiceTest.kt
@@ -23,7 +23,7 @@ class DineSykmeldteServiceTest :
         val lederFnr = "12345678901"
         val token = "token"
 
-        beforeTest { clearAllMocks() }
+        beforeTest { clearAllMocks(currentThreadOnly = true) }
 
         describe("getSykmeldtForNarmesteleder") {
             it("returns cached sykmeldt and does not call http client on cache hit") {

--- a/src/test/kotlin/no/nav/syfo/dokarkiv/DokarkivServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/dokarkiv/DokarkivServiceTest.kt
@@ -16,7 +16,7 @@ class DokarkivServiceTest :
         val dokarkivService = DokarkivService(dokarkivClient)
 
         beforeTest {
-            clearAllMocks()
+            clearAllMocks(currentThreadOnly = true)
         }
 
         describe("DokarkivService") {

--- a/src/test/kotlin/no/nav/syfo/dokumentporten/DokumentportenQueriesTest.kt
+++ b/src/test/kotlin/no/nav/syfo/dokumentporten/DokumentportenQueriesTest.kt
@@ -16,7 +16,7 @@ class DokumentportenQueriesTest :
         val testDb = TestDB.database
 
         beforeTest {
-            clearAllMocks()
+            clearAllMocks(currentThreadOnly = true)
             TestDB.clearAllData()
         }
 

--- a/src/test/kotlin/no/nav/syfo/dokumentporten/DokumentportenServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/dokumentporten/DokumentportenServiceTest.kt
@@ -34,7 +34,7 @@ class DokumentportenServiceTest :
         )
 
         beforeTest {
-            clearAllMocks()
+            clearAllMocks(currentThreadOnly = true)
             TestDB.clearAllData()
         }
         fun addDefaultOppfolgingsplanerToDb(): PersistedOppfolgingsplan = defaultPersistedOppfolgingsplan().let {

--- a/src/test/kotlin/no/nav/syfo/dokumentporten/client/DokumentportenClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/dokumentporten/client/DokumentportenClientTest.kt
@@ -18,7 +18,7 @@ class DokumentportenClientTest :
     DescribeSpec({
         val texasClient = mockk<TexasHttpClient>()
 
-        beforeTest { clearAllMocks() }
+        beforeTest { clearAllMocks(currentThreadOnly = true) }
 
         describe("DokumentportenClient") {
             // Arrange

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
@@ -95,7 +95,7 @@ class OppfolgingsplanApiV1Test :
         val isTilgangskontrollServiceMock = IsTilgangskontrollService(isTilgangskontrollClientMock)
 
         beforeTest {
-            clearAllMocks()
+            clearAllMocks(currentThreadOnly = true)
             TestDB.clearAllData()
             every { valkeyCacheMock.getSykmeldt(any(), any()) } returns null
             coEvery { aaregServiceMock.getStillingsinformasjon(any(), any()) } returns Stillingsinformasjon(

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanUtkastApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanUtkastApiV1Test.kt
@@ -82,7 +82,7 @@ class OppfolgingsplanUtkastApiV1Test :
         val environment: Environment = LocalEnvironment()
 
         beforeTest {
-            clearAllMocks()
+            clearAllMocks(currentThreadOnly = true)
             TestDB.clearAllData()
             every { valkeyCacheMock.getSykmeldt(any(), any()) } returns null
         }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/PaaminnelseApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/PaaminnelseApiTest.kt
@@ -29,13 +29,16 @@ import no.nav.syfo.application.exception.ApiError
 import no.nav.syfo.application.exception.ErrorType
 import no.nav.syfo.application.valkey.ValkeyCache
 import no.nav.syfo.defaultMocks
+import no.nav.syfo.defaultPersistedOppfolgingsplan
 import no.nav.syfo.defaultSykmeldt
 import no.nav.syfo.dinesykmeldte.DineSykmeldteService
 import no.nav.syfo.dinesykmeldte.client.DineSykmeldteHttpClient
 import no.nav.syfo.oppfolgingsplan.db.findPaaminnelseBy
+import no.nav.syfo.oppfolgingsplan.db.upsertPaaminnelse
 import no.nav.syfo.oppfolgingsplan.dto.PaaminnelseStatus
 import no.nav.syfo.oppfolgingsplan.dto.PaaminnelseStatusDto
 import no.nav.syfo.oppfolgingsplan.service.PaaminnelseService
+import no.nav.syfo.persistOppfolgingsplan
 import no.nav.syfo.plugins.installContentNegotiation
 import no.nav.syfo.plugins.installStatusPages
 import no.nav.syfo.returnsNotFound
@@ -43,6 +46,7 @@ import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
 import no.nav.syfo.sykmelding.db.domain.SykmeldingsperiodeToStore
 import no.nav.syfo.texas.client.TexasHttpClient
 import java.time.LocalDate
+import java.time.ZoneId
 
 class PaaminnelseApiTest :
     DescribeSpec({
@@ -169,6 +173,34 @@ class PaaminnelseApiTest :
                 }
             }
 
+            it("GET should return SKJULT when an oppfolgingsplan already exists in the current syketilfelle") {
+                withTestApplication {
+                    val startDato = LocalDate.now().minusDays(7)
+                    seedAktivtSyketilfelle(startDato)
+                    testDb.persistOppfolgingsplan(
+                        defaultPersistedOppfolgingsplan().copy(
+                            createdAt = startDato.atStartOfDay(ZoneId.of("Europe/Oslo")).toInstant(),
+                        ),
+                    )
+                    texasClientMock.defaultMocks(
+                        pid = pidInnloggetBruker,
+                        clientId = environment.dinesykmeldteClientId,
+                    )
+                    dineSykmeldteHttpClientMock.defaultMocks(narmestelederId = narmestelederId)
+
+                    val response = client.get {
+                        url("/api/v1/narmesteleder/$narmestelederId/oppfolgingsplaner/paaminnelse")
+                        bearerAuth("Bearer token")
+                    }
+
+                    response.status shouldBe HttpStatusCode.OK
+                    response.body<PaaminnelseStatusDto>() shouldBe PaaminnelseStatusDto(
+                        status = PaaminnelseStatus.SKJULT,
+                        synligFra = startDato,
+                    )
+                }
+            }
+
             it("POST should persist BESTILT") {
                 withTestApplication {
                     seedAktivtSyketilfelle()
@@ -208,6 +240,32 @@ class PaaminnelseApiTest :
                         narmestelederId = narmestelederId,
                         aktivSykmelding = false,
                     )
+
+                    val response = client.post {
+                        url("/api/v1/narmesteleder/$narmestelederId/oppfolgingsplaner/paaminnelse")
+                        bearerAuth("Bearer token")
+                    }
+
+                    response.status shouldBe HttpStatusCode.BadRequest
+                    response.body<ApiError>().type shouldBe ErrorType.BAD_REQUEST
+                    countPaaminnelseRows() shouldBe 0
+                }
+            }
+
+            it("POST should respond with BadRequest when status is SKJULT because an oppfolgingsplan already exists in the current syketilfelle") {
+                withTestApplication {
+                    val startDato = LocalDate.now().minusDays(7)
+                    seedAktivtSyketilfelle(startDato)
+                    testDb.persistOppfolgingsplan(
+                        defaultPersistedOppfolgingsplan().copy(
+                            createdAt = startDato.atStartOfDay(ZoneId.of("Europe/Oslo")).toInstant(),
+                        ),
+                    )
+                    texasClientMock.defaultMocks(
+                        pid = pidInnloggetBruker,
+                        clientId = environment.dinesykmeldteClientId,
+                    )
+                    dineSykmeldteHttpClientMock.defaultMocks(narmestelederId = narmestelederId)
 
                     val response = client.post {
                         url("/api/v1/narmesteleder/$narmestelederId/oppfolgingsplaner/paaminnelse")
@@ -264,6 +322,30 @@ class PaaminnelseApiTest :
                     response.status shouldBe HttpStatusCode.OK
                     response.body<PaaminnelseStatusDto>().status shouldBe PaaminnelseStatus.TILGJENGELIG
                     testDb.findPaaminnelseBy("12345678901", "orgnummer")?.bestilt shouldBe false
+                }
+            }
+
+            it("DELETE should respond with BadRequest when status is SKJULT because the ordering window has passed") {
+                withTestApplication {
+                    seedAktivtSyketilfelle(startDato = LocalDate.now().minusDays(30))
+                    testDb.upsertPaaminnelse(
+                        sykmeldt = defaultSykmeldt(),
+                        bestilt = true,
+                    )
+                    texasClientMock.defaultMocks(
+                        pid = pidInnloggetBruker,
+                        clientId = environment.dinesykmeldteClientId,
+                    )
+                    dineSykmeldteHttpClientMock.defaultMocks(narmestelederId = narmestelederId)
+
+                    val response = client.delete {
+                        url("/api/v1/narmesteleder/$narmestelederId/oppfolgingsplaner/paaminnelse")
+                        bearerAuth("Bearer token")
+                    }
+
+                    response.status shouldBe HttpStatusCode.BadRequest
+                    response.body<ApiError>().type shouldBe ErrorType.BAD_REQUEST
+                    testDb.findPaaminnelseBy("12345678901", "orgnummer")?.bestilt shouldBe true
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/PaaminnelseApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/PaaminnelseApiTest.kt
@@ -19,6 +19,7 @@ import io.ktor.server.routing.routing
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import io.mockk.clearAllMocks
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.syfo.TestDB
@@ -28,6 +29,7 @@ import no.nav.syfo.application.exception.ApiError
 import no.nav.syfo.application.exception.ErrorType
 import no.nav.syfo.application.valkey.ValkeyCache
 import no.nav.syfo.defaultMocks
+import no.nav.syfo.defaultSykmeldt
 import no.nav.syfo.dinesykmeldte.DineSykmeldteService
 import no.nav.syfo.dinesykmeldte.client.DineSykmeldteHttpClient
 import no.nav.syfo.oppfolgingsplan.db.findPaaminnelseBy
@@ -188,6 +190,33 @@ class PaaminnelseApiTest :
                     persisted?.bestilt shouldBe true
                     persisted?.sykmeldtFnr shouldBe "12345678901"
                     persisted?.organisasjonsnummer shouldBe "orgnummer"
+                }
+            }
+
+            it("POST should respond with BadRequest when sykmeldt has no active sykmelding") {
+                withTestApplication {
+                    texasClientMock.defaultMocks(
+                        pid = pidInnloggetBruker,
+                        clientId = environment.dinesykmeldteBackendClientId,
+                    )
+                    coEvery {
+                        dineSykmeldteHttpClientMock.getSykmeldtForNarmesteLederId(
+                            narmestelederId,
+                            "token",
+                        )
+                    } returns defaultSykmeldt().copy(
+                        narmestelederId = narmestelederId,
+                        aktivSykmelding = false,
+                    )
+
+                    val response = client.post {
+                        url("/api/v1/narmesteleder/$narmestelederId/oppfolgingsplaner/paaminnelse")
+                        bearerAuth("Bearer token")
+                    }
+
+                    response.status shouldBe HttpStatusCode.BadRequest
+                    response.body<ApiError>().type shouldBe ErrorType.BAD_REQUEST
+                    countPaaminnelseRows() shouldBe 0
                 }
             }
 

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/PaaminnelseApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/PaaminnelseApiTest.kt
@@ -132,7 +132,7 @@ class PaaminnelseApiTest :
                 withTestApplication {
                     texasClientMock.defaultMocks(
                         pid = pidInnloggetBruker,
-                        clientId = environment.dinesykmeldteBackendClientId,
+                        clientId = environment.dinesykmeldteClientId,
                     )
                     dineSykmeldteHttpClientMock.returnsNotFound(narmestelederId = narmestelederId)
 
@@ -152,7 +152,7 @@ class PaaminnelseApiTest :
                     seedAktivtSyketilfelle(startDato)
                     texasClientMock.defaultMocks(
                         pid = pidInnloggetBruker,
-                        clientId = environment.dinesykmeldteBackendClientId,
+                        clientId = environment.dinesykmeldteClientId,
                     )
                     dineSykmeldteHttpClientMock.defaultMocks(narmestelederId = narmestelederId)
 
@@ -174,7 +174,7 @@ class PaaminnelseApiTest :
                     seedAktivtSyketilfelle()
                     texasClientMock.defaultMocks(
                         pid = pidInnloggetBruker,
-                        clientId = environment.dinesykmeldteBackendClientId,
+                        clientId = environment.dinesykmeldteClientId,
                     )
                     dineSykmeldteHttpClientMock.defaultMocks(narmestelederId = narmestelederId)
 
@@ -197,7 +197,7 @@ class PaaminnelseApiTest :
                 withTestApplication {
                     texasClientMock.defaultMocks(
                         pid = pidInnloggetBruker,
-                        clientId = environment.dinesykmeldteBackendClientId,
+                        clientId = environment.dinesykmeldteClientId,
                     )
                     coEvery {
                         dineSykmeldteHttpClientMock.getSykmeldtForNarmesteLederId(
@@ -225,7 +225,7 @@ class PaaminnelseApiTest :
                     seedAktivtSyketilfelle()
                     texasClientMock.defaultMocks(
                         pid = pidInnloggetBruker,
-                        clientId = environment.dinesykmeldteBackendClientId,
+                        clientId = environment.dinesykmeldteClientId,
                     )
                     dineSykmeldteHttpClientMock.defaultMocks(narmestelederId = narmestelederId)
 
@@ -248,7 +248,7 @@ class PaaminnelseApiTest :
                     seedAktivtSyketilfelle()
                     texasClientMock.defaultMocks(
                         pid = pidInnloggetBruker,
-                        clientId = environment.dinesykmeldteBackendClientId,
+                        clientId = environment.dinesykmeldteClientId,
                     )
                     dineSykmeldteHttpClientMock.defaultMocks(narmestelederId = narmestelederId)
 

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/PaaminnelseApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/PaaminnelseApiTest.kt
@@ -1,0 +1,241 @@
+package no.nav.syfo.oppfolgingsplan.api.v1.narmesteleder
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.url
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.jackson.jackson
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.syfo.TestDB
+import no.nav.syfo.application.Environment
+import no.nav.syfo.application.LocalEnvironment
+import no.nav.syfo.application.exception.ApiError
+import no.nav.syfo.application.exception.ErrorType
+import no.nav.syfo.application.valkey.ValkeyCache
+import no.nav.syfo.defaultMocks
+import no.nav.syfo.dinesykmeldte.DineSykmeldteService
+import no.nav.syfo.dinesykmeldte.client.DineSykmeldteHttpClient
+import no.nav.syfo.oppfolgingsplan.db.findPaaminnelseBy
+import no.nav.syfo.oppfolgingsplan.dto.PaaminnelseStatus
+import no.nav.syfo.oppfolgingsplan.dto.PaaminnelseStatusDto
+import no.nav.syfo.oppfolgingsplan.service.PaaminnelseService
+import no.nav.syfo.plugins.installContentNegotiation
+import no.nav.syfo.plugins.installStatusPages
+import no.nav.syfo.returnsNotFound
+import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
+import no.nav.syfo.sykmelding.db.domain.SykmeldingsperiodeToStore
+import no.nav.syfo.texas.client.TexasHttpClient
+import java.time.LocalDate
+
+class PaaminnelseApiTest :
+    DescribeSpec({
+        val texasClientMock = mockk<TexasHttpClient>()
+        val dineSykmeldteHttpClientMock = mockk<DineSykmeldteHttpClient>()
+        val valkeyCacheMock = mockk<ValkeyCache>(relaxUnitFun = true)
+        val testDb = TestDB.database
+        val repository = SykmeldingsperiodeRepository(testDb)
+        val environment: Environment = LocalEnvironment()
+        val paaminnelseService = PaaminnelseService(
+            database = testDb,
+            sykmeldingsperiodeRepository = repository,
+        )
+
+        val narmestelederId = "2c1d58cc-a4cc-48a6-a0ef-a0eb0b05f45d"
+        val pidInnloggetBruker = "10987654321"
+
+        beforeTest {
+            clearAllMocks()
+            TestDB.clearAllData()
+            every { valkeyCacheMock.getSykmeldt(any(), any()) } returns null
+        }
+
+        fun seedAktivtSyketilfelle(startDato: LocalDate = LocalDate.now().minusDays(7)) {
+            repository.storeSykmeldingsperioder(
+                listOf(
+                    SykmeldingsperiodeToStore(
+                        sykmeldtFnr = "12345678901",
+                        organisasjonsnummer = "orgnummer",
+                        sykmeldingId = "sykmelding-1",
+                        fom = startDato,
+                        tom = startDato.plusDays(14),
+                    ),
+                ),
+            )
+        }
+
+        fun withTestApplication(
+            fn: suspend ApplicationTestBuilder.() -> Unit,
+        ) {
+            testApplication {
+                this.client = createClient {
+                    install(ContentNegotiation) {
+                        jackson {
+                            registerKotlinModule()
+                            registerModule(JavaTimeModule())
+                            configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                            configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                        }
+                    }
+                }
+                application {
+                    installContentNegotiation()
+                    installStatusPages()
+                    routing {
+                        registerPaaminnelseApi(
+                            dineSykmeldteService = DineSykmeldteService(dineSykmeldteHttpClientMock, valkeyCacheMock),
+                            texasHttpClient = texasClientMock,
+                            paaminnelseService = paaminnelseService,
+                            environment = environment,
+                        )
+                    }
+                }
+                fn(this)
+            }
+        }
+
+        fun countPaaminnelseRows(): Int = testDb.connection.use { connection ->
+            connection.prepareStatement("SELECT COUNT(*) AS count FROM paaminnelse").use { preparedStatement ->
+                preparedStatement.executeQuery().use { resultSet ->
+                    resultSet.next()
+                    resultSet.getInt("count")
+                }
+            }
+        }
+
+        describe("Paaminnelse API") {
+            it("GET should respond with Unauthorized when no authentication is provided") {
+                withTestApplication {
+                    val response = client.get("/api/v1/narmesteleder/$narmestelederId/oppfolgingsplaner/paaminnelse")
+
+                    response.status shouldBe HttpStatusCode.Unauthorized
+                }
+            }
+
+            it("GET should respond with SYKMELDT_NOT_FOUND when dine sykmeldte returns not found") {
+                withTestApplication {
+                    texasClientMock.defaultMocks(
+                        pid = pidInnloggetBruker,
+                        clientId = environment.dinesykmeldteBackendClientId,
+                    )
+                    dineSykmeldteHttpClientMock.returnsNotFound(narmestelederId = narmestelederId)
+
+                    val response = client.get {
+                        url("/api/v1/narmesteleder/$narmestelederId/oppfolgingsplaner/paaminnelse")
+                        bearerAuth("Bearer token")
+                    }
+
+                    response.status shouldBe HttpStatusCode.NotFound
+                    response.body<ApiError>().type shouldBe ErrorType.SYKMELDT_NOT_FOUND
+                }
+            }
+
+            it("GET should return TILGJENGELIG when relation is inside the ordering window and not ordered") {
+                withTestApplication {
+                    val startDato = LocalDate.now().minusDays(7)
+                    seedAktivtSyketilfelle(startDato)
+                    texasClientMock.defaultMocks(
+                        pid = pidInnloggetBruker,
+                        clientId = environment.dinesykmeldteBackendClientId,
+                    )
+                    dineSykmeldteHttpClientMock.defaultMocks(narmestelederId = narmestelederId)
+
+                    val response = client.get {
+                        url("/api/v1/narmesteleder/$narmestelederId/oppfolgingsplaner/paaminnelse")
+                        bearerAuth("Bearer token")
+                    }
+
+                    response.status shouldBe HttpStatusCode.OK
+                    response.body<PaaminnelseStatusDto>() shouldBe PaaminnelseStatusDto(
+                        status = PaaminnelseStatus.TILGJENGELIG,
+                        synligFra = startDato,
+                    )
+                }
+            }
+
+            it("POST should persist BESTILT") {
+                withTestApplication {
+                    seedAktivtSyketilfelle()
+                    texasClientMock.defaultMocks(
+                        pid = pidInnloggetBruker,
+                        clientId = environment.dinesykmeldteBackendClientId,
+                    )
+                    dineSykmeldteHttpClientMock.defaultMocks(narmestelederId = narmestelederId)
+
+                    val response = client.post {
+                        url("/api/v1/narmesteleder/$narmestelederId/oppfolgingsplaner/paaminnelse")
+                        bearerAuth("Bearer token")
+                    }
+
+                    response.status shouldBe HttpStatusCode.OK
+                    response.body<PaaminnelseStatusDto>().status shouldBe PaaminnelseStatus.BESTILT
+
+                    val persisted = testDb.findPaaminnelseBy("12345678901", "orgnummer")
+                    persisted?.bestilt shouldBe true
+                    persisted?.sykmeldtFnr shouldBe "12345678901"
+                    persisted?.organisasjonsnummer shouldBe "orgnummer"
+                }
+            }
+
+            it("POST should be idempotent") {
+                withTestApplication {
+                    seedAktivtSyketilfelle()
+                    texasClientMock.defaultMocks(
+                        pid = pidInnloggetBruker,
+                        clientId = environment.dinesykmeldteBackendClientId,
+                    )
+                    dineSykmeldteHttpClientMock.defaultMocks(narmestelederId = narmestelederId)
+
+                    client.post {
+                        url("/api/v1/narmesteleder/$narmestelederId/oppfolgingsplaner/paaminnelse")
+                        bearerAuth("Bearer token")
+                    }
+                    val response = client.post {
+                        url("/api/v1/narmesteleder/$narmestelederId/oppfolgingsplaner/paaminnelse")
+                        bearerAuth("Bearer token")
+                    }
+
+                    response.status shouldBe HttpStatusCode.OK
+                    countPaaminnelseRows() shouldBe 1
+                }
+            }
+
+            it("DELETE should persist TILGJENGELIG") {
+                withTestApplication {
+                    seedAktivtSyketilfelle()
+                    texasClientMock.defaultMocks(
+                        pid = pidInnloggetBruker,
+                        clientId = environment.dinesykmeldteBackendClientId,
+                    )
+                    dineSykmeldteHttpClientMock.defaultMocks(narmestelederId = narmestelederId)
+
+                    client.post {
+                        url("/api/v1/narmesteleder/$narmestelederId/oppfolgingsplaner/paaminnelse")
+                        bearerAuth("Bearer token")
+                    }
+                    val response = client.delete {
+                        url("/api/v1/narmesteleder/$narmestelederId/oppfolgingsplaner/paaminnelse")
+                        bearerAuth("Bearer token")
+                    }
+
+                    response.status shouldBe HttpStatusCode.OK
+                    response.body<PaaminnelseStatusDto>().status shouldBe PaaminnelseStatus.TILGJENGELIG
+                    testDb.findPaaminnelseBy("12345678901", "orgnummer")?.bestilt shouldBe false
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/PaaminnelseApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/PaaminnelseApiTest.kt
@@ -65,7 +65,7 @@ class PaaminnelseApiTest :
         val pidInnloggetBruker = "10987654321"
 
         beforeTest {
-            clearAllMocks()
+            clearAllMocks(currentThreadOnly = true)
             TestDB.clearAllData()
             every { valkeyCacheMock.getSykmeldt(any(), any()) } returns null
         }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/OppfolgingsplanApiV1Test.kt
@@ -77,7 +77,7 @@ class OppfolgingsplanApiV1Test :
         val aaregServiceMock = mockk<AaregService>(relaxed = true)
 
         beforeTest {
-            clearAllMocks()
+            clearAllMocks(currentThreadOnly = true)
             TestDB.clearAllData()
             every { valkeyCacheMock.getSykmeldt(any(), any()) } returns null
         }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederOppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederOppfolgingsplanApiV1Test.kt
@@ -72,7 +72,7 @@ class VeilederOppfolgingsplanApiV1Test :
         val syfomodiapersonClientId = environment.syfomodiapersonClientId
 
         beforeTest {
-            clearAllMocks()
+            clearAllMocks(currentThreadOnly = true)
             TestDB.clearAllData()
             every { valkeyCacheMock.getSykmeldt(any(), any()) } returns null
         }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanServiceTest.kt
@@ -75,7 +75,7 @@ class OppfolgingsplanServiceTest :
             describe("getAndSetNarmestelederFullname") {
                 afterTest {
                     TestDB.clearAllData()
-                    clearAllMocks()
+                    clearAllMocks(currentThreadOnly = true)
                 }
                 it("should set narmesteleder fullname when it is missing") {
                     // Arrange
@@ -132,7 +132,7 @@ class OppfolgingsplanServiceTest :
             describe("createOppfolgingsplan") {
                 afterTest {
                     TestDB.clearAllData()
-                    clearAllMocks()
+                    clearAllMocks(currentThreadOnly = true)
                 }
 
                 it("should persist stillingssnapshot from aareg") {
@@ -209,7 +209,7 @@ class OppfolgingsplanServiceTest :
             describe("deleteExpiredOppfolgingsplanUtkast") {
                 afterTest {
                     TestDB.clearAllData()
-                    clearAllMocks()
+                    clearAllMocks(currentThreadOnly = true)
                 }
 
                 it("should delete drafts older than cutoff and keep exact cutoff and newer drafts") {

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/PaaminnelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/PaaminnelseServiceTest.kt
@@ -1,10 +1,14 @@
 package no.nav.syfo.oppfolgingsplan.service
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import io.ktor.server.plugins.BadRequestException
 import no.nav.syfo.TestDB
 import no.nav.syfo.defaultPersistedOppfolgingsplan
 import no.nav.syfo.defaultSykmeldt
+import no.nav.syfo.oppfolgingsplan.db.findPaaminnelseBy
+import no.nav.syfo.oppfolgingsplan.db.upsertPaaminnelse
 import no.nav.syfo.oppfolgingsplan.dto.PaaminnelseStatus
 import no.nav.syfo.persistOppfolgingsplan
 import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
@@ -162,6 +166,42 @@ class PaaminnelseServiceTest :
                 avbestilt.status shouldBe PaaminnelseStatus.TILGJENGELIG
                 bestilt.synligFra shouldBe LocalDate.of(2025, 6, 1)
                 avbestilt.synligFra shouldBe LocalDate.of(2025, 6, 1)
+            }
+
+            it("rejects activatePaaminnelse when status is SKJULT because an oppfolgingsplan already exists in the current syketilfelle") {
+                val synligFra = LocalDate.of(2025, 6, 1)
+                seedSyketilfelle(
+                    startDato = synligFra,
+                    tom = LocalDate.of(2025, 6, 30),
+                )
+                TestDB.database.persistOppfolgingsplan(
+                    defaultPersistedOppfolgingsplan().copy(
+                        createdAt = synligFra.atStartOfDay(fixedClock.zone).toInstant(),
+                    ),
+                )
+
+                shouldThrow<BadRequestException> {
+                    service.activatePaaminnelse(defaultSykmeldt())
+                }
+
+                TestDB.database.findPaaminnelseBy("12345678901", "orgnummer") shouldBe null
+            }
+
+            it("rejects deactivatePaaminnelse when status is SKJULT because the ordering window has passed") {
+                seedSyketilfelle(
+                    startDato = LocalDate.of(2025, 5, 1),
+                    tom = LocalDate.of(2025, 6, 30),
+                )
+                TestDB.database.upsertPaaminnelse(
+                    sykmeldt = defaultSykmeldt(),
+                    bestilt = true,
+                )
+
+                shouldThrow<BadRequestException> {
+                    service.deactivatePaaminnelse(defaultSykmeldt())
+                }
+
+                TestDB.database.findPaaminnelseBy("12345678901", "orgnummer")?.bestilt shouldBe true
             }
         }
     })

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/PaaminnelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/PaaminnelseServiceTest.kt
@@ -1,0 +1,108 @@
+package no.nav.syfo.oppfolgingsplan.service
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import no.nav.syfo.TestDB
+import no.nav.syfo.defaultPersistedOppfolgingsplan
+import no.nav.syfo.defaultSykmeldt
+import no.nav.syfo.oppfolgingsplan.dto.PaaminnelseStatus
+import no.nav.syfo.persistOppfolgingsplan
+import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
+import no.nav.syfo.sykmelding.db.domain.SykmeldingsperiodeToStore
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+class PaaminnelseServiceTest :
+    DescribeSpec({
+        val fixedClock = Clock.fixed(Instant.parse("2025-06-19T10:00:00Z"), ZoneId.of("Europe/Oslo"))
+        val repository = SykmeldingsperiodeRepository(TestDB.database)
+        val service = PaaminnelseService(
+            database = TestDB.database,
+            sykmeldingsperiodeRepository = repository,
+            clock = fixedClock,
+        )
+
+        beforeTest {
+            TestDB.clearAllData()
+        }
+
+        fun seedSyketilfelle(
+            startDato: LocalDate,
+            tom: LocalDate = startDato.plusDays(14),
+        ) {
+            repository.storeSykmeldingsperioder(
+                listOf(
+                    SykmeldingsperiodeToStore(
+                        sykmeldtFnr = "12345678901",
+                        organisasjonsnummer = "orgnummer",
+                        sykmeldingId = "sykmelding-service",
+                        fom = startDato,
+                        tom = tom,
+                    ),
+                ),
+            )
+        }
+
+        describe("getPaaminnelseStatus") {
+            it("returns SKJULT when there are no active sykmeldingsperioder") {
+                val status = service.getPaaminnelseStatus(defaultSykmeldt())
+
+                status.status shouldBe PaaminnelseStatus.SKJULT
+                status.synligFra shouldBe null
+            }
+
+            it("returns SKJULT when bestillingsvinduet has passed") {
+                seedSyketilfelle(startDato = LocalDate.of(2025, 5, 1))
+
+                val status = service.getPaaminnelseStatus(defaultSykmeldt())
+
+                status.status shouldBe PaaminnelseStatus.SKJULT
+                status.synligFra shouldBe LocalDate.of(2025, 5, 1)
+            }
+
+            it("returns TILGJENGELIG inside the window when no paaminnelse is ordered") {
+                seedSyketilfelle(startDato = LocalDate.of(2025, 6, 1))
+
+                val status = service.getPaaminnelseStatus(defaultSykmeldt())
+
+                status.status shouldBe PaaminnelseStatus.TILGJENGELIG
+                status.synligFra shouldBe LocalDate.of(2025, 6, 1)
+            }
+
+            it("returns SKJULT when an oppfolgingsplan already exists") {
+                seedSyketilfelle(startDato = LocalDate.of(2025, 6, 1))
+                TestDB.database.persistOppfolgingsplan(defaultPersistedOppfolgingsplan())
+
+                val status = service.getPaaminnelseStatus(defaultSykmeldt())
+
+                status.status shouldBe PaaminnelseStatus.SKJULT
+                status.synligFra shouldBe LocalDate.of(2025, 6, 1)
+            }
+
+            it("returns BESTILT inside the window when paaminnelse is ordered") {
+                seedSyketilfelle(startDato = LocalDate.of(2025, 6, 1))
+                service.bestillPaaminnelse(defaultSykmeldt())
+
+                val status = service.getPaaminnelseStatus(defaultSykmeldt())
+
+                status.status shouldBe PaaminnelseStatus.BESTILT
+                status.synligFra shouldBe LocalDate.of(2025, 6, 1)
+            }
+        }
+
+        describe("bestillPaaminnelse and avbestillPaaminnelse") {
+            it("returns explicit BESTILT and TILGJENGELIG contract values") {
+                seedSyketilfelle(startDato = LocalDate.of(2025, 6, 1))
+
+                val bestilt = service.bestillPaaminnelse(defaultSykmeldt())
+                val avbestilt = service.avbestillPaaminnelse(defaultSykmeldt())
+
+                bestilt.status shouldBe PaaminnelseStatus.BESTILT
+                avbestilt.status shouldBe PaaminnelseStatus.TILGJENGELIG
+                bestilt.synligFra shouldBe LocalDate.of(2025, 6, 1)
+                avbestilt.synligFra shouldBe LocalDate.of(2025, 6, 1)
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/PaaminnelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/PaaminnelseServiceTest.kt
@@ -54,7 +54,10 @@ class PaaminnelseServiceTest :
             }
 
             it("returns SKJULT when bestillingsvinduet has passed") {
-                seedSyketilfelle(startDato = LocalDate.of(2025, 5, 1))
+                seedSyketilfelle(
+                    startDato = LocalDate.of(2025, 5, 1),
+                    tom = LocalDate.of(2025, 6, 30),
+                )
 
                 val status = service.getPaaminnelseStatus(defaultSykmeldt())
 
@@ -63,7 +66,10 @@ class PaaminnelseServiceTest :
             }
 
             it("returns TILGJENGELIG inside the window when no paaminnelse is ordered") {
-                seedSyketilfelle(startDato = LocalDate.of(2025, 6, 1))
+                seedSyketilfelle(
+                    startDato = LocalDate.of(2025, 6, 1),
+                    tom = LocalDate.of(2025, 6, 30),
+                )
 
                 val status = service.getPaaminnelseStatus(defaultSykmeldt())
 
@@ -72,7 +78,10 @@ class PaaminnelseServiceTest :
             }
 
             it("returns SKJULT when an oppfolgingsplan already exists") {
-                seedSyketilfelle(startDato = LocalDate.of(2025, 6, 1))
+                seedSyketilfelle(
+                    startDato = LocalDate.of(2025, 6, 1),
+                    tom = LocalDate.of(2025, 6, 30),
+                )
                 TestDB.database.persistOppfolgingsplan(defaultPersistedOppfolgingsplan())
 
                 val status = service.getPaaminnelseStatus(defaultSykmeldt())
@@ -82,7 +91,10 @@ class PaaminnelseServiceTest :
             }
 
             it("returns BESTILT inside the window when paaminnelse is ordered") {
-                seedSyketilfelle(startDato = LocalDate.of(2025, 6, 1))
+                seedSyketilfelle(
+                    startDato = LocalDate.of(2025, 6, 1),
+                    tom = LocalDate.of(2025, 6, 30),
+                )
                 service.bestillPaaminnelse(defaultSykmeldt())
 
                 val status = service.getPaaminnelseStatus(defaultSykmeldt())
@@ -94,7 +106,10 @@ class PaaminnelseServiceTest :
 
         describe("bestillPaaminnelse and avbestillPaaminnelse") {
             it("returns explicit BESTILT and TILGJENGELIG contract values") {
-                seedSyketilfelle(startDato = LocalDate.of(2025, 6, 1))
+                seedSyketilfelle(
+                    startDato = LocalDate.of(2025, 6, 1),
+                    tom = LocalDate.of(2025, 6, 30),
+                )
 
                 val bestilt = service.bestillPaaminnelse(defaultSykmeldt())
                 val avbestilt = service.avbestillPaaminnelse(defaultSykmeldt())

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/PaaminnelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/PaaminnelseServiceTest.kt
@@ -77,7 +77,25 @@ class PaaminnelseServiceTest :
                 status.synligFra shouldBe LocalDate.of(2025, 6, 1)
             }
 
-            it("returns SKJULT when an oppfolgingsplan already exists") {
+            it("returns TILGJENGELIG when an oppfolgingsplan exists from after synligFra") {
+                val synligFra = LocalDate.of(2025, 6, 1)
+                seedSyketilfelle(
+                    startDato = synligFra,
+                    tom = LocalDate.of(2025, 6, 30),
+                )
+                TestDB.database.persistOppfolgingsplan(
+                    defaultPersistedOppfolgingsplan().copy(
+                        createdAt = synligFra.atStartOfDay(fixedClock.zone).toInstant().minusSeconds(1),
+                    ),
+                )
+
+                val status = service.getPaaminnelseStatus(defaultSykmeldt())
+
+                status.status shouldBe PaaminnelseStatus.TILGJENGELIG
+                status.synligFra shouldBe synligFra
+            }
+
+            it("returns SKJULT when an oppfolgingsplan already exists but from prior to current syketilfelle") {
                 seedSyketilfelle(
                     startDato = LocalDate.of(2025, 6, 1),
                     tom = LocalDate.of(2025, 6, 30),
@@ -88,6 +106,32 @@ class PaaminnelseServiceTest :
 
                 status.status shouldBe PaaminnelseStatus.SKJULT
                 status.synligFra shouldBe LocalDate.of(2025, 6, 1)
+            }
+
+            it("returns TILGJENGELIG on day 23 after synligFra") {
+                val synligFra = LocalDate.of(2025, 5, 27)
+                seedSyketilfelle(
+                    startDato = synligFra,
+                    tom = LocalDate.of(2025, 6, 30),
+                )
+
+                val status = service.getPaaminnelseStatus(defaultSykmeldt())
+
+                status.status shouldBe PaaminnelseStatus.TILGJENGELIG
+                status.synligFra shouldBe synligFra
+            }
+
+            it("returns SKJULT on day 24 after synligFra") {
+                val synligFra = LocalDate.of(2025, 5, 26)
+                seedSyketilfelle(
+                    startDato = synligFra,
+                    tom = LocalDate.of(2025, 6, 30),
+                )
+
+                val status = service.getPaaminnelseStatus(defaultSykmeldt())
+
+                status.status shouldBe PaaminnelseStatus.SKJULT
+                status.synligFra shouldBe synligFra
             }
 
             it("returns BESTILT inside the window when paaminnelse is ordered") {

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/PaaminnelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/PaaminnelseServiceTest.kt
@@ -95,7 +95,7 @@ class PaaminnelseServiceTest :
                     startDato = LocalDate.of(2025, 6, 1),
                     tom = LocalDate.of(2025, 6, 30),
                 )
-                service.bestillPaaminnelse(defaultSykmeldt())
+                service.activatePaaminnelse(defaultSykmeldt())
 
                 val status = service.getPaaminnelseStatus(defaultSykmeldt())
 
@@ -111,8 +111,8 @@ class PaaminnelseServiceTest :
                     tom = LocalDate.of(2025, 6, 30),
                 )
 
-                val bestilt = service.bestillPaaminnelse(defaultSykmeldt())
-                val avbestilt = service.avbestillPaaminnelse(defaultSykmeldt())
+                val bestilt = service.activatePaaminnelse(defaultSykmeldt())
+                val avbestilt = service.deactivatePaaminnelse(defaultSykmeldt())
 
                 bestilt.status shouldBe PaaminnelseStatus.BESTILT
                 avbestilt.status shouldBe PaaminnelseStatus.TILGJENGELIG

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTaskTest.kt
@@ -49,7 +49,7 @@ class SoftDeleteOppfolgingsplanerTaskTest :
         }
 
         beforeTest {
-            clearAllMocks()
+            clearAllMocks(currentThreadOnly = true)
             TestDB.clearAllData()
         }
 

--- a/src/test/kotlin/no/nav/syfo/pdfgen/PdfGenServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/pdfgen/PdfGenServiceTest.kt
@@ -46,7 +46,7 @@ class PdfGenServiceTest :
         }
 
         beforeTest {
-            clearAllMocks()
+            clearAllMocks(currentThreadOnly = true)
             TestDB.clearAllData()
         }
 

--- a/src/test/kotlin/no/nav/syfo/pdl/PdlServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/pdl/PdlServiceTest.kt
@@ -18,7 +18,7 @@ class PdlServiceTest :
         val service = PdlService(pdlClient)
 
         beforeTest {
-            clearAllMocks()
+            clearAllMocks(currentThreadOnly = true)
         }
 
         describe("PdlService.getNameFor") {

--- a/src/test/kotlin/no/nav/syfo/sykmelding/db/SykmeldingsperiodeRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmelding/db/SykmeldingsperiodeRepositoryTest.kt
@@ -10,25 +10,40 @@ import java.time.LocalDate
 class SykmeldingsperiodeRepositoryTest :
     DescribeSpec({
         val repository = SykmeldingsperiodeRepository(TestDB.database)
+        val today = LocalDate.of(2025, 6, 20)
+        val sykmeldtFnr = "12345678901"
+        val organisasjonsnummer = "987654321"
 
         beforeEach {
             TestDB.clearAllData()
         }
+
+        fun sykmeldingsperiodeToStore(
+            sykmeldingId: String,
+            fom: LocalDate,
+            tom: LocalDate,
+        ) = SykmeldingsperiodeToStore(
+            sykmeldtFnr = sykmeldtFnr,
+            organisasjonsnummer = organisasjonsnummer,
+            sykmeldingId = sykmeldingId,
+            fom = fom,
+            tom = tom,
+        )
 
         describe("storeSykmeldingsperioder") {
             it("stores sykmeldingsperioder") {
                 val insertedRows = repository.storeSykmeldingsperioder(
                     listOf(
                         SykmeldingsperiodeToStore(
-                            sykmeldtFnr = "12345678901",
-                            organisasjonsnummer = "987654321",
+                            sykmeldtFnr = sykmeldtFnr,
+                            organisasjonsnummer = organisasjonsnummer,
                             sykmeldingId = "sykmelding-1",
                             fom = LocalDate.of(2025, 1, 1),
                             tom = LocalDate.of(2025, 1, 31),
                         ),
                         SykmeldingsperiodeToStore(
-                            sykmeldtFnr = "12345678901",
-                            organisasjonsnummer = "987654321",
+                            sykmeldtFnr = sykmeldtFnr,
+                            organisasjonsnummer = organisasjonsnummer,
                             sykmeldingId = "sykmelding-1",
                             fom = LocalDate.of(2025, 2, 1),
                             tom = LocalDate.of(2025, 2, 28),
@@ -49,8 +64,8 @@ class SykmeldingsperiodeRepositoryTest :
 
             it("is idempotent for duplicate periods") {
                 val sykmeldingsperiode = SykmeldingsperiodeToStore(
-                    sykmeldtFnr = "12345678901",
-                    organisasjonsnummer = "987654321",
+                    sykmeldtFnr = sykmeldtFnr,
+                    organisasjonsnummer = organisasjonsnummer,
                     sykmeldingId = "sykmelding-2",
                     fom = LocalDate.of(2025, 3, 1),
                     tom = LocalDate.of(2025, 3, 31),
@@ -71,15 +86,15 @@ class SykmeldingsperiodeRepositoryTest :
                 repository.storeSykmeldingsperioder(
                     listOf(
                         SykmeldingsperiodeToStore(
-                            sykmeldtFnr = "12345678901",
-                            organisasjonsnummer = "987654321",
+                            sykmeldtFnr = sykmeldtFnr,
+                            organisasjonsnummer = organisasjonsnummer,
                             sykmeldingId = "sykmelding-3",
                             fom = LocalDate.of(2025, 4, 1),
                             tom = LocalDate.of(2025, 4, 30),
                         ),
                         SykmeldingsperiodeToStore(
-                            sykmeldtFnr = "12345678901",
-                            organisasjonsnummer = "987654321",
+                            sykmeldtFnr = sykmeldtFnr,
+                            organisasjonsnummer = organisasjonsnummer,
                             sykmeldingId = "sykmelding-3",
                             fom = LocalDate.of(2025, 5, 1),
                             tom = LocalDate.of(2025, 5, 31),
@@ -97,32 +112,160 @@ class SykmeldingsperiodeRepositoryTest :
         }
 
         describe("findEarliestFom") {
-            it("returns earliest active fom for sykmeldt and organization") {
+            it("returns earliest fom in a continuous chain ending in an active period today") {
                 repository.storeSykmeldingsperioder(
                     listOf(
-                        SykmeldingsperiodeToStore(
-                            sykmeldtFnr = "12345678901",
-                            organisasjonsnummer = "987654321",
+                        sykmeldingsperiodeToStore(
                             sykmeldingId = "sykmelding-old",
                             fom = LocalDate.of(2025, 1, 1),
                             tom = LocalDate.of(2025, 1, 31),
                         ),
-                        SykmeldingsperiodeToStore(
-                            sykmeldtFnr = "12345678901",
-                            organisasjonsnummer = "987654321",
-                            sykmeldingId = "sykmelding-new",
+                        sykmeldingsperiodeToStore(
+                            sykmeldingId = "sykmelding-current",
                             fom = LocalDate.of(2025, 6, 1),
+                            tom = LocalDate.of(2025, 6, 30),
+                        ),
+                        sykmeldingsperiodeToStore(
+                            sykmeldingId = "sykmelding-connected",
+                            fom = LocalDate.of(2025, 5, 15),
+                            tom = LocalDate.of(2025, 5, 31),
+                        ),
+                    ),
+                )
+
+                val earliestFom = repository.findEarliestFom(
+                    sykmeldtFnr = sykmeldtFnr,
+                    organisasjonsnummer = organisasjonsnummer,
+                    today = today,
+                )
+
+                earliestFom shouldBe LocalDate.of(2025, 5, 15)
+            }
+
+            it("stops at the first gap when searching backwards") {
+                repository.storeSykmeldingsperioder(
+                    listOf(
+                        sykmeldingsperiodeToStore(
+                            sykmeldingId = "sykmelding-current",
+                            fom = LocalDate.of(2025, 6, 1),
+                            tom = LocalDate.of(2025, 6, 30),
+                        ),
+                        sykmeldingsperiodeToStore(
+                            sykmeldingId = "sykmelding-gap",
+                            fom = LocalDate.of(2025, 5, 10),
+                            tom = LocalDate.of(2025, 5, 30),
+                        ),
+                    ),
+                )
+
+                val earliestFom = repository.findEarliestFom(
+                    sykmeldtFnr = sykmeldtFnr,
+                    organisasjonsnummer = organisasjonsnummer,
+                    today = today,
+                )
+
+                earliestFom shouldBe LocalDate.of(2025, 6, 1)
+            }
+
+            it("treats overlapping and adjacent periods as continuous") {
+                repository.storeSykmeldingsperioder(
+                    listOf(
+                        sykmeldingsperiodeToStore(
+                            sykmeldingId = "sykmelding-active",
+                            fom = LocalDate.of(2025, 6, 15),
+                            tom = LocalDate.of(2025, 6, 30),
+                        ),
+                        sykmeldingsperiodeToStore(
+                            sykmeldingId = "sykmelding-overlap",
+                            fom = LocalDate.of(2025, 6, 1),
+                            tom = LocalDate.of(2025, 6, 20),
+                        ),
+                        sykmeldingsperiodeToStore(
+                            sykmeldingId = "sykmelding-adjacent",
+                            fom = LocalDate.of(2025, 5, 20),
+                            tom = LocalDate.of(2025, 5, 31),
+                        ),
+                    ),
+                )
+
+                val earliestFom = repository.findEarliestFom(
+                    sykmeldtFnr = sykmeldtFnr,
+                    organisasjonsnummer = organisasjonsnummer,
+                    today = today,
+                )
+
+                earliestFom shouldBe LocalDate.of(2025, 5, 20)
+            }
+
+            it("returns null when no non-invalidated period is active today") {
+                repository.storeSykmeldingsperioder(
+                    listOf(
+                        sykmeldingsperiodeToStore(
+                            sykmeldingId = "sykmelding-ended",
+                            fom = LocalDate.of(2025, 5, 1),
+                            tom = LocalDate.of(2025, 5, 31),
+                        ),
+                    ),
+                )
+
+                val earliestFom = repository.findEarliestFom(
+                    sykmeldtFnr = sykmeldtFnr,
+                    organisasjonsnummer = organisasjonsnummer,
+                    today = today,
+                )
+
+                earliestFom shouldBe null
+            }
+
+            it("ignores invalidated periods when finding the continuous chain") {
+                repository.storeSykmeldingsperioder(
+                    listOf(
+                        sykmeldingsperiodeToStore(
+                            sykmeldingId = "sykmelding-active",
+                            fom = LocalDate.of(2025, 6, 1),
+                            tom = LocalDate.of(2025, 6, 30),
+                        ),
+                        sykmeldingsperiodeToStore(
+                            sykmeldingId = "sykmelding-invalidated",
+                            fom = LocalDate.of(2025, 5, 1),
+                            tom = LocalDate.of(2025, 5, 31),
+                        ),
+                    ),
+                )
+                repository.invalidateSykmelding("sykmelding-invalidated")
+
+                val earliestFom = repository.findEarliestFom(
+                    sykmeldtFnr = sykmeldtFnr,
+                    organisasjonsnummer = organisasjonsnummer,
+                    today = today,
+                )
+
+                earliestFom shouldBe LocalDate.of(2025, 6, 1)
+            }
+
+            it("does not include periods that ended more than 50 days before today") {
+                repository.storeSykmeldingsperioder(
+                    listOf(
+                        sykmeldingsperiodeToStore(
+                            sykmeldingId = "sykmelding-outside-lookback",
+                            fom = LocalDate.of(2025, 4, 20),
+                            tom = LocalDate.of(2025, 4, 30),
+                        ),
+                        sykmeldingsperiodeToStore(
+                            sykmeldingId = "sykmelding-active",
+                            fom = LocalDate.of(2025, 5, 1),
                             tom = LocalDate.of(2025, 6, 30),
                         ),
                     ),
                 )
 
                 val earliestFom = repository.findEarliestFom(
-                    sykmeldtFnr = "12345678901",
-                    organisasjonsnummer = "987654321",
+                    sykmeldtFnr = sykmeldtFnr,
+                    organisasjonsnummer = organisasjonsnummer,
+                    today = today,
                 )
 
-                earliestFom shouldBe LocalDate.of(2025, 1, 1)
+                earliestFom shouldBe LocalDate.of(2025, 5, 1)
             }
         }
     })

--- a/src/test/kotlin/no/nav/syfo/sykmelding/db/SykmeldingsperiodeRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmelding/db/SykmeldingsperiodeRepositoryTest.kt
@@ -95,4 +95,34 @@ class SykmeldingsperiodeRepositoryTest :
                 persisted.all { it.invalidatedAt != null } shouldBe true
             }
         }
+
+        describe("findEarliestFom") {
+            it("returns earliest active fom for sykmeldt and organization") {
+                repository.storeSykmeldingsperioder(
+                    listOf(
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = "12345678901",
+                            organisasjonsnummer = "987654321",
+                            sykmeldingId = "sykmelding-old",
+                            fom = LocalDate.of(2025, 1, 1),
+                            tom = LocalDate.of(2025, 1, 31),
+                        ),
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = "12345678901",
+                            organisasjonsnummer = "987654321",
+                            sykmeldingId = "sykmelding-new",
+                            fom = LocalDate.of(2025, 6, 1),
+                            tom = LocalDate.of(2025, 6, 30),
+                        ),
+                    ),
+                )
+
+                val earliestFom = repository.findEarliestFom(
+                    sykmeldtFnr = "12345678901",
+                    organisasjonsnummer = "987654321",
+                )
+
+                earliestFom shouldBe LocalDate.of(2025, 1, 1)
+            }
+        }
     })

--- a/src/test/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumerTest.kt
@@ -197,7 +197,6 @@ class SykmeldingsperiodeConsumerTest :
                         "sykmeldingsperioder": [
                           {"fom": "2025-01-10", "tom": "2025-01-20", "type": "AKTIVITET_IKKE_MULIG", "gradert": null, "behandlingsdager": null}
                         ],
-                        "syketilfelleStartDato": "2025-01-10",
                         "mottattTidspunkt": "2025-01-10T08:00:00Z",
                         "behandletTidspunkt": "2025-01-10T09:00:00Z",
                         "arbeidsgiver": {"orgnummer": "111222333", "orgNavn": "Foo AS"},

--- a/src/test/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumerTest.kt
@@ -36,7 +36,7 @@ class SykmeldingsperiodeConsumerTest :
         )
 
         beforeTest {
-            clearAllMocks()
+            clearAllMocks(currentThreadOnly = true)
         }
 
         describe("processRecord") {

--- a/src/test/kotlin/no/nav/syfo/varsel/EsyfovarselProducerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/varsel/EsyfovarselProducerTest.kt
@@ -29,7 +29,7 @@ class EsyfovarselProducerTest :
         val orgnummer = "987654321"
 
         beforeTest {
-            clearAllMocks()
+            clearAllMocks(currentThreadOnly = true)
         }
         describe("sendVarselToEsyfovarsel") {
             it("Calls send on Producer with ProducerRecord") {


### PR DESCRIPTION
## Beskrivelse

Legger til mottak og håndtering av frivillig påminnelse for nærmeste leder om å lage oppfølgingsplan. Løsningen eksponerer et eget påminnelse-API for nærmeste leder, lagrer bestilling idempotent og beregner når påminnelsen skal være synlig ut fra pågående, ubrutte sykmeldingsperiode.

Påminnelse skjules når det allerede finnes en oppfølgingsplan laget i den pågående sykmeldingsserien, når bestillingsvinduet på 24 dager er passert, eller når sykmeldt ikke har aktiv sykmelding. Bestilling av påminnelse avvises med 400 dersom sykmeldt ikke har aktiv sykmelding.

## Endringer

- `PaaminnelseApi`: nytt GET/POST/DELETE-endepunkt for status, bestilling og avbestilling av påminnelse for nærmeste leder.
- `PaaminnelseService`: styrer synlighet, 24-dagers bestillingsvindu, idempotent bestilling/avbestilling og sjekk mot oppfølgingsplaner i gjeldende sykmeldingsserie.
- `SykmeldingsperiodeRepository`: finner `synligFra` som eldste `fom` i en ubrutt rekke sykmeldinger bakover fra aktiv sykmelding i dag.
- `paaminnelse`-tabell: persisterer bestillingsstatus per sykmeldt og virksomhet.
- NAIS/OpenAPI/DI/metrikker: wirer API-et, klienttilgang, dokumentasjon og Prometheus-tellere.
- Tester: dekker API-kontrakt, idempotens, 400 ved manglende aktiv sykmelding, synlighetsregler, oppfølgingsplan i/utenfor pågående sykmeldingsserie og ubrutt sykmeldingsrekke.

## Issue

Closes #334
Relates to #331
Del av epic: #330

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
