### PR TITLE
chore(java): bump to Java 25

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -23,4 +23,4 @@ jobs:
     secrets: inherit
     with:
       app: syfo-oppfolgingsplan-backend
-      java-version: '21'
+      java-version: '25'

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,6 @@
+[tools]
+java = "25"
+
 [tasks.docker-up]
 description = "Spin up dependency services using Docker Compose. Postgres, Kafka etc."
 run = '''

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM  europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-21
+FROM  europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 WORKDIR /app
 COPY build/libs/app.jar app.jar
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=75 -Dlogback.configurationFile=logback.xml"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,7 +101,7 @@ application {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 tasks {

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanUtkastApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanUtkastApiV1Test.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.oppfolgingsplan.api.v1.arbeidsgiver
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
@@ -57,6 +58,7 @@ import java.util.UUID
 
 class OppfolgingsplanUtkastApiV1Test :
     DescribeSpec({
+        val utkastRequestMapper = jacksonObjectMapper()
 
         val texasClientMock = mockk<TexasHttpClient>()
         val dineSykmeldteHttpClientMock = mockk<DineSykmeldteHttpClient>()
@@ -120,6 +122,7 @@ class OppfolgingsplanUtkastApiV1Test :
                 fn(this)
             }
         }
+
         describe("Oppfolgingsplan Utkast API V1") {
             it("PUT /oppfolgingsplaner/utkast creates a new draft if it does not exist") {
                 withTestApplication {
@@ -134,7 +137,7 @@ class OppfolgingsplanUtkastApiV1Test :
                     val response = client.put("/api/v1/arbeidsgiver/$narmestelederId/oppfolgingsplaner/utkast") {
                         bearerAuth("Bearer token")
                         contentType(ContentType.Application.Json)
-                        setBody(utkast)
+                        setBody(utkastRequestMapper.writeValueAsString(utkast))
                     }
 
                     // Assert
@@ -174,7 +177,7 @@ class OppfolgingsplanUtkastApiV1Test :
                     val response = client.put("/api/v1/arbeidsgiver/$narmestelederId/oppfolgingsplaner/utkast") {
                         bearerAuth("Bearer token")
                         contentType(ContentType.Application.Json)
-                        setBody(updatedUtkastRequest)
+                        setBody(utkastRequestMapper.writeValueAsString(updatedUtkastRequest))
                     }
 
                     response.status shouldBe HttpStatusCode.OK
@@ -233,7 +236,7 @@ class OppfolgingsplanUtkastApiV1Test :
                     val response = client.put("/api/v1/arbeidsgiver/$narmestelederId/oppfolgingsplaner/utkast") {
                         bearerAuth("Bearer token")
                         contentType(ContentType.Application.Json)
-                        setBody(utkastWithNulls)
+                        setBody(utkastRequestMapper.writeValueAsString(utkastWithNulls))
                     }
 
                     response.status shouldBe HttpStatusCode.OK

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanUtkastApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanUtkastApiV1Test.kt
@@ -53,12 +53,13 @@ import no.nav.syfo.pdl.client.PdlClient
 import no.nav.syfo.plugins.installContentNegotiation
 import no.nav.syfo.plugins.installStatusPages
 import no.nav.syfo.texas.client.TexasHttpClient
+import no.nav.syfo.util.applyStandardConfiguration
 import no.nav.syfo.varsel.EsyfovarselProducer
 import java.util.UUID
 
 class OppfolgingsplanUtkastApiV1Test :
     DescribeSpec({
-        val utkastRequestMapper = jacksonObjectMapper()
+        val utkastRequestMapper = jacksonObjectMapper().applyStandardConfiguration()
 
         val texasClientMock = mockk<TexasHttpClient>()
         val dineSykmeldteHttpClientMock = mockk<DineSykmeldteHttpClient>()


### PR DESCRIPTION
## Beskrivelse

Oppdaterer prosjektet til Java 25 LTS for bygg, lokal tooling og runtime.

PR-en inkluderer også en liten teststabilisering etter at CI feilet én gang i `OppfolgingsplanUtkastApiV1Test` med `ClosedWriteChannelException` i Ktor test client ved skriving av request body. Produksjonskoden er ikke endret for dette; testen sender nå eksplisitt JSON med samme Jackson-standardkonfigurasjon som applikasjonen bruker.

## Endringer

- `build.gradle.kts`: oppdaterer Kotlin toolchain til Java 25
- `Dockerfile`: bytter runtime-image til `openjdk-25`
- `.github/workflows/build-and-deploy.yaml`: bygger med Java 25 i CI
- `.mise.toml`: legger til lokal Java 25-konfigurasjon
- `OppfolgingsplanUtkastApiV1Test`: stabiliserer utkast-PUT-testene ved å sende eksplisitt JSON serialisert med `applyStandardConfiguration()`

## Issue

Closes #157
Del av epic: #143

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)