### PR TITLE
chore(db): rydd forlatt dev-outbox før #408

### DIFF
--- a/src/main/resources/db/migration/afterMigrate__remove_abandoned_generic_outbox.sql
+++ b/src/main/resources/db/migration/afterMigrate__remove_abandoned_generic_outbox.sql
@@ -1,0 +1,66 @@
+-- Midlertidig dev-opprydding. Skal ikke merges til main.
+--
+-- Dev fikk V26__create_generic_outbox.sql deployet 2026-08-13 fra en tidligere versjon av #408.
+-- Migrasjonsfilen ble endret etterpå (sent_at -> completed_at, ny state-constraint, to nye
+-- indekser), så Flyway-checksummen i dev matcher ikke lenger filen på PR-branchen, og appen
+-- kraesjer under validate ved oppstart.
+--
+-- Dette er en afterMigrate-callback, ikke en versjonert migrasjon. Callbacks foerer ingen rad i
+-- flyway_schema_history, saa denne branchen etterlater ingen historikk som maa ryddes manuelt
+-- etterpaa. Callbacken kjoerer ved hver oppstart og er derfor idempotent: den gjoer ingenting med
+-- mindre den nøyaktige forlatte piloten finnes.
+--
+-- Denne branchen er basert paa main, som ikke har V26. Dev-raden 26 er dermed en "future
+-- migration" for denne branchen og ignoreres av validate, slik at oppstart gaar gjennom.
+--
+-- Bruk: deploy denne branchen til dev, verifiser at appen starter, deploy saa #408. Lukk denne
+-- PR-en uten aa merge.
+DO
+$$
+DECLARE
+    deleted_history_rows BIGINT;
+BEGIN
+    IF to_regclass('public.outbox') IS NOT NULL THEN
+        LOCK TABLE public.outbox IN ACCESS EXCLUSIVE MODE;
+
+        -- Den forlatte varianten har sent_at. Den gjeldende V26 har completed_at i stedet.
+        -- Uten dette skillet kunne callbacken droppe en korrekt opprettet tabell.
+        IF NOT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'outbox'
+              AND column_name = 'sent_at'
+        ) THEN
+            RAISE NOTICE 'outbox matcher ikke den forlatte piloten; lar tabellen staa';
+            RETURN;
+        END IF;
+
+        IF EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'outbox'
+              AND column_name = 'completed_at'
+        ) THEN
+            RAISE NOTICE 'outbox har allerede completed_at; lar tabellen staa';
+            RETURN;
+        END IF;
+
+        DROP TABLE public.outbox;
+        RAISE WARNING 'Droppet forlatt dev-outbox fra tidligere versjon av #408';
+    END IF;
+
+    -- Treffer bare den nøyaktige raden fra 2026-08-13-deployen (checksum for commit 9d95e2f).
+    DELETE FROM flyway_schema_history
+    WHERE version = '26'
+      AND script = 'V26__create_generic_outbox.sql'
+      AND checksum = -380080342;
+
+    GET DIAGNOSTICS deleted_history_rows = ROW_COUNT;
+
+    IF deleted_history_rows > 0 THEN
+        RAISE WARNING 'Fjernet % flyway-historikkrad(er) for den forlatte V26', deleted_history_rows;
+    END IF;
+END
+$$;

--- a/src/test/kotlin/no/nav/syfo/AbandonedOutboxCleanupCallbackTest.kt
+++ b/src/test/kotlin/no/nav/syfo/AbandonedOutboxCleanupCallbackTest.kt
@@ -1,0 +1,182 @@
+package no.nav.syfo
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.flywaydb.core.Flyway
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy
+import java.sql.Connection
+import java.sql.DriverManager
+
+private const val ABANDONED_CHECKSUM = -380080342
+
+/**
+ * Midlertidig test som foelger afterMigrate-callbacken. Skal ikke merges til main.
+ */
+class AbandonedOutboxCleanupCallbackTest :
+    DescribeSpec({
+        describe("afterMigrate cleanup av forlatt dev-outbox") {
+            it("fjerner den forlatte piloten og historikkraden") {
+                withIsolatedDatabase { connection, migrate ->
+                    migrate()
+                    connection.installAbandonedPilot()
+
+                    migrate()
+
+                    connection.tableExists("outbox") shouldBe false
+                    connection.abandonedHistoryRowCount() shouldBe 0
+                }
+            }
+
+            it("lar en korrekt outbox med completed_at staa urort") {
+                withIsolatedDatabase { connection, migrate ->
+                    migrate()
+                    connection.execute(
+                        """
+                        CREATE TABLE outbox (
+                            uuid UUID PRIMARY KEY,
+                            completed_at TIMESTAMPTZ
+                        )
+                        """,
+                    )
+
+                    migrate()
+
+                    connection.tableExists("outbox") shouldBe true
+                }
+            }
+
+            it("lar V26 fra #408 kjoere rent etterpaa") {
+                withIsolatedDatabase { connection, migrate ->
+                    migrate()
+                    connection.installAbandonedPilot()
+                    migrate()
+
+                    // Samme migrate som #408 kjoerer ved oppstart, med den nye V26 paa plass.
+                    Flyway.configure()
+                        .locations("db", "db-pr408")
+                        .configuration(mapOf("flyway.postgresql.transactional.lock" to "false"))
+                        .dataSource(connection.jdbcUrlOfSelf(), "username", "password")
+                        .load()
+                        .migrate()
+
+                    connection.columnExists("outbox", "completed_at") shouldBe true
+                    connection.columnExists("outbox", "sent_at") shouldBe false
+                }
+            }
+
+            it("er idempotent naar det ikke finnes noen forlatt pilot") {
+                withIsolatedDatabase { _, migrate ->
+                    migrate()
+                    migrate()
+                    migrate()
+                }
+            }
+        }
+    })
+
+private val cleanupContainer: PsqlContainer by lazy {
+    PsqlContainer()
+        .withExposedPorts(5432)
+        .withUsername("username")
+        .withPassword("password")
+        .withDatabaseName("database")
+        .also {
+            it.waitingFor(HostPortWaitStrategy())
+            it.start()
+        }
+}
+
+private fun withIsolatedDatabase(block: (Connection, () -> Unit) -> Unit) {
+    val databaseName = "cleanup_${System.nanoTime()}"
+    DriverManager.getConnection(cleanupContainer.jdbcUrl, "username", "password").use { admin ->
+        admin.createStatement().use { it.execute("CREATE DATABASE $databaseName") }
+    }
+
+    val jdbcUrl = cleanupContainer.jdbcUrl.replace("/database", "/$databaseName")
+    val migrate = {
+        Flyway.configure()
+            .locations("db")
+            .configuration(mapOf("flyway.postgresql.transactional.lock" to "false"))
+            .dataSource(jdbcUrl, "username", "password")
+            .load()
+            .migrate()
+        Unit
+    }
+
+    DriverManager.getConnection(jdbcUrl, "username", "password").use { connection ->
+        block(connection, migrate)
+    }
+}
+
+/** Gjenskaper dev-tilstanden fra deployen 2026-08-13: pilotskjema med sent_at og flyway-rad 26. */
+private fun Connection.installAbandonedPilot() {
+    execute(
+        """
+        CREATE TABLE outbox (
+            uuid UUID PRIMARY KEY,
+            message_type TEXT NOT NULL,
+            dedup_key TEXT NOT NULL,
+            external_ref TEXT NOT NULL,
+            payload JSONB NOT NULL,
+            available_at TIMESTAMPTZ NOT NULL,
+            status TEXT NOT NULL DEFAULT 'READY',
+            claim_token UUID,
+            lease_until TIMESTAMPTZ,
+            failure_count INTEGER NOT NULL DEFAULT 0,
+            last_failure_at TIMESTAMPTZ,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            sent_at TIMESTAMPTZ,
+            cancellation_reason TEXT
+        )
+        """,
+    )
+    execute(
+        """
+        INSERT INTO flyway_schema_history
+            (installed_rank, version, description, type, script, checksum,
+             installed_by, execution_time, success)
+        SELECT max(installed_rank) + 1, '26', 'create generic outbox', 'SQL',
+               'V26__create_generic_outbox.sql', $ABANDONED_CHECKSUM, 'test', 72, true
+        FROM flyway_schema_history
+        """,
+    )
+}
+
+private fun Connection.abandonedHistoryRowCount(): Int =
+    prepareStatement(
+        "SELECT count(*) FROM flyway_schema_history WHERE version = '26' AND checksum = $ABANDONED_CHECKSUM",
+    ).use { statement ->
+        statement.executeQuery().use { rows ->
+            rows.next()
+            rows.getInt(1)
+        }
+    }
+
+private fun Connection.tableExists(name: String): Boolean =
+    prepareStatement("SELECT to_regclass('public.$name') IS NOT NULL").use { statement ->
+        statement.executeQuery().use { rows ->
+            rows.next()
+            rows.getBoolean(1)
+        }
+    }
+
+private fun Connection.columnExists(table: String, column: String): Boolean =
+    prepareStatement(
+        """
+        SELECT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public' AND table_name = ? AND column_name = ?
+        )
+        """,
+    ).use { statement ->
+        statement.setString(1, table)
+        statement.setString(2, column)
+        statement.executeQuery().use { rows ->
+            rows.next()
+            rows.getBoolean(1)
+        }
+    }
+
+private fun Connection.jdbcUrlOfSelf(): String = metaData.url
+
+private fun Connection.execute(sql: String) = createStatement().use { it.execute(sql) }

--- a/src/test/resources/db-pr408/V26__create_generic_outbox.sql
+++ b/src/test/resources/db-pr408/V26__create_generic_outbox.sql
@@ -1,0 +1,49 @@
+CREATE TABLE outbox
+(
+    uuid                UUID PRIMARY KEY,
+    message_type        TEXT        NOT NULL,
+    dedup_key           TEXT        NOT NULL,
+    external_ref        TEXT        NOT NULL,
+    payload             JSONB       NOT NULL,
+    available_at        TIMESTAMPTZ NOT NULL,
+    status              TEXT        NOT NULL DEFAULT 'READY',
+    claim_token         UUID,
+    lease_until         TIMESTAMPTZ,
+    failure_count       INTEGER     NOT NULL DEFAULT 0,
+    last_failure_at     TIMESTAMPTZ,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at        TIMESTAMPTZ,
+    cancellation_reason TEXT,
+    CONSTRAINT uq_outbox_message UNIQUE (message_type, dedup_key),
+    CONSTRAINT chk_outbox_status CHECK (status IN ('READY', 'CLAIMED', 'SENT', 'CANCELLED')),
+    CONSTRAINT chk_outbox_failure_metadata CHECK (
+        (failure_count = 0 AND last_failure_at IS NULL)
+        OR (failure_count > 0 AND last_failure_at IS NOT NULL)
+    ),
+    CONSTRAINT chk_outbox_state_metadata CHECK (
+        (status = 'READY' AND claim_token IS NULL AND lease_until IS NULL
+            AND completed_at IS NULL AND cancellation_reason IS NULL)
+        OR (status = 'CLAIMED' AND claim_token IS NOT NULL AND lease_until IS NOT NULL
+            AND completed_at IS NULL AND cancellation_reason IS NULL)
+        OR (status = 'SENT' AND claim_token IS NULL AND lease_until IS NULL
+            AND completed_at IS NOT NULL AND cancellation_reason IS NULL)
+        OR (status = 'CANCELLED' AND claim_token IS NULL AND lease_until IS NULL
+            AND completed_at IS NOT NULL AND cancellation_reason IS NOT NULL)
+    )
+);
+
+CREATE INDEX idx_outbox_ready
+    ON outbox (message_type, available_at, created_at, uuid)
+    WHERE status = 'READY';
+
+CREATE INDEX idx_outbox_expired_claim
+    ON outbox (message_type, lease_until, created_at, uuid)
+    WHERE status = 'CLAIMED';
+
+CREATE INDEX idx_outbox_unresolved_failure
+    ON outbox (message_type, failure_count DESC)
+    WHERE status IN ('READY', 'CLAIMED') AND failure_count > 0;
+
+CREATE INDEX idx_outbox_terminal_retention
+    ON outbox (message_type, completed_at)
+    WHERE status IN ('SENT', 'CANCELLED');


### PR DESCRIPTION
Midlertidig dev-opprydding før #408. **Skal ikke merges til main** — lukkes etter at #408 er deployet.

## Hvorfor

Dev fikk `V26__create_generic_outbox.sql` deployet 2026-08-13 13:08 fra commit `9d95e2f`. Migrasjonsfilen ble endret i `c876851` etterpå (`sent_at` → `completed_at`, oppdatert `chk_outbox_state_metadata`, to nye indekser), så checksummen i dev (`-380080342`) matcher ikke lenger filen på branchen (`2000339430`).

Flyway kjører med default `validateOnMigrate`, så oppstart kaster `FlywayValidateException` for versjon 26. Appen dør før den binder port 8080, og deployen av #408 timer ut på crashloop.

Main deployer fortsatt fint fordi V26 er en «future migration» sett fra main.

## Hvorfor callback og ikke versjonert migrasjon

En versjonert cleanup (som `V25_1` i #409) etterlater sin egen historikkrad. Den raden er lavere enn 26, altså ikke «future», så den blir applied-men-ikke-resolved når #408 deployes — og validate feiler på nytt. Det er derfor #409 krevde manuell sletting av 25.1-raden etterpå.

`afterMigrate`-callbacks fører ingen rad i `flyway_schema_history`. Denne branchen etterlater derfor ingenting som må ryddes manuelt, og krever ingen direkte databasetilgang: ryddingen kjøres av applikasjonsbrukeren, som eier både tabellen og historikktabellen.

Branchen er basert på main, som ikke har V26. Dev-raden 26 er dermed «future» for denne branchen og ignoreres av validate, slik at oppstart går gjennom.

## Sikkerhet

- dropper bare en `outbox` som har `sent_at` og mangler `completed_at`, altså nøyaktig den forlatte varianten
- lar en korrekt opprettet outbox stå urørt
- sletter bare historikkraden med `version = '26'`, `script = 'V26__create_generic_outbox.sql'` og `checksum = -380080342`
- idempotent: callbacken kjører ved hver oppstart og gjør ingenting når piloten ikke finnes

## Verifisering

Fire integrasjonstester mot ekte Flyway og PostgreSQL, alle grønne:

- fjerner den forlatte piloten og historikkraden
- lar en korrekt outbox med `completed_at` stå urørt
- **lar V26 fra #408 kjøre rent etterpå** — gjenskaper dev-tilstanden, kjører denne branchens migrate, og deretter #408 sin migrate; verifiserer at resultatet har `completed_at` og ikke `sent_at`
- er idempotent når det ikke finnes noen forlatt pilot

## Fremgangsmåte

1. deploy denne branchen til dev, verifiser at appen starter
2. deploy #408 til dev
3. lukk denne PR-en uten å merge