### PR TITLE
feat(veileder): expose unntaksvurderinger

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/ApiV1.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/ApiV1.kt
@@ -82,6 +82,7 @@ fun Route.registerApiV1(
         registerVeilederOppfolgingsplanApiV1(
             texasHttpClient,
             oppfolgingsplanService,
+            unntaksvurderingService,
             isTilgangskontrollService,
             pdfGenService,
         )

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/SykmeldtReadRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/SykmeldtReadRequest.kt
@@ -1,5 +1,5 @@
 package no.nav.syfo.oppfolgingsplan.api.v1.veileder
 
-data class OppfolgingsplanerReadRequest(
+data class SykmeldtReadRequest(
     val sykmeldtFnr: String,
 )

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/UnntaksvurderingVeileder.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/UnntaksvurderingVeileder.kt
@@ -11,16 +11,16 @@ data class UnntaksvurderingerVeilederResponse(
 data class UnntaksvurderingVeileder(
     val uuid: UUID,
     val fnr: String,
-    val virksomhetsnummer: String,
-    val virksomhetsnavn: String?,
+    val organisasjonsnummer: String,
+    val organisasjonsnavn: String?,
     val meldtTidspunkt: Instant,
 ) {
     companion object {
         fun from(item: PersistedUnntaksvurdering): UnntaksvurderingVeileder = UnntaksvurderingVeileder(
             uuid = item.uuid,
             fnr = item.sykmeldtFnr,
-            virksomhetsnummer = item.organisasjonsnummer,
-            virksomhetsnavn = item.organisasjonsnavn,
+            organisasjonsnummer = item.organisasjonsnummer,
+            organisasjonsnavn = item.organisasjonsnavn,
             meldtTidspunkt = item.createdAt,
         )
     }

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/UnntaksvurderingVeileder.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/UnntaksvurderingVeileder.kt
@@ -1,0 +1,27 @@
+package no.nav.syfo.oppfolgingsplan.api.v1.veileder
+
+import no.nav.syfo.oppfolgingsplan.db.domain.PersistedUnntaksvurdering
+import java.time.Instant
+import java.util.UUID
+
+data class UnntaksvurderingerVeilederResponse(
+    val unntaksvurderinger: List<UnntaksvurderingVeileder>,
+)
+
+data class UnntaksvurderingVeileder(
+    val uuid: UUID,
+    val fnr: String,
+    val virksomhetsnummer: String,
+    val virksomhetsnavn: String?,
+    val meldtTidspunkt: Instant,
+) {
+    companion object {
+        fun from(item: PersistedUnntaksvurdering): UnntaksvurderingVeileder = UnntaksvurderingVeileder(
+            uuid = item.uuid,
+            fnr = item.sykmeldtFnr,
+            virksomhetsnummer = item.organisasjonsnummer,
+            virksomhetsnavn = item.organisasjonsnavn,
+            meldtTidspunkt = item.createdAt,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederOppfolgingsplanApiV1.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederOppfolgingsplanApiV1.kt
@@ -32,18 +32,16 @@ fun Route.registerVeilederOppfolgingsplanApiV1(
     isTilgangskontrollService: IsTilgangskontrollService,
     pdfGenService: PdfGenService,
 ) {
-    suspend fun ApplicationCall.receiveVeilederSykmeldtQuery(): VeilederSykmeldtQuery {
-        val innloggetBruker = principal<BrukerPrincipal>()
-            ?: throw ApiErrorException.Unauthorized("No user principal found in request")
-        val sykmeldtFnr = try {
-            receive<SykmeldtReadRequest>().sykmeldtFnr
+    fun ApplicationCall.requireVeilederToken(): String = principal<BrukerPrincipal>()?.token
+        ?: throw ApiErrorException.Unauthorized("No user principal found in request")
+
+    suspend fun ApplicationCall.receiveSykmeldtFnr(): Fodselsnummer {
+        val request = try {
+            receive<SykmeldtReadRequest>()
         } catch (e: Exception) {
             throw ApiErrorException.BadRequest("Request is missing sykmeldtFnr: ${e.message}", e)
         }
-        return VeilederSykmeldtQuery(
-            sykmeldtFnr = Fodselsnummer(value = sykmeldtFnr),
-            token = innloggetBruker.token,
-        )
+        return Fodselsnummer(value = request.sykmeldtFnr)
     }
 
     suspend fun validateTilgangToSykmeldt(
@@ -74,13 +72,14 @@ fun Route.registerVeilederOppfolgingsplanApiV1(
         }
 
         post("/query") {
-            val query = call.receiveVeilederSykmeldtQuery()
+            val token = call.requireVeilederToken()
+            val sykmeldtFnr = call.receiveSykmeldtFnr()
             validateTilgangToSykmeldt(
-                sykmeldtFnr = query.sykmeldtFnr,
-                token = query.token,
+                sykmeldtFnr = sykmeldtFnr,
+                token = token,
             )
             val oppfolgingsplaner = oppfolgingsplanService.getPersistedOppfolgingsplanListBy(
-                sykmeldtFnr = query.sykmeldtFnr.value,
+                sykmeldtFnr = sykmeldtFnr.value,
                 inkluderSkjulte = true,
             ).toListOppfolgingsplanVeileder()
 
@@ -89,13 +88,12 @@ fun Route.registerVeilederOppfolgingsplanApiV1(
 
         get("/{uuid}") {
             val uuid = call.parameters.extractAndValidateUUIDParameter()
-            val innloggetBruker = call.principal<BrukerPrincipal>()
-                ?: throw ApiErrorException.Unauthorized("No user principal found in request")
+            val token = call.requireVeilederToken()
 
             val oppfolgingsplan = tryToGetOppfolgingsplanByUuid(uuid)
             validateTilgangToSykmeldt(
                 sykmeldtFnr = Fodselsnummer(value = oppfolgingsplan.sykmeldtFnr),
-                token = innloggetBruker.token,
+                token = token,
             )
             val pdfByteArray = pdfGenService.generatePdf(oppfolgingsplan)
                 ?: throw ApiErrorException.InternalServerError("Could not generate pdf")
@@ -108,24 +106,20 @@ fun Route.registerVeilederOppfolgingsplanApiV1(
 
     route("/unntaksvurderinger") {
         post("/query") {
-            val query = call.receiveVeilederSykmeldtQuery()
+            val token = call.requireVeilederToken()
+            val sykmeldtFnr = call.receiveSykmeldtFnr()
             validateTilgangToSykmeldt(
-                sykmeldtFnr = query.sykmeldtFnr,
-                token = query.token,
+                sykmeldtFnr = sykmeldtFnr,
+                token = token,
             )
 
             val unntaksvurderinger = unntaksvurderingService
-                .getPersistedUnntaksvurderingerForSykmeldt(query.sykmeldtFnr.value)
+                .getPersistedUnntaksvurderingerForSykmeldt(sykmeldtFnr.value)
                 .map(UnntaksvurderingVeileder::from)
 
             call.respond(HttpStatusCode.OK, UnntaksvurderingerVeilederResponse(unntaksvurderinger))
         }
     }
 }
-
-private data class VeilederSykmeldtQuery(
-    val sykmeldtFnr: Fodselsnummer,
-    val token: String,
-)
 
 const val NAV_PERSONIDENT_HEADER = "nav-personident"

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederOppfolgingsplanApiV1.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederOppfolgingsplanApiV1.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.oppfolgingsplan.api.v1.veileder
 
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.principal
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
@@ -17,6 +18,7 @@ import no.nav.syfo.oppfolgingsplan.api.v1.extractAndValidateUUIDParameter
 import no.nav.syfo.oppfolgingsplan.db.domain.PersistedOppfolgingsplan
 import no.nav.syfo.oppfolgingsplan.domain.Fodselsnummer
 import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
+import no.nav.syfo.oppfolgingsplan.service.UnntaksvurderingService
 import no.nav.syfo.oppfolgingsplan.service.toListOppfolgingsplanVeileder
 import no.nav.syfo.pdfgen.PdfGenService
 import no.nav.syfo.texas.client.TexasHttpClient
@@ -26,9 +28,37 @@ import java.util.UUID
 fun Route.registerVeilederOppfolgingsplanApiV1(
     texasHttpClient: TexasHttpClient,
     oppfolgingsplanService: OppfolgingsplanService,
+    unntaksvurderingService: UnntaksvurderingService,
     isTilgangskontrollService: IsTilgangskontrollService,
     pdfGenService: PdfGenService,
 ) {
+    suspend fun ApplicationCall.receiveVeilederSykmeldtQuery(): VeilederSykmeldtQuery {
+        val innloggetBruker = principal<BrukerPrincipal>()
+            ?: throw ApiErrorException.Unauthorized("No user principal found in request")
+        val sykmeldtFnr = try {
+            receive<SykmeldtReadRequest>().sykmeldtFnr
+        } catch (e: Exception) {
+            throw ApiErrorException.BadRequest("Request is missing sykmeldtFnr: ${e.message}", e)
+        }
+        return VeilederSykmeldtQuery(
+            sykmeldtFnr = Fodselsnummer(value = sykmeldtFnr),
+            token = innloggetBruker.token,
+        )
+    }
+
+    suspend fun validateTilgangToSykmeldt(
+        sykmeldtFnr: Fodselsnummer,
+        token: String,
+    ) {
+        val tilgang = isTilgangskontrollService.harTilgangTilSykmeldt(
+            sykmeldtFnr,
+            texasHttpClient.exchangeTokenForIsTilgangskontroll(token).accessToken,
+        )
+        if (!tilgang) {
+            throw ApiErrorException.Forbidden("Veileder does not have access to sykmeldt")
+        }
+    }
+
     route("/oppfolgingsplaner") {
         suspend fun tryToGetOppfolgingsplanByUuid(
             uuid: UUID,
@@ -43,33 +73,14 @@ fun Route.registerVeilederOppfolgingsplanApiV1(
             }
         }
 
-        suspend fun validateTilgangToSykmeldt(
-            sykmeldtFnr: Fodselsnummer,
-            token: String,
-        ) {
-            val tilgang = isTilgangskontrollService.harTilgangTilSykmeldt(
-                sykmeldtFnr,
-                texasHttpClient.exchangeTokenForIsTilgangskontroll(token).accessToken,
-            )
-            if (!tilgang) {
-                throw ApiErrorException.Forbidden("Veileder does not have access to sykmeldt")
-            }
-        }
-
         post("/query") {
-            val innloggetBruker = call.principal<BrukerPrincipal>()
-                ?: throw ApiErrorException.Unauthorized("No user principal found in request")
-            val sykmeldtFnr = try {
-                call.receive<OppfolgingsplanerReadRequest>().sykmeldtFnr
-            } catch (e: Exception) {
-                throw ApiErrorException.BadRequest("Request is missing sykmeldtFnr: ${e.message}", e)
-            }
+            val query = call.receiveVeilederSykmeldtQuery()
             validateTilgangToSykmeldt(
-                sykmeldtFnr = Fodselsnummer(value = sykmeldtFnr),
-                token = innloggetBruker.token,
+                sykmeldtFnr = query.sykmeldtFnr,
+                token = query.token,
             )
             val oppfolgingsplaner = oppfolgingsplanService.getPersistedOppfolgingsplanListBy(
-                sykmeldtFnr = sykmeldtFnr,
+                sykmeldtFnr = query.sykmeldtFnr.value,
                 inkluderSkjulte = true,
             ).toListOppfolgingsplanVeileder()
 
@@ -94,6 +105,27 @@ fun Route.registerVeilederOppfolgingsplanApiV1(
             call.respond<ByteArray>(pdfByteArray)
         }
     }
+
+    route("/unntaksvurderinger") {
+        post("/query") {
+            val query = call.receiveVeilederSykmeldtQuery()
+            validateTilgangToSykmeldt(
+                sykmeldtFnr = query.sykmeldtFnr,
+                token = query.token,
+            )
+
+            val unntaksvurderinger = unntaksvurderingService
+                .getPersistedUnntaksvurderingerForSykmeldt(query.sykmeldtFnr.value)
+                .map(UnntaksvurderingVeileder::from)
+
+            call.respond(HttpStatusCode.OK, UnntaksvurderingerVeilederResponse(unntaksvurderinger))
+        }
+    }
 }
+
+private data class VeilederSykmeldtQuery(
+    val sykmeldtFnr: Fodselsnummer,
+    val token: String,
+)
 
 const val NAV_PERSONIDENT_HEADER = "nav-personident"

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/UnntaksvurderingDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/UnntaksvurderingDAO.kt
@@ -45,6 +45,21 @@ suspend fun DatabaseInterface.findAllUnntaksvurderingerBy(
         .map { it.toPersistedUnntaksvurdering() }
 }
 
+suspend fun DatabaseInterface.findAllUnntaksvurderingerBySykmeldtFnr(
+    sykmeldtFnr: String,
+): List<PersistedUnntaksvurdering> = exposedTransaction(readOnly = true) {
+    UnntaksvurderingTable
+        .selectAll()
+        .where {
+            (UnntaksvurderingTable.sykmeldtFnr eq sykmeldtFnr) and
+                UnntaksvurderingTable.skjultFra.isNull()
+        }.orderBy(
+            UnntaksvurderingTable.createdAt to SortOrder.DESC,
+            UnntaksvurderingTable.uuid to SortOrder.DESC,
+        )
+        .map { it.toPersistedUnntaksvurdering() }
+}
+
 suspend fun DatabaseInterface.softDeleteExpiredUnntaksvurderinger(
     batchSize: Int = 1000,
 ): Int = exposedTransaction {

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/UnntaksvurderingService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/UnntaksvurderingService.kt
@@ -7,6 +7,7 @@ import no.nav.syfo.oppfolgingsplan.db.domain.PersistedUnntaksvurdering
 import no.nav.syfo.oppfolgingsplan.db.domain.toUnntaksvurderingMetadata
 import no.nav.syfo.oppfolgingsplan.db.existsAktivPlanOrUtkast
 import no.nav.syfo.oppfolgingsplan.db.findAllUnntaksvurderingerBy
+import no.nav.syfo.oppfolgingsplan.db.findAllUnntaksvurderingerBySykmeldtFnr
 import no.nav.syfo.oppfolgingsplan.db.persistUnntaksvurdering
 import no.nav.syfo.oppfolgingsplan.db.setUnntaksvurderingNarmesteLederFullName
 import no.nav.syfo.oppfolgingsplan.db.softDeleteExpiredUnntaksvurderinger
@@ -47,6 +48,10 @@ class UnntaksvurderingService(
     ): List<UnntaksvurderingMetadata> = database
         .findAllUnntaksvurderingerBy(sykmeldtFnr)
         .tilMetadataMedNavn()
+
+    suspend fun getPersistedUnntaksvurderingerForSykmeldt(
+        sykmeldtFnr: String,
+    ): List<PersistedUnntaksvurdering> = database.findAllUnntaksvurderingerBySykmeldtFnr(sykmeldtFnr)
 
     suspend fun softDeleteExpiredUnntaksvurderinger(): Int = runSoftDeleteBatchLoop {
         database.softDeleteExpiredUnntaksvurderinger()

--- a/src/main/resources/openapi/veileder.yaml
+++ b/src/main/resources/openapi/veileder.yaml
@@ -25,7 +25,7 @@ tags:
     description: Veileder-operasjoner for oppfølgingsplaner
 
 paths:
-  /api/v1/veileder/oppfolgingsplaner:
+  /api/v1/veileder/oppfolgingsplaner/query:
     post:
       tags:
         - Oppfølgingsplan
@@ -43,7 +43,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/VeilederOppfolgingsplanRequest'
+              $ref: '#/components/schemas/SykmeldtReadRequest'
       responses:
         '200':
           description: Liste med oppfølgingsplaner som er delt med Nav
@@ -53,6 +53,38 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/VeilederOppfolgingsplanResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/v1/veileder/unntaksvurderinger/query:
+    post:
+      tags:
+        - Oppfølgingsplan
+      summary: Hent unntaksvurderinger for en sykmeldt
+      description: |
+        Returnerer unntaksvurderinger meldt av arbeidsgiver for en gitt sykmeldt.
+
+        Veileder må ha tilgang til brukerens enhet via istilgangskontroll.
+      operationId: getVeilederUnntaksvurderinger
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SykmeldtReadRequest'
+      responses:
+        '200':
+          description: Unntaksvurderinger, nyeste først
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VeilederUnntaksvurderingerResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -208,7 +240,7 @@ components:
           nullable: true
           description: URL-path som forårsaket feilen
 
-    VeilederOppfolgingsplanRequest:
+    SykmeldtReadRequest:
       type: object
       required:
         - sykmeldtFnr
@@ -258,3 +290,40 @@ components:
           type: string
           format: date-time
           description: Tidspunkt planen ble delt med Nav
+
+    VeilederUnntaksvurderingerResponse:
+      type: object
+      required:
+        - unntaksvurderinger
+      properties:
+        unntaksvurderinger:
+          type: array
+          items:
+            $ref: '#/components/schemas/VeilederUnntaksvurderingResponse'
+
+    VeilederUnntaksvurderingResponse:
+      type: object
+      required:
+        - uuid
+        - fnr
+        - virksomhetsnummer
+        - meldtTidspunkt
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          description: Unik identifikator for unntaksvurderingen
+        fnr:
+          type: string
+          description: Fødselsnummer for den sykmeldte
+        virksomhetsnummer:
+          type: string
+          description: Organisasjonsnummer for virksomheten
+        virksomhetsnavn:
+          type: string
+          nullable: true
+          description: Navn på virksomheten
+        meldtTidspunkt:
+          type: string
+          format: date-time
+          description: Tidspunkt arbeidsgiver meldte unntaksvurderingen

--- a/src/main/resources/openapi/veileder.yaml
+++ b/src/main/resources/openapi/veileder.yaml
@@ -257,7 +257,7 @@ components:
         - uuid
         - sykmeldtNavn
         - virksomhetsnavn
-        - virksomhetsnummer
+        - organisasjonsnummer
         - evalueringsDato
         - ferdigstiltTidspunkt
         - deltMedNavTidspunkt
@@ -316,10 +316,10 @@ components:
         fnr:
           type: string
           description: Fødselsnummer for den sykmeldte
-        virksomhetsnummer:
+        organisasjonsnummer:
           type: string
           description: Organisasjonsnummer for virksomheten
-        virksomhetsnavn:
+        organisasjonsnavn:
           type: string
           nullable: true
           description: Navn på virksomheten

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederApiV1TestFixture.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederApiV1TestFixture.kt
@@ -1,0 +1,99 @@
+package no.nav.syfo.oppfolgingsplan.api.v1.veileder
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.jackson.jackson
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.syfo.TestDB
+import no.nav.syfo.aareg.AaregService
+import no.nav.syfo.application.Environment
+import no.nav.syfo.application.LocalEnvironment
+import no.nav.syfo.application.valkey.ValkeyCache
+import no.nav.syfo.dinesykmeldte.DineSykmeldteService
+import no.nav.syfo.dinesykmeldte.client.DineSykmeldteHttpClient
+import no.nav.syfo.dokarkiv.DokarkivService
+import no.nav.syfo.isdialogmelding.IsDialogmeldingService
+import no.nav.syfo.isdialogmelding.client.IsDialogmeldingClient
+import no.nav.syfo.istilgangskontroll.IsTilgangskontrollService
+import no.nav.syfo.istilgangskontroll.client.IIsTilgangskontrollClient
+import no.nav.syfo.oppfolgingsplan.api.v1.registerApiV1
+import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
+import no.nav.syfo.oppfolgingsplan.service.UnntaksvurderingService
+import no.nav.syfo.pdfgen.PdfGenService
+import no.nav.syfo.plugins.installContentNegotiation
+import no.nav.syfo.plugins.installStatusPages
+import no.nav.syfo.texas.client.TexasHttpClient
+import no.nav.syfo.varsel.EsyfovarselProducer
+import java.util.UUID
+
+class VeilederApiV1TestFixture {
+    val texasClientMock = mockk<TexasHttpClient>()
+    val dineSykmeldteHttpClientMock = mockk<DineSykmeldteHttpClient>()
+    val valkeyCacheMock = mockk<ValkeyCache>(relaxUnitFun = true)
+    val esyfovarselProducerMock = mockk<EsyfovarselProducer>()
+    val testDb = TestDB.database
+    val sykmeldtFnr = "12345678910"
+    val narmestelederId = UUID.randomUUID().toString()
+    val pdfGenService = mockk<PdfGenService>()
+    val isDialogmeldingClientMock = mockk<IsDialogmeldingClient>()
+    val dokarkivServiceMock = mockk<DokarkivService>()
+    val isTilgangskontrollClientMock = mockk<IIsTilgangskontrollClient>()
+    val isTilgangskontrollServiceMock = IsTilgangskontrollService(isTilgangskontrollClientMock)
+    val environment: Environment = LocalEnvironment()
+    val syfomodiapersonClientId = environment.syfomodiapersonClientId
+
+    fun reset() {
+        clearAllMocks(currentThreadOnly = true)
+        TestDB.clearAllData()
+        every { valkeyCacheMock.getSykmeldt(any(), any()) } returns null
+    }
+
+    fun withTestApplication(
+        fn: suspend ApplicationTestBuilder.() -> Unit,
+    ) {
+        testApplication {
+            this.client = createClient {
+                install(ContentNegotiation) {
+                    jackson {
+                        registerKotlinModule()
+                        registerModule(JavaTimeModule())
+                        configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                        configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                    }
+                }
+            }
+            application {
+                installContentNegotiation()
+                installStatusPages()
+                routing {
+                    registerApiV1(
+                        DineSykmeldteService(dineSykmeldteHttpClientMock, valkeyCacheMock),
+                        texasClientMock,
+                        oppfolgingsplanService = OppfolgingsplanService(
+                            database = testDb,
+                            esyfovarselProducer = esyfovarselProducerMock,
+                            pdlService = mockk(relaxed = true),
+                            aaregService = mockk<AaregService>(relaxed = true),
+                            unntaksvurderingService = mockk(relaxed = true),
+                        ),
+                        unntaksvurderingService = UnntaksvurderingService(testDb, mockk(relaxed = true)),
+                        pdfGenService = pdfGenService,
+                        isDialogmeldingService = IsDialogmeldingService(isDialogmeldingClientMock),
+                        dokarkivService = dokarkivServiceMock,
+                        isTilgangskontrollService = isTilgangskontrollServiceMock,
+                        environment = this@VeilederApiV1TestFixture.environment,
+                    )
+                }
+            }
+            fn(this)
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederOppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederOppfolgingsplanApiV1Test.kt
@@ -1,13 +1,8 @@
 package no.nav.syfo.oppfolgingsplan.api.v1.veileder
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.client.call.body
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
 import io.ktor.client.request.header
@@ -17,106 +12,36 @@ import io.ktor.client.request.url
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
-import io.ktor.serialization.jackson.jackson
-import io.ktor.server.routing.routing
 import io.ktor.server.testing.ApplicationTestBuilder
-import io.ktor.server.testing.testApplication
-import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
-import io.mockk.mockk
-import no.nav.syfo.TestDB
-import no.nav.syfo.aareg.AaregService
-import no.nav.syfo.application.Environment
-import no.nav.syfo.application.LocalEnvironment
-import no.nav.syfo.application.valkey.ValkeyCache
 import no.nav.syfo.defaultMocks
 import no.nav.syfo.defaultPersistedOppfolgingsplan
-import no.nav.syfo.dinesykmeldte.DineSykmeldteService
-import no.nav.syfo.dinesykmeldte.client.DineSykmeldteHttpClient
-import no.nav.syfo.dokarkiv.DokarkivService
-import no.nav.syfo.isdialogmelding.IsDialogmeldingService
-import no.nav.syfo.isdialogmelding.client.IsDialogmeldingClient
-import no.nav.syfo.istilgangskontroll.IsTilgangskontrollService
-import no.nav.syfo.istilgangskontroll.client.IIsTilgangskontrollClient
-import no.nav.syfo.oppfolgingsplan.api.v1.registerApiV1
 import no.nav.syfo.oppfolgingsplan.db.setDeltMedVeilederTidspunkt
 import no.nav.syfo.oppfolgingsplan.db.updateSkalDelesMedVeileder
 import no.nav.syfo.oppfolgingsplan.domain.Fodselsnummer
-import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
-import no.nav.syfo.pdfgen.PdfGenService
 import no.nav.syfo.persistOppfolgingsplan
-import no.nav.syfo.plugins.installContentNegotiation
-import no.nav.syfo.plugins.installStatusPages
-import no.nav.syfo.texas.client.TexasHttpClient
-import no.nav.syfo.varsel.EsyfovarselProducer
 import java.time.Instant
-import java.util.UUID
 
 class VeilederOppfolgingsplanApiV1Test :
     DescribeSpec({
-        val texasClientMock = mockk<TexasHttpClient>()
-        val dineSykmeldteHttpClientMock = mockk<DineSykmeldteHttpClient>()
-        val valkeyCacheMock = mockk<ValkeyCache>(relaxUnitFun = true)
-        val esyfovarselProducerMock = mockk<EsyfovarselProducer>()
-        val testDb = TestDB.database
-        val sykmeldtFnr = "12345678910"
-        val narmestelederId = UUID.randomUUID().toString()
-        val pdfGenService = mockk<PdfGenService>()
-        val isDialogmeldingClientMock = mockk<IsDialogmeldingClient>()
-        val dokarkivServiceMock = mockk<DokarkivService>()
-        val isTilgangskontrollClientMock = mockk<IIsTilgangskontrollClient>()
-        val isTilgangskontrollServiceMock = IsTilgangskontrollService(isTilgangskontrollClientMock)
-        val environment: Environment = LocalEnvironment()
-        val syfomodiapersonClientId = environment.syfomodiapersonClientId
+        val fixture = VeilederApiV1TestFixture()
+        val texasClientMock = fixture.texasClientMock
+        val testDb = fixture.testDb
+        val sykmeldtFnr = fixture.sykmeldtFnr
+        val narmestelederId = fixture.narmestelederId
+        val pdfGenService = fixture.pdfGenService
+        val isTilgangskontrollClientMock = fixture.isTilgangskontrollClientMock
+        val environment = fixture.environment
+        val syfomodiapersonClientId = fixture.syfomodiapersonClientId
 
         beforeTest {
-            clearAllMocks(currentThreadOnly = true)
-            TestDB.clearAllData()
-            every { valkeyCacheMock.getSykmeldt(any(), any()) } returns null
+            fixture.reset()
         }
 
         fun withTestApplication(
             fn: suspend ApplicationTestBuilder.() -> Unit,
-        ) {
-            testApplication {
-                this.client = createClient {
-                    install(ContentNegotiation) {
-                        jackson {
-                            registerKotlinModule()
-                            registerModule(JavaTimeModule())
-                            configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-                            configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                        }
-                    }
-                }
-                application {
-                    installContentNegotiation()
-                    installStatusPages()
-                    routing {
-                        registerApiV1(
-                            DineSykmeldteService(dineSykmeldteHttpClientMock, valkeyCacheMock),
-                            texasClientMock,
-                            oppfolgingsplanService = OppfolgingsplanService(
-                                database = testDb,
-                                esyfovarselProducer = esyfovarselProducerMock,
-                                pdlService = mockk(relaxed = true),
-                                aaregService = mockk<AaregService>(relaxed = true),
-                                unntaksvurderingService = mockk(relaxed = true),
-                            ),
-                            unntaksvurderingService = mockk(relaxed = true),
-                            pdfGenService = pdfGenService,
-                            isDialogmeldingService = IsDialogmeldingService(isDialogmeldingClientMock),
-                            dokarkivService = dokarkivServiceMock,
-                            isTilgangskontrollService = isTilgangskontrollServiceMock,
-                            environment = environment,
-                        )
-                    }
-                }
-                fn(this)
-            }
-        }
+        ) = fixture.withTestApplication(fn)
 
         describe("Veileder Oppfolgingsplan API") {
             describe("List") {
@@ -170,7 +95,7 @@ class VeilederOppfolgingsplanApiV1Test :
                             url("/api/v1/veileder/oppfolgingsplaner/query")
                             bearerAuth(token = "Bearer token")
                             contentType(ContentType.Application.Json)
-                            setBody(OppfolgingsplanerReadRequest(sykmeldtFnr))
+                            setBody(SykmeldtReadRequest(sykmeldtFnr))
                         }
 
                         // Assert
@@ -220,7 +145,7 @@ class VeilederOppfolgingsplanApiV1Test :
                             url("/api/v1/veileder/oppfolgingsplaner/query")
                             bearerAuth(token = "Bearer token")
                             contentType(ContentType.Application.Json)
-                            setBody(OppfolgingsplanerReadRequest(sykmeldtFnr))
+                            setBody(SykmeldtReadRequest(sykmeldtFnr))
                         }
 
                         // Assert
@@ -265,7 +190,7 @@ class VeilederOppfolgingsplanApiV1Test :
                             bearerAuth(token = "Bearer token")
                             header(NAV_PERSONIDENT_HEADER, sykmeldtFnr)
                             contentType(ContentType.Application.Json)
-                            setBody(OppfolgingsplanerReadRequest(sykmeldtFnr))
+                            setBody(SykmeldtReadRequest(sykmeldtFnr))
                         }
 
                         // Assert
@@ -308,7 +233,7 @@ class VeilederOppfolgingsplanApiV1Test :
                             bearerAuth(token = "Bearer token")
                             header(NAV_PERSONIDENT_HEADER, sykmeldtFnr)
                             contentType(ContentType.Application.Json)
-                            setBody(OppfolgingsplanerReadRequest(sykmeldtFnr))
+                            setBody(SykmeldtReadRequest(sykmeldtFnr))
                         }
 
                         response.status shouldBe HttpStatusCode.OK
@@ -352,7 +277,7 @@ class VeilederOppfolgingsplanApiV1Test :
                             bearerAuth(token = "Bearer token")
                             header(NAV_PERSONIDENT_HEADER, sykmeldtFnr)
                             contentType(ContentType.Application.Json)
-                            setBody(OppfolgingsplanerReadRequest(sykmeldtFnr))
+                            setBody(SykmeldtReadRequest(sykmeldtFnr))
                         }
 
                         response.status shouldBe HttpStatusCode.OK

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederUnntaksvurderingApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederUnntaksvurderingApiV1Test.kt
@@ -1,0 +1,103 @@
+package no.nav.syfo.oppfolgingsplan.api.v1.veileder
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.call.body
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.request.url
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.mockk.coEvery
+import io.mockk.coVerify
+import no.nav.syfo.defaultMocks
+import no.nav.syfo.defaultSykmeldt
+import no.nav.syfo.oppfolgingsplan.db.persistUnntaksvurdering
+import no.nav.syfo.oppfolgingsplan.domain.Fodselsnummer
+
+class VeilederUnntaksvurderingApiV1Test :
+    DescribeSpec({
+        val fixture = VeilederApiV1TestFixture()
+        val texasClientMock = fixture.texasClientMock
+        val testDb = fixture.testDb
+        val sykmeldtFnr = fixture.sykmeldtFnr
+        val isTilgangskontrollClientMock = fixture.isTilgangskontrollClientMock
+        val syfomodiapersonClientId = fixture.syfomodiapersonClientId
+
+        beforeTest {
+            fixture.reset()
+        }
+
+        it("responds with Unauthorized when no authentication is provided") {
+            fixture.withTestApplication {
+                val response = client.post("/api/v1/veileder/unntaksvurderinger/query")
+
+                response.status shouldBe HttpStatusCode.Unauthorized
+            }
+        }
+
+        it("returns all visible unntaksvurderinger newest first") {
+            fixture.withTestApplication {
+                texasClientMock.defaultMocks(
+                    pid = "some-veileder-token",
+                    navident = "some-navident",
+                    azpName = syfomodiapersonClientId,
+                )
+                coEvery { isTilgangskontrollClientMock.harTilgangTilSykmeldt(any(), any()) } returns true
+                val sykmeldt = defaultSykmeldt().copy(fnr = sykmeldtFnr)
+                val first = testDb.persistUnntaksvurdering("10987654321", sykmeldt, "Maren Hegna")
+                val second = testDb.persistUnntaksvurdering(
+                    "10987654321",
+                    sykmeldt.copy(orgnummer = "annetorgnummer"),
+                    "Maren Hegna",
+                )
+                testDb.persistUnntaksvurdering(
+                    "10987654321",
+                    sykmeldt.copy(fnr = "99999999999"),
+                    "Maren Hegna",
+                )
+
+                val response = client.post {
+                    url("/api/v1/veileder/unntaksvurderinger/query")
+                    bearerAuth(token = "******")
+                    contentType(ContentType.Application.Json)
+                    setBody(SykmeldtReadRequest(sykmeldtFnr))
+                }
+
+                response.status shouldBe HttpStatusCode.OK
+                val responseBody = response.body<UnntaksvurderingerVeilederResponse>()
+                responseBody.unntaksvurderinger.map { it.uuid } shouldBe listOf(second, first)
+                responseBody.unntaksvurderinger.first().fnr shouldBe sykmeldtFnr
+                responseBody.unntaksvurderinger.first().virksomhetsnummer shouldBe "annetorgnummer"
+                responseBody.unntaksvurderinger.first().virksomhetsnavn shouldBe "Test AS"
+                coVerify(exactly = 1) {
+                    isTilgangskontrollClientMock.harTilgangTilSykmeldt(
+                        sykmeldtFnr = eq(Fodselsnummer(sykmeldtFnr)),
+                        token = any(),
+                    )
+                }
+            }
+        }
+
+        it("responds with Forbidden when tilgangskontroll rejects access") {
+            fixture.withTestApplication {
+                texasClientMock.defaultMocks(
+                    pid = "some-veileder-token",
+                    navident = "some-navident",
+                    azpName = syfomodiapersonClientId,
+                )
+                coEvery { isTilgangskontrollClientMock.harTilgangTilSykmeldt(any(), any()) } returns false
+
+                val response = client.post {
+                    url("/api/v1/veileder/unntaksvurderinger/query")
+                    bearerAuth(token = "******")
+                    contentType(ContentType.Application.Json)
+                    setBody(SykmeldtReadRequest(sykmeldtFnr))
+                }
+
+                response.status shouldBe HttpStatusCode.Forbidden
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederUnntaksvurderingApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederUnntaksvurderingApiV1Test.kt
@@ -70,8 +70,8 @@ class VeilederUnntaksvurderingApiV1Test :
                 val responseBody = response.body<UnntaksvurderingerVeilederResponse>()
                 responseBody.unntaksvurderinger.map { it.uuid } shouldBe listOf(second, first)
                 responseBody.unntaksvurderinger.first().fnr shouldBe sykmeldtFnr
-                responseBody.unntaksvurderinger.first().virksomhetsnummer shouldBe "annetorgnummer"
-                responseBody.unntaksvurderinger.first().virksomhetsnavn shouldBe "Test AS"
+                responseBody.unntaksvurderinger.first().organisasjonsnummer shouldBe "annetorgnummer"
+                responseBody.unntaksvurderinger.first().organisasjonsnavn shouldBe "Test AS"
                 coVerify(exactly = 1) {
                     isTilgangskontrollClientMock.harTilgangTilSykmeldt(
                         sykmeldtFnr = eq(Fodselsnummer(sykmeldtFnr)),

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/db/UnntaksvurderingDAOTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/db/UnntaksvurderingDAOTest.kt
@@ -71,6 +71,22 @@ class UnntaksvurderingDAOTest :
                 testDb.findAllUnntaksvurderingerBy(sykmeldt.fnr, "annetorgnummer").shouldBeEmpty()
                 testDb.findAllUnntaksvurderingerBy("99999999999", sykmeldt.orgnummer).shouldBeEmpty()
             }
+
+            it("returns unntaksvurderinger for all arbeidsforhold for a sykmeldt") {
+                val first = testDb.persistUnntaksvurdering(narmesteLederFnr, sykmeldt, null)
+                val second = testDb.persistUnntaksvurdering(
+                    narmesteLederFnr,
+                    sykmeldt.copy(orgnummer = "annetorgnummer"),
+                    null,
+                )
+                testDb.persistUnntaksvurdering(
+                    narmesteLederFnr,
+                    sykmeldt.copy(fnr = "99999999999"),
+                    null,
+                )
+
+                testDb.findAllUnntaksvurderingerBySykmeldtFnr(sykmeldt.fnr).map { it.uuid } shouldBe listOf(second, first)
+            }
         }
 
         describe("softDeleteExpiredUnntaksvurderinger") {


### PR DESCRIPTION
## Beskrivelse

Eksponerer unntaksvurderinger for Modia gjennom veileder-API-et.

## Endringer

- Legger til `POST /api/v1/veileder/unntaksvurderinger/query` med tilgangskontroll.
- Returnerer avgrenset metadata i et utvidbart responsobjekt, sortert nyeste først.
- Oppdaterer OpenAPI og dekker autorisasjon, tilgang og oppslag i testene.

## Issue

Closes #399

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)