### PR TITLE
Deploy Prometheus alert resources

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -24,3 +24,35 @@ jobs:
     with:
       app: syfo-oppfolgingsplan-backend
       java-version: '25'
+
+  deploy-alerts-dev:
+    if: ${{ github.actor != 'dependabot[bot]' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)) }}
+    name: Deploy alerts to dev
+    runs-on: ubuntu-latest
+    needs: [jar-app]
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # v2
+        env:
+          CLUSTER: dev-gcp
+          RESOURCE: nais/alerts-dev.yaml
+
+  deploy-alerts-prod:
+    if: github.ref_name == 'main'
+    name: Deploy alerts to prod
+    runs-on: ubuntu-latest
+    needs: [jar-app]
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # v2
+        env:
+          CLUSTER: prod-gcp
+          RESOURCE: nais/alerts-prod.yaml


### PR DESCRIPTION
## Hva

- deployer eksisterende `nais/alerts-dev.yaml` etter grønn build på main og ikke-draft PR-er
- deployer eksisterende `nais/alerts-prod.yaml` etter grønn build på main
- gir de to deploy-jobbene egne, minimale OIDC-permissions

## Hvorfor

Den gjenbrukbare app-workflowen deployer bare `nais/nais-{dev,prod}.yaml`. PrometheusRule-filene
ligger allerede i repoet, men blir ellers ikke sendt til clusteret. Denne PR-en holder selve
ressurs-deployen uavhengig av outbox-endringene i #408/#410.

## Verifisering

- `actionlint .github/workflows/build-and-deploy.yaml`
- `git diff --check`
