### PR TITLE
chore(db): remove abandoned dev outbox pilot

### DIFF
--- a/src/main/resources/db/migration/V25_1__remove_abandoned_notification_outbox.sql
+++ b/src/main/resources/db/migration/V25_1__remove_abandoned_notification_outbox.sql
@@ -1,0 +1,85 @@
+-- Temporary dev-only cleanup. Do not merge this migration to main.
+--
+-- Before deploying this branch:
+-- 1. Scale every app replica to zero.
+-- 2. Verify and delete only the abandoned pilot history rows 25.1, 26 and 27.
+-- 3. Verify that old pilot writers are stopped.
+--
+-- This branch is deployed only to the disposable dev environment. After the exact pilot signature
+-- is verified, the table is dropped even when it contains rows. The final outbox PR contains only
+-- a create-only V26 after this migration has run and the temporary V25.1 history row has been
+-- removed again.
+DO
+$$
+DECLARE
+    deleted_row_count BIGINT;
+    deleted_status_counts JSONB;
+BEGIN
+    IF to_regclass('public.outbox') IS NOT NULL THEN
+        LOCK TABLE public.outbox IN ACCESS EXCLUSIVE MODE;
+
+        IF NOT (
+            SELECT array_agg(
+                (column_name || ':' || udt_name || ':' || is_nullable)::TEXT
+                ORDER BY column_name
+            ) = ARRAY[
+                'attempt_count:int4:NO',
+                'created_at:timestamptz:NO',
+                'dedup_key:text:NO',
+                'external_ref:text:NO',
+                'last_attempt_at:timestamptz:YES',
+                'message_type:text:NO',
+                'payload:jsonb:NO',
+                'scheduled_at:timestamptz:NO',
+                'sent_at:timestamptz:YES',
+                'status:text:NO',
+                'uuid:uuid:NO'
+            ]::TEXT[]
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'outbox'
+        ) THEN
+            RAISE EXCEPTION 'Existing outbox table does not match the abandoned notification pilot schema';
+        END IF;
+
+        IF NOT EXISTS (
+            SELECT 1
+            FROM pg_constraint constraint_definition
+            JOIN pg_class table_definition
+              ON table_definition.oid = constraint_definition.conrelid
+            JOIN pg_namespace table_namespace
+              ON table_namespace.oid = table_definition.relnamespace
+            WHERE table_namespace.nspname = 'public'
+              AND table_definition.relname = 'outbox'
+              AND constraint_definition.conname = 'chk_outbox_status'
+              AND constraint_definition.contype = 'c'
+              AND pg_get_constraintdef(constraint_definition.oid) LIKE '%IRRELEVANT%'
+              AND pg_get_constraintdef(constraint_definition.oid) LIKE '%FAILED%'
+        ) THEN
+            RAISE EXCEPTION 'Existing outbox table does not have the abandoned pilot status constraint';
+        END IF;
+
+        SELECT count(*)
+        INTO deleted_row_count
+        FROM public.outbox;
+
+        SELECT jsonb_object_agg(status, row_count)
+        INTO deleted_status_counts
+        FROM (
+            SELECT status, count(*) AS row_count
+            FROM public.outbox
+            GROUP BY status
+        ) counts_by_status;
+
+        DROP TABLE public.outbox;
+
+        RAISE WARNING 'Deleted % abandoned dev outbox pilot rows; status counts=%',
+            deleted_row_count,
+            coalesce(deleted_status_counts, '{}'::jsonb);
+    END IF;
+END
+$$;
+
+-- The abandoned V27 added this default. Current application code owns event-id creation.
+ALTER TABLE oppfolgingsplan
+    ALTER COLUMN event_id DROP DEFAULT;

--- a/src/test/kotlin/no/nav/syfo/TemporaryOutboxCleanupMigrationTest.kt
+++ b/src/test/kotlin/no/nav/syfo/TemporaryOutboxCleanupMigrationTest.kt
@@ -1,0 +1,180 @@
+package no.nav.syfo
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.flywaydb.core.Flyway
+import org.flywaydb.core.api.MigrationVersion
+import java.sql.DriverManager
+import java.util.UUID
+
+class TemporaryOutboxCleanupMigrationTest :
+    DescribeSpec({
+        it("removes the empty abandoned notification pilot") {
+            val isolatedDatabase = createIsolatedDatabase()
+            with(isolatedDatabase) {
+                migrateToPilotState(this, withMessage = false)
+
+                Flyway.configure()
+                    .locations("db")
+                    .dataSource(jdbcUrl, username, password)
+                    .load()
+                    .migrate()
+
+                DriverManager.getConnection(jdbcUrl, username, password).use { connection ->
+                    connection.createStatement().use { statement ->
+                        statement.executeQuery("SELECT to_regclass('outbox')").use { resultSet ->
+                            resultSet.next() shouldBe true
+                            resultSet.getString(1) shouldBe null
+                        }
+                        statement.executeQuery(
+                            """
+                            SELECT column_default
+                            FROM information_schema.columns
+                            WHERE table_schema = current_schema()
+                              AND table_name = 'oppfolgingsplan'
+                              AND column_name = 'event_id'
+                            """.trimIndent(),
+                        ).use { resultSet ->
+                            resultSet.next() shouldBe true
+                            resultSet.getString("column_default") shouldBe null
+                        }
+                    }
+                }
+            }
+        }
+
+        it("removes a non-empty pilot after verifying its exact signature") {
+            val isolatedDatabase = createIsolatedDatabase()
+            with(isolatedDatabase) {
+                migrateToPilotState(this, withMessage = true)
+
+                Flyway.configure()
+                    .locations("db")
+                    .dataSource(jdbcUrl, username, password)
+                    .load()
+                    .migrate()
+
+                DriverManager.getConnection(jdbcUrl, username, password).use { connection ->
+                    connection.createStatement().use { statement ->
+                        statement.executeQuery("SELECT to_regclass('public.outbox')").use { resultSet ->
+                            resultSet.next() shouldBe true
+                            resultSet.getString(1) shouldBe null
+                        }
+                        statement.executeQuery("SELECT to_regclass('abandoned_outbox_pilot.outbox')").use { resultSet ->
+                            resultSet.next() shouldBe true
+                            resultSet.getString(1) shouldBe null
+                        }
+                    }
+                }
+            }
+        }
+
+        it("refuses to drop an outbox that is not the abandoned pilot") {
+            val isolatedDatabase = createIsolatedDatabase()
+            with(isolatedDatabase) {
+                migrateToPilotState(
+                    database = this,
+                    withMessage = true,
+                    pilotSql = abandonedPilotSql.replace(", 'FAILED'", ""),
+                )
+
+                shouldThrow<Exception> {
+                    Flyway.configure()
+                        .locations("db")
+                        .dataSource(jdbcUrl, username, password)
+                        .load()
+                        .migrate()
+                }
+
+                DriverManager.getConnection(jdbcUrl, username, password).use { connection ->
+                    connection.createStatement().use { statement ->
+                        statement.executeQuery("SELECT to_regclass('public.outbox')").use { resultSet ->
+                            resultSet.next() shouldBe true
+                            resultSet.getString(1) shouldBe "outbox"
+                        }
+                        statement.executeQuery("SELECT count(*) FROM public.outbox").use { resultSet ->
+                            resultSet.next() shouldBe true
+                            resultSet.getLong(1) shouldBe 1L
+                        }
+                    }
+                }
+            }
+        }
+    })
+
+private fun migrateToPilotState(
+    database: IsolatedDatabase,
+    withMessage: Boolean,
+    pilotSql: String = abandonedPilotSql,
+) = with(database) {
+    val configuration = Flyway.configure()
+        .locations("db")
+        .dataSource(jdbcUrl, username, password)
+    configuration.target(MigrationVersion.fromVersion("25")).load().migrate()
+    DriverManager.getConnection(jdbcUrl, username, password).use { connection ->
+        connection.createStatement().use { statement ->
+            statement.execute(pilotSql)
+            if (withMessage) {
+                statement.execute(
+                    """
+                    INSERT INTO outbox (uuid, message_type, dedup_key, external_ref)
+                    VALUES (
+                        '00000000-0000-0000-0000-000000000001',
+                        'OPPFOLGINGSPLAN_OPPRETTET',
+                        '00000000-0000-0000-0000-000000000002',
+                        '00000000-0000-0000-0000-000000000002'
+                    )
+                    """.trimIndent(),
+                )
+            }
+        }
+    }
+}
+
+private val abandonedPilotSql =
+    """
+    CREATE TABLE outbox
+    (
+        uuid UUID PRIMARY KEY,
+        message_type TEXT NOT NULL,
+        dedup_key TEXT NOT NULL,
+        external_ref TEXT NOT NULL,
+        payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+        scheduled_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        status TEXT NOT NULL DEFAULT 'READY',
+        attempt_count INTEGER NOT NULL DEFAULT 0,
+        last_attempt_at TIMESTAMPTZ,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        sent_at TIMESTAMPTZ,
+        CONSTRAINT uq_outbox_message UNIQUE (message_type, dedup_key),
+        CONSTRAINT chk_outbox_status CHECK (status IN ('READY', 'SENT', 'IRRELEVANT', 'FAILED')),
+        CONSTRAINT chk_outbox_attempt_count CHECK (attempt_count >= 0)
+    );
+
+    ALTER TABLE oppfolgingsplan
+        ALTER COLUMN event_id SET DEFAULT gen_random_uuid();
+    """.trimIndent()
+
+private data class IsolatedDatabase(
+    val jdbcUrl: String,
+    val username: String,
+    val password: String,
+)
+
+private fun createIsolatedDatabase(): IsolatedDatabase {
+    val databaseName = "cleanup_${UUID.randomUUID().toString().replace("-", "")}"
+    val sourceUrl = TestDB.database.connection.use { connection ->
+        val jdbcUrl = connection.metaData.url
+        connection.autoCommit = true
+        connection.createStatement().use { statement ->
+            statement.execute("CREATE DATABASE $databaseName")
+        }
+        jdbcUrl
+    }
+    return IsolatedDatabase(
+        jdbcUrl = sourceUrl.substringBeforeLast('/') + "/$databaseName",
+        username = "username",
+        password = "password",
+    )
+}


### PR DESCRIPTION
Temporary dev-only cleanup before #408.

- Refuses unknown outbox schemas
- Takes an ACCESS EXCLUSIVE lock
- Deletes the exact abandoned pilot even when it contains rows
- Logs only deleted row count grouped by low-cardinality status
- Removes the abandoned event_id default
- Tests empty, non-empty, and unknown-schema paths with real Flyway/PostgreSQL

Do not merge to main. Deploy this branch only to the disposable dev environment after old pilot writers are stopped and the old pilot Flyway rows have been removed. After success, delete the new 25.1 history row and deploy #408.