### PR TITLE
Endrer enum-navn fra NKS_OPENING_HOURS til BUSTIKKA_OPENING_HOURS 

### DIFF
--- a/src/main/kotlin/no/nav/syfo/varsel/budstikka/domain/CommonTypes.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/budstikka/domain/CommonTypes.kt
@@ -37,5 +37,5 @@ data class BrevFallback(
 @Serializable
 enum class SendingWindow {
     ONGOING,
-    NKS_OPENING_HOURS,
+    BUDSTIKKA_OPENING_HOURS,
 }


### PR DESCRIPTION
Feltet er foreløpig ikke benyttet i oppfølgingsplan. Syns det blir et mer presist navn da vi ikke egentlig baserer oss på når NKS er åpent. 

Må merges etter [171 i budstikka](https://github.com/navikt/syfo-budstikka/pull/171)


