### PR TITLE
Bruk generisk outbox for opprettelsesvarsel

### DIFF
--- a/docs/adr/0002-oppfolgingsplan-created-outbox.md
+++ b/docs/adr/0002-oppfolgingsplan-created-outbox.md
@@ -1,0 +1,48 @@
+# ADR 0002: Opprettelsesvarsel bruker den generiske outboxen
+
+- **Status:** Akseptert
+- **Dato:** 2026-08-13
+
+## Kontekst
+
+Når arbeidsgiver oppretter en oppfølgingsplan, sender appen et Budstikka-varsel til den sykmeldte.
+Den gamle flyten committet planen før Kafka-publisering. Et krasj eller en publiseringsfeil mellom
+disse operasjonene kunne derfor etterlate en plan uten varsel.
+
+## Beslutning
+
+Planen og en `OPPFOLGINGSPLAN_CREATED`-kommando opprettes atomisk i den samme eksisterende
+JDBC-transaksjonen. Planpersistensen beholder sin etablerte SQL og transaksjonssemantikk; den eneste
+nye operasjonen er outbox-inserten før commit. Kommandoen har:
+
+- planens UUID som `dedup_key` og `external_ref`
+- det allerede lagrede `event_id` som outbox-UUID og Budstikka-dedupliserings-ID
+- tomt JSON-payload; handleren henter mottakeren fra fersk domenetilstand
+- planens opprettelsestidspunkt som `available_at`
+
+Handleren avbryter leveringen dersom planen er skjult, feilregistrert eller borte. Etter Kafka-ACK
+markerer workeren outbox-raden som `SENT`. Dersom databaseoppdateringen feiler etter ACK, brukes
+samme event-ID ved retry, og Budstikka dedupliserer.
+
+Alle replikaer kjører worker uten leader election. Kafka-kallet er tidsbegrenset i produsenten og er
+kortere enn outbox-leasen.
+
+## Rullerende deploy og rollback
+
+Under utrulling kan gamle podder fremdeles opprette planer og publisere synkront, mens nye podder
+oppretter plan og outbox-kommando atomisk. Vi innfører ikke en midlertidig reconciler eller indeks
+for den gamle flyten: den ville gitt betydelig kode- og migreringskompleksitet for et kort
+utrullingsvindu, og ville uansett ikke gitt en full rollback-mekanisme.
+
+En full rollback til en pre-outbox-versjon kan ikke drenere allerede opprettede outbox-rader.
+Rollback etter aktivering er derfor roll-forward eller krever at READY/CLAIMED-rader først dreneres
+av en outbox-kompatibel versjon.
+
+## Retention og observability
+
+`SENT` og `CANCELLED` for denne meldingstypen slettes 90 dager etter `completed_at`. Den generiske,
+lederkoordinerte retention-tasken sletter i små, avgrensede transaksjoner.
+
+Worker eksponerer lavkardinale målinger for antall leveringsklare rader, alder på eldste rad,
+utløpte claims og uløste tekniske feil. Dev og prod varsler på vedvarende køalder, utløpte leases og
+gjentatte feil. Payload, fødselsnummer og varseltekst logges eller tagges ikke.

--- a/docs/adr/0002-oppfolgingsplan-created-outbox.md
+++ b/docs/adr/0002-oppfolgingsplan-created-outbox.md
@@ -20,9 +20,11 @@ nye operasjonen er outbox-inserten før commit. Kommandoen har:
 - tomt JSON-payload; handleren henter mottakeren fra fersk domenetilstand
 - planens opprettelsestidspunkt som `available_at`
 
-Handleren avbryter leveringen dersom planen er skjult, feilregistrert eller borte. Etter Kafka-ACK
-markerer workeren outbox-raden som `SENT`. Dersom databaseoppdateringen feiler etter ACK, brukes
-samme event-ID ved retry, og Budstikka dedupliserer.
+Handleren avbryter leveringen dersom planen er skjult eller feilregistrert og lagrer
+`SOURCE_NO_LONGER_ELIGIBLE`. En manglende plan bryter invarianten om atomisk plan/outbox-opprettelse;
+det logges derfor som feil før kommandoen avsluttes med `SOURCE_NOT_FOUND`, fremfor å retryes for
+alltid. Etter Kafka-ACK markerer workeren outbox-raden som `SENT`. Dersom databaseoppdateringen
+feiler etter ACK, brukes samme event-ID ved retry, og Budstikka dedupliserer.
 
 Alle replikaer kjører worker uten leader election. Kafka-kallet er tidsbegrenset i produsenten og er
 kortere enn outbox-leasen.
@@ -40,8 +42,12 @@ av en outbox-kompatibel versjon.
 
 ## Retention og observability
 
-`SENT` og `CANCELLED` for denne meldingstypen slettes 90 dager etter `completed_at`. Den generiske,
-lederkoordinerte retention-tasken sletter i små, avgrensede transaksjoner.
+`SENT` og `CANCELLED` for denne meldingstypen slettes 90 dager etter `completed_at`. Kommandoen kan
+bare oppstå i den atomiske planopprettelsen; det finnes ingen reconciler eller reaktivering som kan
+opprette den på nytt. Terminal retention er derfor et app-eid operasjonelt og personvernmessig
+vindu, ikke en forutsetning for idempotens. Den generiske, lederkoordinerte retention-tasken sletter
+i små, avgrensede transaksjoner. Budstikka eier separat retention for sine egne inbox- og
+delivery-tabeller.
 
 Worker eksponerer lavkardinale målinger for antall leveringsklare rader, alder på eldste rad,
 utløpte claims og uløste tekniske feil. Dev og prod varsler på vedvarende køalder, utløpte leases og

--- a/nais/alerts-dev.yaml
+++ b/nais/alerts-dev.yaml
@@ -49,11 +49,11 @@ spec:
           labels:
             namespace: team-esyfo
             severity: warning
-        - alert: OppfolgingsplanOutboxRepeatedFailures
-          expr: syfo_oppfolgingsplan_backend_outbox_max_failure_count{namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_CREATED"} > 5
-          for: 10m
+        - alert: OppfolgingsplanOutboxPersistentFailures
+          expr: syfo_oppfolgingsplan_backend_outbox_retrying{namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_CREATED"} > 0
+          for: 15m
           annotations:
-            consequence: Minst ett opprettelsesvarsel har feilet gjentatte ganger, også om meldingen for øyeblikket venter i backoff.
+            consequence: Minst ett opprettelsesvarsel har hatt en uløst teknisk feil i minst 15 minutter, også om meldingen for øyeblikket venter i backoff.
             action: "Sjekk outbox-loggene, Budstikka/Kafka-tilgjengelighet og failure_count på ikke-terminale rader."
             summary: Oppfølgingsplan-outboxen har et varsel med vedvarende tekniske feil.
           labels:

--- a/nais/alerts-dev.yaml
+++ b/nais/alerts-dev.yaml
@@ -29,3 +29,33 @@ spec:
           labels:
             namespace: team-esyfo
             severity: warning
+        - alert: OppfolgingsplanOutboxOldestDueTooOld
+          expr: syfo_oppfolgingsplan_backend_outbox_oldest_due_age_seconds{namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_CREATED"} > 900
+          for: 10m
+          annotations:
+            consequence: Opprettelsesvarsler til Budstikka har vært klare for levering i mer enn 15 minutter.
+            action: "Sjekk outbox-loggene, Kafka/Budstikka-tilgjengelighet og failure_count på READY-rader."
+            summary: Oppfølgingsplan-outboxen leverer ikke varsler raskt nok.
+          labels:
+            namespace: team-esyfo
+            severity: warning
+        - alert: OppfolgingsplanOutboxExpiredClaims
+          expr: syfo_oppfolgingsplan_backend_outbox_expired_claims{namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_CREATED"} > 0
+          for: 10m
+          annotations:
+            consequence: Outbox-claims har forblitt utløpt og kan gi forsinkelse eller duplikate leveringsforsøk.
+            action: "Sjekk pod-restarts, handler-timeout, Kafka-latens og lease-budsjett i outbox-loggene."
+            summary: Oppfølgingsplan-outboxen har en vedvarende backlog av utløpte claims.
+          labels:
+            namespace: team-esyfo
+            severity: warning
+        - alert: OppfolgingsplanOutboxRepeatedFailures
+          expr: syfo_oppfolgingsplan_backend_outbox_max_failure_count{namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_CREATED"} > 5
+          for: 10m
+          annotations:
+            consequence: Minst ett opprettelsesvarsel har feilet gjentatte ganger, også om meldingen for øyeblikket venter i backoff.
+            action: "Sjekk outbox-loggene, Budstikka/Kafka-tilgjengelighet og failure_count på ikke-terminale rader."
+            summary: Oppfølgingsplan-outboxen har et varsel med vedvarende tekniske feil.
+          labels:
+            namespace: team-esyfo
+            severity: warning

--- a/nais/alerts-prod.yaml
+++ b/nais/alerts-prod.yaml
@@ -49,11 +49,11 @@ spec:
           labels:
             namespace: team-esyfo
             severity: warning
-        - alert: OppfolgingsplanOutboxRepeatedFailures
-          expr: syfo_oppfolgingsplan_backend_outbox_max_failure_count{namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_CREATED"} > 5
-          for: 10m
+        - alert: OppfolgingsplanOutboxPersistentFailures
+          expr: syfo_oppfolgingsplan_backend_outbox_retrying{namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_CREATED"} > 0
+          for: 15m
           annotations:
-            consequence: Minst ett opprettelsesvarsel har feilet gjentatte ganger, også om meldingen for øyeblikket venter i backoff.
+            consequence: Minst ett opprettelsesvarsel har hatt en uløst teknisk feil i minst 15 minutter, også om meldingen for øyeblikket venter i backoff.
             action: "Sjekk outbox-loggene, Budstikka/Kafka-tilgjengelighet og failure_count på ikke-terminale rader."
             summary: Oppfølgingsplan-outboxen har et varsel med vedvarende tekniske feil.
           labels:

--- a/nais/alerts-prod.yaml
+++ b/nais/alerts-prod.yaml
@@ -29,3 +29,33 @@ spec:
           labels:
             namespace: team-esyfo
             severity: warning
+        - alert: OppfolgingsplanOutboxOldestDueTooOld
+          expr: syfo_oppfolgingsplan_backend_outbox_oldest_due_age_seconds{namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_CREATED"} > 900
+          for: 10m
+          annotations:
+            consequence: Opprettelsesvarsler til Budstikka har vært klare for levering i mer enn 15 minutter.
+            action: "Sjekk outbox-loggene, Kafka/Budstikka-tilgjengelighet og failure_count på READY-rader."
+            summary: Oppfølgingsplan-outboxen leverer ikke varsler raskt nok.
+          labels:
+            namespace: team-esyfo
+            severity: critical
+        - alert: OppfolgingsplanOutboxExpiredClaims
+          expr: syfo_oppfolgingsplan_backend_outbox_expired_claims{namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_CREATED"} > 0
+          for: 10m
+          annotations:
+            consequence: Outbox-claims har forblitt utløpt og kan gi forsinkelse eller duplikate leveringsforsøk.
+            action: "Sjekk pod-restarts, handler-timeout, Kafka-latens og lease-budsjett i outbox-loggene."
+            summary: Oppfølgingsplan-outboxen har en vedvarende backlog av utløpte claims.
+          labels:
+            namespace: team-esyfo
+            severity: warning
+        - alert: OppfolgingsplanOutboxRepeatedFailures
+          expr: syfo_oppfolgingsplan_backend_outbox_max_failure_count{namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_CREATED"} > 5
+          for: 10m
+          annotations:
+            consequence: Minst ett opprettelsesvarsel har feilet gjentatte ganger, også om meldingen for øyeblikket venter i backoff.
+            action: "Sjekk outbox-loggene, Budstikka/Kafka-tilgjengelighet og failure_count på ikke-terminale rader."
+            summary: Oppfølgingsplan-outboxen har et varsel med vedvarende tekniske feil.
+          labels:
+            namespace: team-esyfo
+            severity: critical

--- a/src/main/kotlin/no/nav/syfo/application/outbox/OutboxWorker.kt
+++ b/src/main/kotlin/no/nav/syfo/application/outbox/OutboxWorker.kt
@@ -99,7 +99,9 @@ class OutboxWorker(
 
     private suspend fun processClaimedBatch(handler: OutboxMessageHandler): OutboxBatchResult {
         val batchStartedAt = clock.instant()
-        val claimed = database.exposedTransaction {
+        // The claim is pure database work and safe to replay when REPEATABLE READ surfaces 40001
+        // during a replica race. Handler side effects run only after this transaction commits.
+        val claimed = database.exposedTransaction(maxAttempts = 3) {
             claimOutboxMessages(
                 messageType = handler.messageType,
                 now = batchStartedAt,

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
@@ -1,8 +1,8 @@
 package no.nav.syfo.oppfolgingsplan.db
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.application.outbox.db.enqueueOutboxMessage
+import no.nav.syfo.application.outbox.domain.NewOutboxMessage
 import no.nav.syfo.dinesykmeldte.client.Sykmeldt
 import no.nav.syfo.dinesykmeldte.client.getOrganizationName
 import no.nav.syfo.oppfolgingsplan.db.domain.PersistedOppfolgingsplan
@@ -10,6 +10,7 @@ import no.nav.syfo.oppfolgingsplan.dto.CreateOppfolgingsplanRequest
 import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.FormSnapshot
 import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.jsonToFormSnapshot
 import no.nav.syfo.oppfolgingsplan.dto.formsnapshot.toJsonString
+import no.nav.syfo.oppfolgingsplan.outbox.OppfolgingsplanOutboxMessageType
 import org.slf4j.LoggerFactory
 import java.lang.invoke.MethodHandles
 import java.math.BigDecimal
@@ -50,7 +51,7 @@ fun DatabaseInterface.persistOppfolgingsplanAndDeleteUtkast(
             created_at,
             event_id
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), gen_random_uuid())
-        RETURNING uuid
+        RETURNING uuid, event_id, created_at
     """.trimIndent()
 
     val deleteStatement = """
@@ -70,7 +71,7 @@ fun DatabaseInterface.persistOppfolgingsplanAndDeleteUtkast(
             }
         }
 
-        val uuid = connection.prepareStatement(insertStatement).use {
+        val (uuid, eventId, createdAt) = connection.prepareStatement(insertStatement).use {
             it.setString(1, sykmeldt.fnr)
             it.setString(2, sykmeldt.navn)
             it.setString(3, sykmeldt.narmestelederId)
@@ -92,8 +93,24 @@ fun DatabaseInterface.persistOppfolgingsplanAndDeleteUtkast(
             }
             val resultSet = it.executeQuery()
             resultSet.next()
-            resultSet.getObject("uuid", UUID::class.java)
+            Triple(
+                resultSet.getObject("uuid", UUID::class.java),
+                resultSet.getObject("event_id", UUID::class.java),
+                resultSet.getTimestamp("created_at").toInstant(),
+            )
         }
+        check(
+            connection.enqueueOutboxMessage(
+                NewOutboxMessage(
+                    uuid = eventId,
+                    messageType = OppfolgingsplanOutboxMessageType.CREATED,
+                    dedupKey = uuid.toString(),
+                    externalRef = uuid.toString(),
+                    payload = "{}",
+                    availableAt = createdAt,
+                ),
+            ),
+        ) { "A new oppfolgingsplan must create a new outbox command" }
         connection.commit()
         return uuid
     }
@@ -402,45 +419,6 @@ fun DatabaseInterface.softDeleteExpiredOppfolgingsplaner(
             it.setInt(2, batchSize)
             it.executeUpdate()
         }.also { connection.commit() }
-    }
-}
-
-suspend fun DatabaseInterface.findEventId(
-    oppfolgingsplanId: UUID,
-): UUID = withContext(Dispatchers.IO) {
-    val statement = """
-        SELECT event_id 
-        FROM oppfolgingsplan
-        WHERE uuid = ?
-    """.trimIndent()
-
-    connection.use { connection ->
-        connection.prepareStatement(statement).use { preparedStatement ->
-            preparedStatement.setObject(1, oppfolgingsplanId)
-            preparedStatement.executeQuery().use { resultSet ->
-                if (resultSet.next()) {
-                    resultSet.getObject("event_id", UUID::class.java)
-                } else {
-                    throw IllegalStateException("Oppfolgingsplan not found")
-                }
-            }
-        }
-    }
-}
-
-suspend fun DatabaseInterface.setVarselPublished(oppfolgingsplanId: UUID) = withContext(Dispatchers.IO) {
-    val statement = """
-        UPDATE oppfolgingsplan
-        SET varsel_published_at = NOW()
-        WHERE uuid = ?
-    """.trimIndent()
-
-    connection.use { connection ->
-        connection.prepareStatement(statement).use { preparedStatement ->
-            preparedStatement.setObject(1, oppfolgingsplanId)
-            preparedStatement.executeUpdate()
-        }
-        connection.commit()
     }
 }
 

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanOutboxDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanOutboxDAO.kt
@@ -1,0 +1,34 @@
+package no.nav.syfo.oppfolgingsplan.db
+
+import no.nav.syfo.application.database.DatabaseInterface
+import java.util.UUID
+
+fun DatabaseInterface.findOppfolgingsplanVarselRecipient(
+    oppfolgingsplanUuid: UUID,
+): OppfolgingsplanVarselRecipient? = connection.use { connection ->
+    connection.prepareStatement(
+        """
+        SELECT sykmeldt_fnr
+        FROM oppfolgingsplan
+        WHERE uuid = ?
+          AND skjult_fra IS NULL
+          AND feilregistrert IS NULL
+        """.trimIndent(),
+    ).use { statement ->
+        statement.setObject(1, oppfolgingsplanUuid)
+        statement.executeQuery().use { resultSet ->
+            if (resultSet.next()) {
+                OppfolgingsplanVarselRecipient(resultSet.getString("sykmeldt_fnr"))
+            } else {
+                null
+            }
+        }
+    }
+}
+
+@JvmInline
+value class OppfolgingsplanVarselRecipient(
+    val sykmeldtFnr: String,
+) {
+    override fun toString(): String = "OppfolgingsplanVarselRecipient()"
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanOutboxDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanOutboxDAO.kt
@@ -3,27 +3,37 @@ package no.nav.syfo.oppfolgingsplan.db
 import no.nav.syfo.application.database.DatabaseInterface
 import java.util.UUID
 
-fun DatabaseInterface.findOppfolgingsplanVarselRecipient(
+fun DatabaseInterface.findOppfolgingsplanVarselSource(
     oppfolgingsplanUuid: UUID,
-): OppfolgingsplanVarselRecipient? = connection.use { connection ->
+): OppfolgingsplanVarselSource = connection.use { connection ->
     connection.prepareStatement(
         """
-        SELECT sykmeldt_fnr
+        SELECT
+            sykmeldt_fnr,
+            skjult_fra IS NULL AND feilregistrert IS NULL AS eligible
         FROM oppfolgingsplan
         WHERE uuid = ?
-          AND skjult_fra IS NULL
-          AND feilregistrert IS NULL
         """.trimIndent(),
     ).use { statement ->
         statement.setObject(1, oppfolgingsplanUuid)
         statement.executeQuery().use { resultSet ->
-            if (resultSet.next()) {
-                OppfolgingsplanVarselRecipient(resultSet.getString("sykmeldt_fnr"))
-            } else {
-                null
+            when {
+                !resultSet.next() -> OppfolgingsplanVarselSource.NotFound
+                !resultSet.getBoolean("eligible") -> OppfolgingsplanVarselSource.NoLongerEligible
+                else -> OppfolgingsplanVarselSource.Eligible(
+                    OppfolgingsplanVarselRecipient(resultSet.getString("sykmeldt_fnr")),
+                )
             }
         }
     }
+}
+
+sealed interface OppfolgingsplanVarselSource {
+    data class Eligible(val recipient: OppfolgingsplanVarselRecipient) : OppfolgingsplanVarselSource
+
+    data object NotFound : OppfolgingsplanVarselSource
+
+    data object NoLongerEligible : OppfolgingsplanVarselSource
 }
 
 @JvmInline

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/outbox/OppfolgingsplanCreatedOutboxHandler.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/outbox/OppfolgingsplanCreatedOutboxHandler.kt
@@ -2,12 +2,15 @@ package no.nav.syfo.oppfolgingsplan.outbox
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import net.logstash.logback.argument.StructuredArguments.kv
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.application.outbox.OutboxMessageHandler
 import no.nav.syfo.application.outbox.OutboxResult
 import no.nav.syfo.application.outbox.domain.OutboxCancellationReason
 import no.nav.syfo.application.outbox.domain.OutboxMessage
-import no.nav.syfo.oppfolgingsplan.db.findOppfolgingsplanVarselRecipient
+import no.nav.syfo.oppfolgingsplan.db.OppfolgingsplanVarselSource
+import no.nav.syfo.oppfolgingsplan.db.findOppfolgingsplanVarselSource
+import no.nav.syfo.util.logger
 import no.nav.syfo.varsel.budstikka.infrastructure.BudstikkaPublisher
 import java.time.Instant
 import java.util.UUID
@@ -16,6 +19,8 @@ class OppfolgingsplanCreatedOutboxHandler(
     private val database: DatabaseInterface,
     private val publisher: BudstikkaPublisher,
 ) : OutboxMessageHandler {
+    private val log = logger()
+
     override val messageType = OppfolgingsplanOutboxMessageType.CREATED
 
     override suspend fun handle(
@@ -23,16 +28,31 @@ class OppfolgingsplanCreatedOutboxHandler(
         now: Instant,
     ): OutboxResult {
         val oppfolgingsplanUuid = message.externalRef.toUuid()
-        val recipient = withContext(Dispatchers.IO) {
-            database.findOppfolgingsplanVarselRecipient(oppfolgingsplanUuid)
-        } ?: return OutboxResult.Cancelled(OutboxCancellationReason.SOURCE_NO_LONGER_ELIGIBLE)
-
-        publisher.publishOppfolgingsplanCreated(
-            oppfolgingsplanUuid = oppfolgingsplanUuid,
-            sykmeldtFnr = recipient.sykmeldtFnr,
-            eventId = message.uuid,
-        )
-        return OutboxResult.Sent
+        return when (
+            val source = withContext(Dispatchers.IO) {
+                database.findOppfolgingsplanVarselSource(oppfolgingsplanUuid)
+            }
+        ) {
+            is OppfolgingsplanVarselSource.Eligible -> {
+                publisher.publishOppfolgingsplanCreated(
+                    oppfolgingsplanUuid = oppfolgingsplanUuid,
+                    sykmeldtFnr = source.recipient.sykmeldtFnr,
+                    eventId = message.uuid,
+                )
+                OutboxResult.Sent
+            }
+            OppfolgingsplanVarselSource.NoLongerEligible ->
+                OutboxResult.Cancelled(OutboxCancellationReason.SOURCE_NO_LONGER_ELIGIBLE)
+            OppfolgingsplanVarselSource.NotFound -> {
+                log.error(
+                    "Cancelling outbox message because its source oppfolgingsplan was not found {} {} {}",
+                    kv("outbox_uuid", message.uuid),
+                    kv("message_type", message.messageType.value),
+                    kv("cancellation_reason", OutboxCancellationReason.SOURCE_NOT_FOUND.value),
+                )
+                OutboxResult.Cancelled(OutboxCancellationReason.SOURCE_NOT_FOUND)
+            }
+        }
     }
 
     private fun String.toUuid(): UUID = try {

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/outbox/OppfolgingsplanCreatedOutboxHandler.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/outbox/OppfolgingsplanCreatedOutboxHandler.kt
@@ -1,0 +1,43 @@
+package no.nav.syfo.oppfolgingsplan.outbox
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.application.outbox.OutboxMessageHandler
+import no.nav.syfo.application.outbox.OutboxResult
+import no.nav.syfo.application.outbox.domain.OutboxCancellationReason
+import no.nav.syfo.application.outbox.domain.OutboxMessage
+import no.nav.syfo.oppfolgingsplan.db.findOppfolgingsplanVarselRecipient
+import no.nav.syfo.varsel.budstikka.infrastructure.BudstikkaPublisher
+import java.time.Instant
+import java.util.UUID
+
+class OppfolgingsplanCreatedOutboxHandler(
+    private val database: DatabaseInterface,
+    private val publisher: BudstikkaPublisher,
+) : OutboxMessageHandler {
+    override val messageType = OppfolgingsplanOutboxMessageType.CREATED
+
+    override suspend fun handle(
+        message: OutboxMessage,
+        now: Instant,
+    ): OutboxResult {
+        val oppfolgingsplanUuid = message.externalRef.toUuid()
+        val recipient = withContext(Dispatchers.IO) {
+            database.findOppfolgingsplanVarselRecipient(oppfolgingsplanUuid)
+        } ?: return OutboxResult.Cancelled(OutboxCancellationReason.SOURCE_NO_LONGER_ELIGIBLE)
+
+        publisher.publishOppfolgingsplanCreated(
+            oppfolgingsplanUuid = oppfolgingsplanUuid,
+            sykmeldtFnr = recipient.sykmeldtFnr,
+            eventId = message.uuid,
+        )
+        return OutboxResult.Sent
+    }
+
+    private fun String.toUuid(): UUID = try {
+        UUID.fromString(this)
+    } catch (error: IllegalArgumentException) {
+        throw IllegalArgumentException("Outbox externalRef must be an oppfolgingsplan UUID", error)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/outbox/OppfolgingsplanOutboxMessageType.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/outbox/OppfolgingsplanOutboxMessageType.kt
@@ -1,0 +1,9 @@
+package no.nav.syfo.oppfolgingsplan.outbox
+
+import no.nav.syfo.application.outbox.domain.OutboxMessageType
+
+enum class OppfolgingsplanOutboxMessageType(
+    override val value: String,
+) : OutboxMessageType {
+    CREATED("OPPFOLGINGSPLAN_CREATED"),
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
@@ -3,7 +3,6 @@ package no.nav.syfo.oppfolgingsplan.service
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import net.logstash.logback.argument.StructuredArguments.kv
 import no.nav.syfo.aareg.AaregService
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.application.exception.ApiErrorException
@@ -18,7 +17,6 @@ import no.nav.syfo.oppfolgingsplan.db.domain.PersistedOppfolgingsplanUtkast
 import no.nav.syfo.oppfolgingsplan.db.domain.toOppfolgingsplanMetadata
 import no.nav.syfo.oppfolgingsplan.db.domain.toUtkastMetadata
 import no.nav.syfo.oppfolgingsplan.db.findAllOppfolgingsplanerBy
-import no.nav.syfo.oppfolgingsplan.db.findEventId
 import no.nav.syfo.oppfolgingsplan.db.findOppfolgingsplanBy
 import no.nav.syfo.oppfolgingsplan.db.findOppfolgingsplanUtkastBy
 import no.nav.syfo.oppfolgingsplan.db.persistOppfolgingsplanAndDeleteUtkast
@@ -26,7 +24,6 @@ import no.nav.syfo.oppfolgingsplan.db.setDeltMedLegeTidspunkt
 import no.nav.syfo.oppfolgingsplan.db.setDeltMedVeilederTidspunkt
 import no.nav.syfo.oppfolgingsplan.db.setJournalpostId
 import no.nav.syfo.oppfolgingsplan.db.setNarmesteLederFullName
-import no.nav.syfo.oppfolgingsplan.db.setVarselPublished
 import no.nav.syfo.oppfolgingsplan.db.softDeleteExpiredOppfolgingsplaner
 import no.nav.syfo.oppfolgingsplan.db.updateDelingAvPlanMedVeileder
 import no.nav.syfo.oppfolgingsplan.db.updateSkalDelesMedLege
@@ -43,7 +40,6 @@ import no.nav.syfo.oppfolgingsplan.dto.utledGjeldendeStatus
 import no.nav.syfo.pdl.PdlService
 import no.nav.syfo.util.logger
 import no.nav.syfo.varsel.EsyfovarselProducer
-import no.nav.syfo.varsel.budstikka.infrastructure.BudstikkaPublisher
 import no.nav.syfo.varsel.domain.ArbeidstakerHendelse
 import no.nav.syfo.varsel.domain.HendelseType
 import java.time.Instant
@@ -61,7 +57,6 @@ const val OPPFOLGINGSPLAN_UTKAST_RETENTION_MONTHS = 4
 class OppfolgingsplanService(
     private val database: DatabaseInterface,
     private val esyfovarselProducer: EsyfovarselProducer,
-    private val budstikkaPublisher: BudstikkaPublisher,
     private val pdlService: PdlService,
     private val aaregService: AaregService,
     private val unntaksvurderingService: UnntaksvurderingService,
@@ -88,7 +83,7 @@ class OppfolgingsplanService(
             null
         }
 
-        val uuid = withContext(Dispatchers.IO) {
+        return withContext(Dispatchers.IO) {
             database.persistOppfolgingsplanAndDeleteUtkast(
                 narmesteLederFnr = narmesteLederFnr,
                 sykmeldt = sykmeldt,
@@ -97,28 +92,6 @@ class OppfolgingsplanService(
                 stillingsprosent = stillingsinformasjon?.stillingsprosent,
             )
         }
-
-        val eventId = database.findEventId(uuid)
-
-        try {
-            budstikkaPublisher.publishOppfolgingsplanCreated(
-                oppfolgingsplanUuid = uuid,
-                sykmeldtFnr = sykmeldt.fnr,
-                eventId = eventId,
-            )
-            database.setVarselPublished(uuid)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            logger.error(
-                "Error when publishing Budstikka varsel {}, {}",
-                kv("oppfolgingsplan_uuid", uuid),
-                kv("event_id", eventId),
-                e,
-            )
-        }
-
-        return uuid
     }
 
     suspend fun persistOppfolgingsplanUtkast(

--- a/src/main/kotlin/no/nav/syfo/plugins/ConfigureTasks.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/ConfigureTasks.kt
@@ -3,6 +3,8 @@ package no.nav.syfo.plugins
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationStopping
 import kotlinx.coroutines.launch
+import no.nav.syfo.application.outbox.OutboxRetentionTask
+import no.nav.syfo.application.outbox.OutboxTask
 import no.nav.syfo.dokumentporten.SendOppfolgingsplanTask
 import no.nav.syfo.oppfolgingsplan.task.CleanupUtkastTask
 import no.nav.syfo.oppfolgingsplan.task.SoftDeleteOppfolgingsplanerTask
@@ -13,12 +15,16 @@ import org.koin.ktor.ext.inject
 fun Application.configureBackgroundTasks() {
     val sendDialogTask by inject<SendOppfolgingsplanTask>()
     val cleanupUtkastTask by inject<CleanupUtkastTask>()
+    val outboxTask by inject<OutboxTask>()
+    val outboxRetentionTask by inject<OutboxRetentionTask>()
     val softDeleteOppfolgingsplanerTask by inject<SoftDeleteOppfolgingsplanerTask>()
     val softDeleteUnntaksvurderingerTask by inject<SoftDeleteUnntaksvurderingerTask>()
     val sykmeldingsperiodeConsumer by inject<SykmeldingsperiodeConsumer>()
 
     val sendDialogTaskJob = launch { sendDialogTask.runTask() }
     val cleanupUtkastTaskJob = launch { cleanupUtkastTask.runTask() }
+    val outboxTaskJob = launch { outboxTask.runTask() }
+    val outboxRetentionTaskJob = launch { outboxRetentionTask.runTask() }
     val softDeleteOppfolgingsplanerTaskJob = launch { softDeleteOppfolgingsplanerTask.runTask() }
     val softDeleteUnntaksvurderingerTaskJob = launch { softDeleteUnntaksvurderingerTask.runTask() }
     val sykmeldingsperiodeConsumerJob = launch { sykmeldingsperiodeConsumer.runConsumer() }
@@ -26,6 +32,8 @@ fun Application.configureBackgroundTasks() {
         sykmeldingsperiodeConsumer.stop()
         sendDialogTaskJob.cancel()
         cleanupUtkastTaskJob.cancel()
+        outboxTaskJob.cancel()
+        outboxRetentionTaskJob.cancel()
         softDeleteOppfolgingsplanerTaskJob.cancel()
         softDeleteUnntaksvurderingerTaskJob.cancel()
         sykmeldingsperiodeConsumerJob.cancel()

--- a/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
@@ -18,6 +18,10 @@ import no.nav.syfo.application.isProdEnv
 import no.nav.syfo.application.kafka.producerProperties
 import no.nav.syfo.application.kafka.stringProducerProperties
 import no.nav.syfo.application.leaderelection.LeaderElection
+import no.nav.syfo.application.outbox.OutboxRetentionPolicy
+import no.nav.syfo.application.outbox.OutboxRetentionTask
+import no.nav.syfo.application.outbox.OutboxTask
+import no.nav.syfo.application.outbox.OutboxWorker
 import no.nav.syfo.application.valkey.ValkeyCache
 import no.nav.syfo.dinesykmeldte.DineSykmeldteService
 import no.nav.syfo.dinesykmeldte.client.DineSykmeldteHttpClient
@@ -36,6 +40,8 @@ import no.nav.syfo.isdialogmelding.client.IsDialogmeldingClient
 import no.nav.syfo.istilgangskontroll.IsTilgangskontrollService
 import no.nav.syfo.istilgangskontroll.client.FakeIsTilgangskontrollClient
 import no.nav.syfo.istilgangskontroll.client.IsTilgangskontrollClient
+import no.nav.syfo.oppfolgingsplan.outbox.OppfolgingsplanCreatedOutboxHandler
+import no.nav.syfo.oppfolgingsplan.outbox.OppfolgingsplanOutboxMessageType
 import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
 import no.nav.syfo.oppfolgingsplan.service.PaaminnelseService
 import no.nav.syfo.oppfolgingsplan.service.UnntaksvurderingService
@@ -61,6 +67,7 @@ import org.koin.core.scope.Scope
 import org.koin.dsl.module
 import org.koin.ktor.plugin.Koin
 import org.koin.logger.slf4jLogger
+import java.time.Duration
 
 fun Application.configureDependencies() {
     install(Koin) {
@@ -227,7 +234,6 @@ private fun servicesModule() = module {
         OppfolgingsplanService(
             database = get(),
             esyfovarselProducer = get(),
-            budstikkaPublisher = get(),
             pdlService = get(),
             aaregService = get(),
             unntaksvurderingService = get(),
@@ -237,6 +243,26 @@ private fun servicesModule() = module {
     single { PdfGenService(get(), get()) }
     single { SendOppfolgingsplanTask(get(), get()) }
     single { CleanupUtkastTask(get(), get()) }
+    single { OppfolgingsplanCreatedOutboxHandler(database = get(), publisher = get()) }
+    single {
+        OutboxWorker(
+            database = get(),
+            handlers = listOf(get<OppfolgingsplanCreatedOutboxHandler>()),
+        )
+    }
+    single { OutboxTask(worker = get()) }
+    single {
+        OutboxRetentionTask(
+            database = get(),
+            leaderElection = get(),
+            policies = listOf(
+                OutboxRetentionPolicy(
+                    messageType = OppfolgingsplanOutboxMessageType.CREATED,
+                    retention = Duration.ofDays(90),
+                ),
+            ),
+        )
+    }
     single {
         SoftDeleteOppfolgingsplanerTask(
             leaderElection = get(),

--- a/src/test/kotlin/no/nav/syfo/TestDb.kt
+++ b/src/test/kotlin/no/nav/syfo/TestDb.kt
@@ -273,22 +273,16 @@ fun DatabaseInterface.findOppfolgingsplanUtkastByNarmesteLederId(
     }
 }
 
-fun DatabaseInterface.findVarselPublishedAtByOppfolgingsplanId(
-    oppfolgingsplanId: UUID,
-): Instant? = connection.use { connection ->
+fun DatabaseInterface.findEventId(oppfolgingsplanId: UUID): UUID? = connection.use { connection ->
     connection.prepareStatement(
         """
-        SELECT varsel_published_at
+        SELECT event_id
         FROM oppfolgingsplan
         WHERE uuid = ?
         """.trimIndent(),
     ).use {
         it.setObject(1, oppfolgingsplanId)
         val resultSet = it.executeQuery()
-        if (resultSet.next()) {
-            resultSet.getTimestamp("varsel_published_at")?.toInstant()
-        } else {
-            null
-        }
+        if (resultSet.next()) resultSet.getObject("event_id", UUID::class.java) else null
     }
 }

--- a/src/test/kotlin/no/nav/syfo/application/outbox/OutboxDAOTest.kt
+++ b/src/test/kotlin/no/nav/syfo/application/outbox/OutboxDAOTest.kt
@@ -159,6 +159,32 @@ class OutboxDAOTest :
         }
 
         describe("claimOutboxMessages") {
+            it("replays a claim that encounters a stale repeatable-read snapshot") {
+                TestDB.database.enqueueTestOutboxMessage(availableAt = now)
+                val staleSnapshotEstablished = CountDownLatch(1)
+                val competingClaimCommitted = CountDownLatch(1)
+                val attempts = AtomicInteger(0)
+
+                coroutineScope {
+                    val staleClaim = async(Dispatchers.IO) {
+                        TestDB.database.exposedTransaction(maxAttempts = 3) {
+                            if (attempts.incrementAndGet() == 1) {
+                                exec("SELECT 1")
+                                staleSnapshotEstablished.countDown()
+                                competingClaimCommitted.await()
+                            }
+                            claimOutboxMessages(TEST_IMMEDIATE_MESSAGE, now, 1, 5.minutes)
+                        }
+                    }
+
+                    staleSnapshotEstablished.await()
+                    TestDB.database.claim(now).single()
+                    competingClaimCommitted.countDown()
+                    staleClaim.await().shouldBeEmpty()
+                }
+                attempts.get() shouldBeExactly 2
+            }
+
             it("claims only due messages and persists a lease token") {
                 val due = TestDB.database.enqueueTestOutboxMessage(availableAt = now.minusSeconds(1))
                 TestDB.database.enqueueTestOutboxMessage(availableAt = now.plusSeconds(1))

--- a/src/test/kotlin/no/nav/syfo/dokumentporten/DokumentportenServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/dokumentporten/DokumentportenServiceTest.kt
@@ -30,7 +30,6 @@ class DokumentportenServiceTest :
             database = testDb,
             pdlService = mockk<PdlService>(relaxed = true),
             esyfovarselProducer = mockk<EsyfovarselProducer>(relaxed = true),
-            budstikkaPublisher = mockk(relaxed = true),
             aaregService = mockk<AaregService>(relaxed = true),
             unntaksvurderingService = mockk(relaxed = true),
         )

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
@@ -35,6 +35,8 @@ import no.nav.syfo.application.LocalEnvironment
 import no.nav.syfo.application.exception.ApiError
 import no.nav.syfo.application.exception.ErrorType
 import no.nav.syfo.application.exception.LegeNotFoundException
+import no.nav.syfo.application.outbox.db.findOutboxMessage
+import no.nav.syfo.application.outbox.domain.OutboxStatus
 import no.nav.syfo.application.valkey.ValkeyCache
 import no.nav.syfo.defaultMocks
 import no.nav.syfo.defaultOppfolgingsplan
@@ -44,6 +46,7 @@ import no.nav.syfo.defaultUtkastRequest
 import no.nav.syfo.dinesykmeldte.DineSykmeldteService
 import no.nav.syfo.dinesykmeldte.client.DineSykmeldteHttpClient
 import no.nav.syfo.dokarkiv.DokarkivService
+import no.nav.syfo.findEventId
 import no.nav.syfo.generatedPdfStandin
 import no.nav.syfo.isdialogmelding.IsDialogmeldingService
 import no.nav.syfo.isdialogmelding.client.IsDialogmeldingClient
@@ -51,13 +54,13 @@ import no.nav.syfo.istilgangskontroll.IsTilgangskontrollService
 import no.nav.syfo.istilgangskontroll.client.IIsTilgangskontrollClient
 import no.nav.syfo.oppfolgingsplan.api.v1.registerApiV1
 import no.nav.syfo.oppfolgingsplan.db.findAllOppfolgingsplanerBy
-import no.nav.syfo.oppfolgingsplan.db.findEventId
 import no.nav.syfo.oppfolgingsplan.db.findOppfolgingsplanUtkastBy
 import no.nav.syfo.oppfolgingsplan.db.upsertOppfolgingsplanUtkast
 import no.nav.syfo.oppfolgingsplan.dto.ArbeidsgiverOppfolgingsplanOverviewResponse
 import no.nav.syfo.oppfolgingsplan.dto.DelMedLegeResponse
 import no.nav.syfo.oppfolgingsplan.dto.DelMedVeilederResponse
 import no.nav.syfo.oppfolgingsplan.dto.OppfolgingsplanResponse
+import no.nav.syfo.oppfolgingsplan.outbox.OppfolgingsplanOutboxMessageType
 import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
 import no.nav.syfo.pdfgen.PdfGenService
 import no.nav.syfo.pdl.PdlService
@@ -68,7 +71,6 @@ import no.nav.syfo.returnsNotFound
 import no.nav.syfo.texas.client.TexasHttpClient
 import no.nav.syfo.texas.client.TexasIntrospectionResponse
 import no.nav.syfo.varsel.EsyfovarselProducer
-import no.nav.syfo.varsel.budstikka.infrastructure.BudstikkaPublisher
 import java.math.BigDecimal
 import java.time.Instant
 import java.util.UUID
@@ -80,7 +82,6 @@ class OppfolgingsplanApiV1Test :
         val dineSykmeldteHttpClientMock = mockk<DineSykmeldteHttpClient>()
         val valkeyCacheMock = mockk<ValkeyCache>(relaxUnitFun = true)
         val esyfovarselProducerMock = mockk<EsyfovarselProducer>()
-        val budstikkaPublisherMock = mockk<BudstikkaPublisher>()
         val testDb = TestDB.database
         val isDialogmeldingClientMock = mockk<IsDialogmeldingClient>()
         val isTilgangskontrollClientMock = mockk<IIsTilgangskontrollClient>()
@@ -99,7 +100,6 @@ class OppfolgingsplanApiV1Test :
             clearAllMocks(currentThreadOnly = true)
             TestDB.clearAllData()
             every { valkeyCacheMock.getSykmeldt(any(), any()) } returns null
-            coEvery { budstikkaPublisherMock.publishOppfolgingsplanCreated(any(), any(), any()) } answers { thirdArg<UUID>() }
             coEvery { aaregServiceMock.getStillingsinformasjon(any(), any()) } returns Stillingsinformasjon(
                 stillingstittel = "Systemutvikler",
                 stillingsprosent = BigDecimal("100.00"),
@@ -108,7 +108,6 @@ class OppfolgingsplanApiV1Test :
         val oppfolgingsplanService = OppfolgingsplanService(
             database = testDb,
             esyfovarselProducer = esyfovarselProducerMock,
-            budstikkaPublisher = budstikkaPublisherMock,
             pdlService = pdlServiceMock,
             aaregService = aaregServiceMock,
             unntaksvurderingService = mockk(relaxed = true),
@@ -504,13 +503,12 @@ class OppfolgingsplanApiV1Test :
                     persisted.first().stillingsprosent shouldBe BigDecimal("100.00")
                     val persistedEventId = testDb.findEventId(persisted.first().uuid)
                     persistedEventId.shouldNotBeNull()
-                    coVerify(exactly = 1) {
-                        budstikkaPublisherMock.publishOppfolgingsplanCreated(
-                            persisted.first().uuid,
-                            sykmeldt.fnr,
-                            persistedEventId,
-                        )
-                    }
+                    val outboxMessage = testDb.findOutboxMessage(
+                        OppfolgingsplanOutboxMessageType.CREATED,
+                        persisted.first().uuid.toString(),
+                    ).shouldNotBeNull()
+                    outboxMessage.uuid shouldBe persistedEventId
+                    outboxMessage.status shouldBe OutboxStatus.READY
                 }
             }
             it("POST /oppfolgingsplaner creates new oppfolgingsplan and deletes existing utkast for narmesteLederId") {
@@ -554,52 +552,10 @@ class OppfolgingsplanApiV1Test :
                     persistedUtkast shouldBe null
                     val persistedEventId = testDb.findEventId(persistedOppfolgingsplaner.first().uuid)
                     persistedEventId.shouldNotBeNull()
-                    coVerify(exactly = 1) {
-                        budstikkaPublisherMock.publishOppfolgingsplanCreated(
-                            persistedOppfolgingsplaner.first().uuid,
-                            sykmeldt.fnr,
-                            persistedEventId,
-                        )
-                    }
-                }
-            }
-        }
-        it("POST /oppfolgingsplaner still creates new oppfolgingsplan when Budstikka publisher throws exception") {
-            withTestApplication {
-                // Arrange
-                texasClientMock.defaultMocks(pidInnlogetBruker, clientId = environment.syfoOppfolgingsplanFrontendClientId)
-
-                dineSykmeldteHttpClientMock.defaultMocks(narmestelederId = narmestelederId)
-
-                coEvery {
-                    budstikkaPublisherMock.publishOppfolgingsplanCreated(any(), any(), any())
-                } throws RuntimeException("exception")
-
-                testDb.upsertOppfolgingsplanUtkast(
-                    narmesteLederFnr = pidInnlogetBruker,
-                    sykmeldt = sykmeldt,
-                    lagreUtkastRequest = defaultUtkastRequest(),
-                )
-
-                // Act
-                val response = client.post {
-                    url("/api/v1/arbeidsgiver/$narmestelederId/oppfolgingsplaner")
-                    bearerAuth("******")
-                    contentType(ContentType.Application.Json)
-                    setBody(defaultOppfolgingsplan())
-                }
-
-                // Assert
-                response.status shouldBe HttpStatusCode.Created
-                val persistedOppfolgingsplaner = testDb.findAllOppfolgingsplanerBy("12345678901", "orgnummer")
-                persistedOppfolgingsplaner.size shouldBe 1
-                testDb.findEventId(persistedOppfolgingsplaner.first().uuid) shouldNotBe null
-                coVerify(exactly = 1) {
-                    budstikkaPublisherMock.publishOppfolgingsplanCreated(
-                        persistedOppfolgingsplaner.first().uuid,
-                        sykmeldt.fnr,
-                        any(),
-                    )
+                    testDb.findOutboxMessage(
+                        OppfolgingsplanOutboxMessageType.CREATED,
+                        persistedOppfolgingsplaner.first().uuid.toString(),
+                    ).shouldNotBeNull().uuid shouldBe persistedEventId
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanUtkastApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanUtkastApiV1Test.kt
@@ -77,7 +77,6 @@ class OppfolgingsplanUtkastApiV1Test :
             database = testDb,
             esyfovarselProducer = esyfovarselProducerMock,
             pdlService = pdlService,
-            budstikkaPublisher = mockk(relaxed = true),
             aaregService = mockk<AaregService>(relaxed = true),
             unntaksvurderingService = mockk(relaxed = true),
         )

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/UnntaksvurderingApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/UnntaksvurderingApiV1Test.kt
@@ -53,7 +53,6 @@ import no.nav.syfo.plugins.installContentNegotiation
 import no.nav.syfo.plugins.installStatusPages
 import no.nav.syfo.texas.client.TexasHttpClient
 import no.nav.syfo.varsel.EsyfovarselProducer
-import no.nav.syfo.varsel.budstikka.infrastructure.BudstikkaPublisher
 import java.time.Instant
 import java.util.UUID
 
@@ -64,7 +63,6 @@ class UnntaksvurderingApiV1Test :
         val dineSykmeldteHttpClientMock = mockk<DineSykmeldteHttpClient>()
         val valkeyCacheMock = mockk<ValkeyCache>(relaxUnitFun = true)
         val esyfovarselProducerMock = mockk<EsyfovarselProducer>()
-        val budstikkaPublisherMock = mockk<BudstikkaPublisher>()
         val testDb = TestDB.database
         val isDialogmeldingClientMock = mockk<IsDialogmeldingClient>()
         val isTilgangskontrollClientMock = mockk<IIsTilgangskontrollClient>()
@@ -89,7 +87,6 @@ class UnntaksvurderingApiV1Test :
         val oppfolgingsplanService = OppfolgingsplanService(
             database = testDb,
             esyfovarselProducer = esyfovarselProducerMock,
-            budstikkaPublisher = budstikkaPublisherMock,
             pdlService = pdlServiceMock,
             aaregService = aaregServiceMock,
             unntaksvurderingService = unntaksvurderingService,

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/OppfolgingsplanApiV1Test.kt
@@ -107,7 +107,6 @@ class OppfolgingsplanApiV1Test :
                                 database = testDb,
                                 esyfovarselProducer = esyfovarselProducerMock,
                                 pdlService = pdlServiceMock,
-                                budstikkaPublisher = mockk(relaxed = true),
                                 aaregService = aaregServiceMock,
                                 unntaksvurderingService = mockk(relaxed = true),
                             ),

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederOppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederOppfolgingsplanApiV1Test.kt
@@ -102,7 +102,6 @@ class VeilederOppfolgingsplanApiV1Test :
                                 database = testDb,
                                 esyfovarselProducer = esyfovarselProducerMock,
                                 pdlService = mockk(relaxed = true),
-                                budstikkaPublisher = mockk(relaxed = true),
                                 aaregService = mockk<AaregService>(relaxed = true),
                                 unntaksvurderingService = mockk(relaxed = true),
                             ),

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/outbox/OppfolgingsplanCreatedOutboxIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/outbox/OppfolgingsplanCreatedOutboxIntegrationTest.kt
@@ -1,5 +1,9 @@
 package no.nav.syfo.oppfolgingsplan.outbox
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -13,6 +17,7 @@ import no.nav.syfo.TestDB
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.application.outbox.OutboxWorker
 import no.nav.syfo.application.outbox.db.findOutboxMessage
+import no.nav.syfo.application.outbox.domain.OutboxCancellationReason
 import no.nav.syfo.application.outbox.domain.OutboxStatus
 import no.nav.syfo.defaultOppfolgingsplan
 import no.nav.syfo.defaultPersistedOppfolgingsplanUtkast
@@ -24,6 +29,7 @@ import no.nav.syfo.oppfolgingsplan.db.findOppfolgingsplanBy
 import no.nav.syfo.oppfolgingsplan.db.persistOppfolgingsplanAndDeleteUtkast
 import no.nav.syfo.persistOppfolgingsplanUtkast
 import no.nav.syfo.varsel.budstikka.infrastructure.BudstikkaPublisher
+import org.slf4j.LoggerFactory
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
@@ -133,7 +139,62 @@ class OppfolgingsplanCreatedOutboxIntegrationTest :
 
                 worker.runOnce().cancelled shouldBe 1
 
-                TestDB.database.findCreatedMessage(planUuid).status shouldBe OutboxStatus.CANCELLED
+                TestDB.database.findCreatedMessage(planUuid).let { message ->
+                    message.status shouldBe OutboxStatus.CANCELLED
+                    message.cancellationReason shouldBe OutboxCancellationReason.SOURCE_NO_LONGER_ELIGIBLE
+                }
+                coVerify(exactly = 0) { publisher.publishOppfolgingsplanCreated(any(), any(), any()) }
+            }
+
+            it("cancels with source not found when the atomic source invariant is broken") {
+                val planUuid = TestDB.database.createOppfolgingsplan()
+                val outboxMessage = TestDB.database.findCreatedMessage(planUuid)
+                TestDB.database.deletePlan(planUuid)
+                val publisher = mockk<BudstikkaPublisher>(relaxed = true)
+                val worker = OutboxWorker(
+                    database = TestDB.database,
+                    handlers = listOf(OppfolgingsplanCreatedOutboxHandler(TestDB.database, publisher)),
+                    clock = clock,
+                )
+                val handlerLogger = LoggerFactory.getLogger(OppfolgingsplanCreatedOutboxHandler::class.java) as Logger
+                val appender = ListAppender<ILoggingEvent>().apply { start() }
+                handlerLogger.addAppender(appender)
+
+                try {
+                    worker.runOnce().cancelled shouldBe 1
+
+                    TestDB.database.findCreatedMessage(planUuid).let { message ->
+                        message.status shouldBe OutboxStatus.CANCELLED
+                        message.cancellationReason shouldBe OutboxCancellationReason.SOURCE_NOT_FOUND
+                    }
+                    appender.list.any {
+                        it.level == Level.ERROR &&
+                            it.formattedMessage.contains(outboxMessage.uuid.toString()) &&
+                            it.formattedMessage.contains(OutboxCancellationReason.SOURCE_NOT_FOUND.value)
+                    } shouldBe true
+                    coVerify(exactly = 0) { publisher.publishOppfolgingsplanCreated(any(), any(), any()) }
+                } finally {
+                    handlerLogger.detachAppender(appender)
+                    appender.stop()
+                }
+            }
+
+            it("cancels a notification when the plan was feilregistrert") {
+                val planUuid = TestDB.database.createOppfolgingsplan()
+                TestDB.database.setPlanFeilregistrert(planUuid, now)
+                val publisher = mockk<BudstikkaPublisher>(relaxed = true)
+                val worker = OutboxWorker(
+                    database = TestDB.database,
+                    handlers = listOf(OppfolgingsplanCreatedOutboxHandler(TestDB.database, publisher)),
+                    clock = clock,
+                )
+
+                worker.runOnce().cancelled shouldBe 1
+
+                TestDB.database.findCreatedMessage(planUuid).let { message ->
+                    message.status shouldBe OutboxStatus.CANCELLED
+                    message.cancellationReason shouldBe OutboxCancellationReason.SOURCE_NO_LONGER_ELIGIBLE
+                }
                 coVerify(exactly = 0) { publisher.publishOppfolgingsplanCreated(any(), any(), any()) }
             }
         }
@@ -161,6 +222,26 @@ private fun DatabaseInterface.setPlanHidden(
     connection.prepareStatement("UPDATE oppfolgingsplan SET skjult_fra = ? WHERE uuid = ?").use {
         it.setObject(1, hiddenAt.atOffset(ZoneOffset.UTC))
         it.setObject(2, planUuid)
+        it.executeUpdate()
+    }
+    connection.commit()
+}
+
+private fun DatabaseInterface.setPlanFeilregistrert(
+    planUuid: UUID,
+    feilregistrertAt: Instant,
+) = connection.use { connection ->
+    connection.prepareStatement("UPDATE oppfolgingsplan SET feilregistrert = ? WHERE uuid = ?").use {
+        it.setObject(1, feilregistrertAt.atOffset(ZoneOffset.UTC))
+        it.setObject(2, planUuid)
+        it.executeUpdate()
+    }
+    connection.commit()
+}
+
+private fun DatabaseInterface.deletePlan(planUuid: UUID) = connection.use { connection ->
+    connection.prepareStatement("DELETE FROM oppfolgingsplan WHERE uuid = ?").use {
+        it.setObject(1, planUuid)
         it.executeUpdate()
     }
     connection.commit()

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/outbox/OppfolgingsplanCreatedOutboxIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/outbox/OppfolgingsplanCreatedOutboxIntegrationTest.kt
@@ -1,0 +1,187 @@
+package no.nav.syfo.oppfolgingsplan.outbox
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import no.nav.syfo.TestDB
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.application.outbox.OutboxWorker
+import no.nav.syfo.application.outbox.db.findOutboxMessage
+import no.nav.syfo.application.outbox.domain.OutboxStatus
+import no.nav.syfo.defaultOppfolgingsplan
+import no.nav.syfo.defaultPersistedOppfolgingsplanUtkast
+import no.nav.syfo.defaultSykmeldt
+import no.nav.syfo.findEventId
+import no.nav.syfo.findOppfolgingsplanUtkastByNarmesteLederId
+import no.nav.syfo.oppfolgingsplan.db.findAllOppfolgingsplanerBy
+import no.nav.syfo.oppfolgingsplan.db.findOppfolgingsplanBy
+import no.nav.syfo.oppfolgingsplan.db.persistOppfolgingsplanAndDeleteUtkast
+import no.nav.syfo.persistOppfolgingsplanUtkast
+import no.nav.syfo.varsel.budstikka.infrastructure.BudstikkaPublisher
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+class OppfolgingsplanCreatedOutboxIntegrationTest :
+    DescribeSpec({
+        val now = Instant.parse("2030-08-13T12:00:00Z")
+        val clock = Clock.fixed(now, ZoneOffset.UTC)
+
+        beforeTest {
+            TestDB.clearAllData()
+            clearAllMocks(currentThreadOnly = true)
+        }
+
+        describe("atomic creation") {
+            it("persists the plan and its immutable outbox command together") {
+                val planUuid = TestDB.database.createOppfolgingsplan()
+                val plan = TestDB.database.findOppfolgingsplanBy(planUuid).shouldNotBeNull()
+
+                val message = TestDB.database.findOutboxMessage(
+                    OppfolgingsplanOutboxMessageType.CREATED,
+                    planUuid.toString(),
+                ).shouldNotBeNull()
+                message.uuid shouldBe TestDB.database.findEventId(planUuid)
+                message.externalRef shouldBe planUuid.toString()
+                message.availableAt shouldBe plan.createdAt
+                message.status shouldBe OutboxStatus.READY
+            }
+
+            it("rolls back the plan and draft deletion when outbox persistence fails") {
+                val draft = defaultPersistedOppfolgingsplanUtkast()
+                TestDB.database.persistOppfolgingsplanUtkast(draft)
+                TestDB.database.rejectCreatedOutboxInserts()
+
+                try {
+                    shouldThrow<Exception> {
+                        TestDB.database.createOppfolgingsplan(narmesteLederId = draft.narmesteLederId)
+                    }
+                } finally {
+                    TestDB.database.allowCreatedOutboxInserts()
+                }
+
+                TestDB.database.findAllOppfolgingsplanerBy(
+                    defaultSykmeldt().fnr,
+                    defaultSykmeldt().orgnummer,
+                ).shouldBeEmpty()
+                TestDB.database.findOppfolgingsplanUtkastByNarmesteLederId(draft.narmesteLederId)
+                    .shouldNotBeNull()
+            }
+        }
+
+        describe("delivery") {
+            it("publishes with the outbox uuid and marks the command sent after acknowledgement") {
+                val planUuid = TestDB.database.createOppfolgingsplan()
+                val message = TestDB.database.findCreatedMessage(planUuid)
+                val publisher = mockk<BudstikkaPublisher>()
+                coEvery { publisher.publishOppfolgingsplanCreated(any(), any(), any()) } returns Unit
+                val worker = OutboxWorker(
+                    database = TestDB.database,
+                    handlers = listOf(OppfolgingsplanCreatedOutboxHandler(TestDB.database, publisher)),
+                    clock = clock,
+                )
+
+                worker.runOnce().sent shouldBe 1
+
+                coVerify(exactly = 1) {
+                    publisher.publishOppfolgingsplanCreated(
+                        oppfolgingsplanUuid = planUuid,
+                        sykmeldtFnr = defaultSykmeldt().fnr,
+                        eventId = message.uuid,
+                    )
+                }
+                TestDB.database.findCreatedMessage(planUuid).let { completedMessage ->
+                    completedMessage.status shouldBe OutboxStatus.SENT
+                    completedMessage.completedAt shouldBe now
+                }
+            }
+
+            it("retries a technical publish failure") {
+                val planUuid = TestDB.database.createOppfolgingsplan()
+                val publisher = mockk<BudstikkaPublisher>()
+                coEvery { publisher.publishOppfolgingsplanCreated(any(), any(), any()) } throws RuntimeException("broker down")
+                val worker = OutboxWorker(
+                    database = TestDB.database,
+                    handlers = listOf(OppfolgingsplanCreatedOutboxHandler(TestDB.database, publisher)),
+                    clock = clock,
+                )
+
+                worker.runOnce().retryScheduled shouldBe 1
+
+                TestDB.database.findCreatedMessage(planUuid).let { message ->
+                    message.status shouldBe OutboxStatus.READY
+                    message.failureCount shouldBe 1
+                }
+            }
+
+            it("cancels a notification when the plan is no longer eligible") {
+                val planUuid = TestDB.database.createOppfolgingsplan()
+                TestDB.database.setPlanHidden(planUuid, now)
+                val publisher = mockk<BudstikkaPublisher>(relaxed = true)
+                val worker = OutboxWorker(
+                    database = TestDB.database,
+                    handlers = listOf(OppfolgingsplanCreatedOutboxHandler(TestDB.database, publisher)),
+                    clock = clock,
+                )
+
+                worker.runOnce().cancelled shouldBe 1
+
+                TestDB.database.findCreatedMessage(planUuid).status shouldBe OutboxStatus.CANCELLED
+                coVerify(exactly = 0) { publisher.publishOppfolgingsplanCreated(any(), any(), any()) }
+            }
+        }
+    })
+
+private fun DatabaseInterface.createOppfolgingsplan(
+    narmesteLederId: String = defaultSykmeldt().narmestelederId,
+): UUID = persistOppfolgingsplanAndDeleteUtkast(
+    narmesteLederFnr = "10987654321",
+    sykmeldt = defaultSykmeldt().copy(narmestelederId = narmesteLederId),
+    createOppfolgingsplanRequest = defaultOppfolgingsplan(),
+    stillingstittel = "Systemutvikler",
+    stillingsprosent = null,
+)
+
+private suspend fun DatabaseInterface.findCreatedMessage(planUuid: UUID) = findOutboxMessage(
+    OppfolgingsplanOutboxMessageType.CREATED,
+    planUuid.toString(),
+).shouldNotBeNull()
+
+private fun DatabaseInterface.setPlanHidden(
+    planUuid: UUID,
+    hiddenAt: Instant,
+) = connection.use { connection ->
+    connection.prepareStatement("UPDATE oppfolgingsplan SET skjult_fra = ? WHERE uuid = ?").use {
+        it.setObject(1, hiddenAt.atOffset(ZoneOffset.UTC))
+        it.setObject(2, planUuid)
+        it.executeUpdate()
+    }
+    connection.commit()
+}
+
+private fun DatabaseInterface.rejectCreatedOutboxInserts() = connection.use { connection ->
+    connection.createStatement().use { statement ->
+        statement.execute(
+            """
+            ALTER TABLE outbox
+            ADD CONSTRAINT reject_created_outbox_test
+            CHECK (message_type <> 'OPPFOLGINGSPLAN_CREATED')
+            """.trimIndent(),
+        )
+    }
+    connection.commit()
+}
+
+private fun DatabaseInterface.allowCreatedOutboxInserts() = connection.use { connection ->
+    connection.createStatement().use { statement ->
+        statement.execute("ALTER TABLE outbox DROP CONSTRAINT reject_created_outbox_test")
+    }
+    connection.commit()
+}

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanServiceTest.kt
@@ -4,36 +4,34 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.just
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
 import no.nav.syfo.TestDB
 import no.nav.syfo.aareg.AaregService
 import no.nav.syfo.aareg.Stillingsinformasjon
+import no.nav.syfo.application.outbox.db.findOutboxMessage
+import no.nav.syfo.application.outbox.domain.OutboxStatus
 import no.nav.syfo.defaultOppfolgingsplan
 import no.nav.syfo.defaultPersistedOppfolgingsplan
 import no.nav.syfo.defaultPersistedOppfolgingsplanUtkast
 import no.nav.syfo.defaultSykmeldt
+import no.nav.syfo.findEventId
 import no.nav.syfo.findOppfolgingsplanUtkastByNarmesteLederId
-import no.nav.syfo.findVarselPublishedAtByOppfolgingsplanId
 import no.nav.syfo.oppfolgingsplan.db.deleteExpiredOppfolgingsplanUtkast
-import no.nav.syfo.oppfolgingsplan.db.findEventId
+import no.nav.syfo.oppfolgingsplan.outbox.OppfolgingsplanOutboxMessageType
 import no.nav.syfo.pdl.PdlService
 import no.nav.syfo.persistOppfolgingsplan
 import no.nav.syfo.persistOppfolgingsplanUtkast
 import no.nav.syfo.setOppfolgingsplanUtkastUpdatedAt
 import no.nav.syfo.varsel.EsyfovarselProducer
-import no.nav.syfo.varsel.budstikka.infrastructure.BudstikkaPublisher
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
-import java.util.UUID
 
 class OppfolgingsplanServiceTest :
     DescribeSpec({
@@ -92,7 +90,6 @@ class OppfolgingsplanServiceTest :
                         database = TestDB.database,
                         pdlService = pdlServive,
                         esyfovarselProducer = mockk<EsyfovarselProducer>(relaxed = true),
-                        budstikkaPublisher = mockk(relaxed = true),
                         aaregService = mockk(relaxed = true),
                         unntaksvurderingService = mockk(relaxed = true),
                     )
@@ -122,7 +119,6 @@ class OppfolgingsplanServiceTest :
                         database = TestDB.database,
                         pdlService = pdlServive,
                         esyfovarselProducer = mockk<EsyfovarselProducer>(relaxed = true),
-                        budstikkaPublisher = mockk(relaxed = true),
                         aaregService = mockk(relaxed = true),
                         unntaksvurderingService = mockk(relaxed = true),
                     )
@@ -148,12 +144,10 @@ class OppfolgingsplanServiceTest :
 
                 it("should persist stillingssnapshot from aareg") {
                     val aaregService = mockk<AaregService>()
-                    val budstikkaPublisher = mockk<BudstikkaPublisher>()
                     val service = OppfolgingsplanService(
                         database = TestDB.database,
                         pdlService = mockk(relaxed = true),
                         esyfovarselProducer = mockk(relaxed = true),
-                        budstikkaPublisher = budstikkaPublisher,
                         aaregService = aaregService,
                         unntaksvurderingService = mockk(relaxed = true),
                     )
@@ -163,10 +157,6 @@ class OppfolgingsplanServiceTest :
                         stillingstittel = "Systemutvikler",
                         stillingsprosent = BigDecimal("80.50"),
                     )
-                    coEvery {
-                        budstikkaPublisher.publishOppfolgingsplanCreated(any(), any(), any())
-                    } just Runs
-
                     val uuid = service.createOppfolgingsplan(
                         narmesteLederFnr = "10987654321",
                         sykmeldt = defaultSykmeldt(),
@@ -178,33 +168,26 @@ class OppfolgingsplanServiceTest :
                     persisted.stillingsprosent shouldBe BigDecimal("80.50")
                     val eventId = TestDB.database.findEventId(uuid)
                     eventId.shouldNotBeNull()
-                    coVerify(exactly = 1) {
-                        budstikkaPublisher.publishOppfolgingsplanCreated(
-                            oppfolgingsplanUuid = uuid,
-                            sykmeldtFnr = "12345678901",
-                            eventId = eventId,
-                        )
-                    }
+                    val outboxMessage = TestDB.database.findOutboxMessage(
+                        OppfolgingsplanOutboxMessageType.CREATED,
+                        uuid.toString(),
+                    ).shouldNotBeNull()
+                    outboxMessage.uuid shouldBe eventId
+                    outboxMessage.status shouldBe OutboxStatus.READY
                 }
 
                 it("should persist null stillingssnapshot when aareg fails") {
                     val aaregService = mockk<AaregService>()
-                    val budstikkaPublisher = mockk<BudstikkaPublisher>()
                     val service = OppfolgingsplanService(
                         database = TestDB.database,
                         pdlService = mockk(relaxed = true),
                         esyfovarselProducer = mockk(relaxed = true),
-                        budstikkaPublisher = budstikkaPublisher,
                         aaregService = aaregService,
                         unntaksvurderingService = mockk(relaxed = true),
                     )
                     coEvery {
                         aaregService.getStillingsinformasjon("12345678901", "orgnummer")
                     } throws RuntimeException("boom")
-                    coEvery {
-                        budstikkaPublisher.publishOppfolgingsplanCreated(any(), any(), any())
-                    } answers { thirdArg<UUID>() }
-
                     val uuid = service.createOppfolgingsplan(
                         narmesteLederFnr = "10987654321",
                         sykmeldt = defaultSykmeldt(),
@@ -216,52 +199,12 @@ class OppfolgingsplanServiceTest :
                     persisted.stillingsprosent.shouldBeNull()
                 }
 
-                it("should still create oppfolgingsplan when Budstikka publisher throws") {
-                    val aaregService = mockk<AaregService>()
-                    val esyfovarselProducer = mockk<EsyfovarselProducer>(relaxed = true)
-                    val budstikkaPublisher = mockk<BudstikkaPublisher>()
-                    val service = OppfolgingsplanService(
-                        database = TestDB.database,
-                        pdlService = mockk(relaxed = true),
-                        esyfovarselProducer = esyfovarselProducer,
-                        budstikkaPublisher = budstikkaPublisher,
-                        aaregService = aaregService,
-                        unntaksvurderingService = mockk(relaxed = true),
-                    )
-                    coEvery {
-                        aaregService.getStillingsinformasjon("12345678901", "orgnummer")
-                    } returns Stillingsinformasjon(
-                        stillingstittel = "Systemutvikler",
-                        stillingsprosent = BigDecimal("80.50"),
-                    )
-                    coEvery {
-                        budstikkaPublisher.publishOppfolgingsplanCreated(any(), any(), any())
-                    } throws RuntimeException("boom")
-
-                    val uuid = service.createOppfolgingsplan(
-                        narmesteLederFnr = "10987654321",
-                        sykmeldt = defaultSykmeldt(),
-                        createOppfolgingsplanRequest = defaultOppfolgingsplan(),
-                    )
-
-                    service.getPersistedOppfolgingsplanByUuid(uuid).uuid shouldBe uuid
-                    TestDB.database.findEventId(uuid).shouldNotBeNull()
-                    coVerify(exactly = 1) {
-                        budstikkaPublisher.publishOppfolgingsplanCreated(
-                            oppfolgingsplanUuid = uuid,
-                            sykmeldtFnr = "12345678901",
-                            eventId = any(),
-                        )
-                    }
-                }
-
                 it("should rethrow cancellation exception from aareg") {
                     val aaregService = mockk<AaregService>()
                     val service = OppfolgingsplanService(
                         database = TestDB.database,
                         pdlService = mockk(relaxed = true),
                         esyfovarselProducer = mockk(relaxed = true),
-                        budstikkaPublisher = mockk(relaxed = true),
                         aaregService = aaregService,
                         unntaksvurderingService = mockk(relaxed = true),
                     )
@@ -331,7 +274,6 @@ class OppfolgingsplanServiceTest :
                         database = TestDB.database,
                         pdlService = mockk(relaxed = true),
                         esyfovarselProducer = mockk(relaxed = true),
-                        budstikkaPublisher = mockk(relaxed = true),
                         aaregService = mockk(relaxed = true),
                         unntaksvurderingService = mockk(relaxed = true),
                     )
@@ -362,68 +304,6 @@ class OppfolgingsplanServiceTest :
                     TestDB.database.findOppfolgingsplanUtkastByNarmesteLederId(freshDraft.narmesteLederId)
                         ?.uuid shouldBe freshDraft.uuid
                 }
-            }
-
-            it("Should set varsel_published_at when varsel is sent") {
-                val aaregService = mockk<AaregService>()
-                val esyfovarselProducer = mockk<EsyfovarselProducer>(relaxed = true)
-                val budstikkaPublisher = mockk<BudstikkaPublisher>()
-                val service = OppfolgingsplanService(
-                    database = TestDB.database,
-                    pdlService = mockk(relaxed = true),
-                    esyfovarselProducer = esyfovarselProducer,
-                    budstikkaPublisher = budstikkaPublisher,
-                    aaregService = aaregService,
-                    unntaksvurderingService = mockk(relaxed = true),
-                )
-                coEvery {
-                    aaregService.getStillingsinformasjon("12845678901", "orgnummer")
-                } returns Stillingsinformasjon(
-                    stillingstittel = "Systemutvikler",
-                    stillingsprosent = BigDecimal("80.50"),
-                )
-                coEvery {
-                    budstikkaPublisher.publishOppfolgingsplanCreated(any(), any(), any())
-                } answers { thirdArg<UUID>() }
-
-                val uuid = service.createOppfolgingsplan(
-                    narmesteLederFnr = "10987654321",
-                    sykmeldt = defaultSykmeldt(),
-                    createOppfolgingsplanRequest = defaultOppfolgingsplan(),
-                )
-
-                TestDB.database.findVarselPublishedAtByOppfolgingsplanId(uuid).shouldNotBeNull()
-            }
-
-            it("Should not set varsel_published_at when varsel is not sent") {
-                val aaregService = mockk<AaregService>()
-                val esyfovarselProducer = mockk<EsyfovarselProducer>(relaxed = true)
-                val budstikkaPublisher = mockk<BudstikkaPublisher>()
-                val service = OppfolgingsplanService(
-                    database = TestDB.database,
-                    pdlService = mockk(relaxed = true),
-                    esyfovarselProducer = esyfovarselProducer,
-                    budstikkaPublisher = budstikkaPublisher,
-                    aaregService = aaregService,
-                    unntaksvurderingService = mockk(relaxed = true),
-                )
-                coEvery {
-                    aaregService.getStillingsinformasjon("12845678901", "orgnummer")
-                } returns Stillingsinformasjon(
-                    stillingstittel = "Systemutvikler",
-                    stillingsprosent = BigDecimal("80.50"),
-                )
-                coEvery {
-                    budstikkaPublisher.publishOppfolgingsplanCreated(any(), any(), any())
-                } throws RuntimeException("boom")
-
-                val uuid = service.createOppfolgingsplan(
-                    narmesteLederFnr = "10987654321",
-                    sykmeldt = defaultSykmeldt(),
-                    createOppfolgingsplanRequest = defaultOppfolgingsplan(),
-                )
-
-                TestDB.database.findVarselPublishedAtByOppfolgingsplanId(uuid).shouldBeNull()
             }
         }
     })

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteOppfolgingsplanerTaskTest.kt
@@ -31,7 +31,6 @@ class SoftDeleteOppfolgingsplanerTaskTest :
             database = testDb,
             esyfovarselProducer = mockk<EsyfovarselProducer>(relaxed = true),
             pdlService = mockk(relaxed = true),
-            budstikkaPublisher = mockk(relaxed = true),
             aaregService = mockk(relaxed = true),
             unntaksvurderingService = mockk(relaxed = true),
         )


### PR DESCRIPTION
## Avhengighet før aktivering

#408 er merget og denne PR-en er rebased på `main`. #414 må merges før denne PR-en aktiveres, slik at alarmressursene faktisk deployes.

## Hva

- utvider den eksisterende JDBC-persistensen av oppfølgingsplan minimalt: planens `event_id` og `created_at` returneres, og én outbox-rad settes inn på samme connection før den eksisterende commit-en
- beholder eksisterende SQL, parameterbinding, sletting av utkast og transaksjonssemantikk i `OppfolgingsplanDAO`
- leverer det eksisterende Budstikka-varselet gjennom en adaptereid, typesikker outbox-handler
- bruker planens eksisterende `event_id` som outbox-UUID og stabil Budstikka event-ID
- bruker plan-UUID som ugjennomsiktig dedupliseringsnøkkel og reference
- kjører claim/lease-workeren på alle replikaer uten leader election
- replayer kun den rene claim-transaksjonen ved PostgreSQL 40001; handler- og Kafka-sideeffekter kjører etter commit og replayes ikke automatisk
- henter mottakeren ferskt ved sendetid; skjult/feilregistrert plan avsluttes som forventet med `SOURCE_NO_LONGER_ELIGIBLE`, mens en manglende plan logges som et invariantbrudd og avsluttes med `SOURCE_NOT_FOUND`
- konfigurerer 90 dagers app-eid retention av terminale rader og operative alarmer for meldingstypen

Det er ingen Exposed-remodellering av oppfølgingsplan/utkast og ingen legacy-reconciler eller nye kompatibilitetsmigreringer i denne PR-en.

## Leveringssemantikk og utrulling

Etter Kafka-ACK markerer workeren outbox-raden som `SENT`. Dersom databaseoppdateringen feiler etter ACK, brukes samme event-ID ved retry, og Budstikka dedupliserer.

Under rullerende deploy sender gamle podder fortsatt synkront, mens nye podder oppretter plan og outbox-rad atomisk. Det korte vinduet backfilles ikke. Full rollback til en pre-outbox-versjon kan ikke drenere nye `READY`/`CLAIMED`-rader; ADR-en dokumenterer derfor roll-forward/drain-kravet.

Vedvarende tekniske feil alarmeres når minst én ikke-terminal rad har hatt en uløst feil i 15 minutter, også mens raden venter i retry-backoff. Køalder og utløpte claims har separate alarmer.

Retention-tasken er felles for meldingstypene i denne appen. For denne kommandoen finnes ingen reconciler eller reaktivering, så terminal retention er et operasjonelt/personvernmessig vindu og ikke nødvendig for idempotens. Budstikka forvalter separat retention for sine egne inbox- og delivery-tabeller.

## Verifisert

- `./gradlew build --rerun-tasks --no-daemon`
- målrettede adapter-, service-, outbox- og ktlint-tester
- integrasjonstest som verifiserer `oppfolgingsplan.event_id == outbox.uuid`, sletting av utkast og samme commit
- tvungen outbox-constraint-feil som verifiserer atomisk rollback: ingen plan opprettes og utkastet beholdes
- koordinert PostgreSQL-test som fremprovoserer REPEATABLE READ-racen og verifiserer ett trygt claim-replay
- tester for vellykket Budstikka-levering, teknisk retry, forventet kansellering av skjult/feilregistrert plan og feilklassifisering/logging når kildeplanen mangler
- `git diff --check`
