### PR TITLE
chore(dev): repair missing Flyway V27 and V28 history

### DIFF
--- a/src/main/resources/db/migration/V28__add_organisasjonsnavn_to_unntaksvurdering.sql
+++ b/src/main/resources/db/migration/V28__add_organisasjonsnavn_to_unntaksvurdering.sql
@@ -1,0 +1,2 @@
+ALTER TABLE unntaksvurdering
+    ADD COLUMN organisasjonsnavn TEXT;

--- a/src/main/resources/db/migration/beforeValidate__repair_dev_paaminnelse_v27_history.sql
+++ b/src/main/resources/db/migration/beforeValidate__repair_dev_paaminnelse_v27_history.sql
@@ -1,76 +1,118 @@
 -- Temporary dev-only recovery callback.
 --
--- The V27 schema change was applied in dev before its Flyway history row was removed.
--- Restore only the canonical history entry when the schema proves that V27 is already
--- fully applied. This branch must never be merged.
+-- The V27 and V28 schema changes were applied in dev before their Flyway history rows
+-- were removed. Restore only the canonical history entries when the schema proves that
+-- each migration is already fully applied. This branch must never be merged.
 DO
 $$
 DECLARE
     v_has_sykmeldingsperiode_id BOOLEAN;
     v_has_outbox_at             BOOLEAN;
+    v_has_organisasjonsnavn     BOOLEAN;
 BEGIN
-    IF to_regclass('public.paaminnelse') IS NULL
-        OR to_regclass('public.flyway_schema_history') IS NULL THEN
+    IF to_regclass('public.flyway_schema_history') IS NULL THEN
         RETURN;
     END IF;
 
     -- Serialize concurrent pod starts before reading or repairing Flyway history.
-    PERFORM pg_advisory_xact_lock(hashtext('repair-dev-paaminnelse-v27-history'));
+    PERFORM pg_advisory_xact_lock(hashtext('repair-dev-v27-v28-history'));
 
-    IF EXISTS (
+    IF NOT EXISTS (
         SELECT 1
         FROM flyway_schema_history
         WHERE version = '27'
           AND success
-    ) THEN
-        RETURN;
+    ) AND to_regclass('public.paaminnelse') IS NOT NULL THEN
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'paaminnelse'
+              AND column_name = 'sykmeldingsperiode_id'
+        )
+        INTO v_has_sykmeldingsperiode_id;
+
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'paaminnelse'
+              AND column_name = 'outbox_at'
+        )
+        INTO v_has_outbox_at;
+
+        IF v_has_sykmeldingsperiode_id AND NOT v_has_outbox_at THEN
+            INSERT INTO flyway_schema_history (
+                installed_rank,
+                version,
+                description,
+                type,
+                script,
+                checksum,
+                installed_by,
+                installed_on,
+                execution_time,
+                success
+            )
+            SELECT COALESCE(MAX(installed_rank), 0) + 1,
+                   '27',
+                   'update paaminnelse table',
+                   'SQL',
+                   'V27__update_paaminnelse_table.sql',
+                   -836683551,
+                   current_user,
+                   NOW(),
+                   0,
+                   TRUE
+            FROM flyway_schema_history;
+        ELSIF v_has_sykmeldingsperiode_id OR NOT v_has_outbox_at THEN
+            RAISE EXCEPTION
+                'Refusing temporary V27 history repair: paaminnelse has a partial V27 schema';
+        END IF;
     END IF;
 
-    SELECT EXISTS (
+    IF NOT EXISTS (
         SELECT 1
-        FROM information_schema.columns
-        WHERE table_schema = 'public'
-          AND table_name = 'paaminnelse'
-          AND column_name = 'sykmeldingsperiode_id'
-    )
-    INTO v_has_sykmeldingsperiode_id;
+        FROM flyway_schema_history
+        WHERE version = '28'
+          AND success
+    ) AND to_regclass('public.unntaksvurdering') IS NOT NULL THEN
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'unntaksvurdering'
+              AND column_name = 'organisasjonsnavn'
+              AND data_type = 'text'
+              AND is_nullable = 'YES'
+        )
+        INTO v_has_organisasjonsnavn;
 
-    SELECT EXISTS (
-        SELECT 1
-        FROM information_schema.columns
-        WHERE table_schema = 'public'
-          AND table_name = 'paaminnelse'
-          AND column_name = 'outbox_at'
-    )
-    INTO v_has_outbox_at;
-
-    IF NOT v_has_sykmeldingsperiode_id OR v_has_outbox_at THEN
-        RAISE EXCEPTION
-            'Refusing temporary V27 history repair: paaminnelse does not match the complete V27 schema';
+        IF v_has_organisasjonsnavn THEN
+            INSERT INTO flyway_schema_history (
+                installed_rank,
+                version,
+                description,
+                type,
+                script,
+                checksum,
+                installed_by,
+                installed_on,
+                execution_time,
+                success
+            )
+            SELECT COALESCE(MAX(installed_rank), 0) + 1,
+                   '28',
+                   'add organisasjonsnavn to unntaksvurdering',
+                   'SQL',
+                   'V28__add_organisasjonsnavn_to_unntaksvurdering.sql',
+                   954084108,
+                   current_user,
+                   NOW(),
+                   0,
+                   TRUE
+            FROM flyway_schema_history;
+        END IF;
     END IF;
-
-    INSERT INTO flyway_schema_history (
-        installed_rank,
-        version,
-        description,
-        type,
-        script,
-        checksum,
-        installed_by,
-        installed_on,
-        execution_time,
-        success
-    )
-    SELECT COALESCE(MAX(installed_rank), 0) + 1,
-           '27',
-           'update paaminnelse table',
-           'SQL',
-           'V27__update_paaminnelse_table.sql',
-           -836683551,
-           current_user,
-           NOW(),
-           0,
-           TRUE
-    FROM flyway_schema_history;
 END
 $$;

--- a/src/main/resources/db/migration/beforeValidate__repair_dev_paaminnelse_v27_history.sql
+++ b/src/main/resources/db/migration/beforeValidate__repair_dev_paaminnelse_v27_history.sql
@@ -1,0 +1,76 @@
+-- Temporary dev-only recovery callback.
+--
+-- The V27 schema change was applied in dev before its Flyway history row was removed.
+-- Restore only the canonical history entry when the schema proves that V27 is already
+-- fully applied. This branch must never be merged.
+DO
+$$
+DECLARE
+    v_has_sykmeldingsperiode_id BOOLEAN;
+    v_has_outbox_at             BOOLEAN;
+BEGIN
+    IF to_regclass('public.paaminnelse') IS NULL
+        OR to_regclass('public.flyway_schema_history') IS NULL THEN
+        RETURN;
+    END IF;
+
+    -- Serialize concurrent pod starts before reading or repairing Flyway history.
+    PERFORM pg_advisory_xact_lock(hashtext('repair-dev-paaminnelse-v27-history'));
+
+    IF EXISTS (
+        SELECT 1
+        FROM flyway_schema_history
+        WHERE version = '27'
+          AND success
+    ) THEN
+        RETURN;
+    END IF;
+
+    SELECT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'paaminnelse'
+          AND column_name = 'sykmeldingsperiode_id'
+    )
+    INTO v_has_sykmeldingsperiode_id;
+
+    SELECT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'paaminnelse'
+          AND column_name = 'outbox_at'
+    )
+    INTO v_has_outbox_at;
+
+    IF NOT v_has_sykmeldingsperiode_id OR v_has_outbox_at THEN
+        RAISE EXCEPTION
+            'Refusing temporary V27 history repair: paaminnelse does not match the complete V27 schema';
+    END IF;
+
+    INSERT INTO flyway_schema_history (
+        installed_rank,
+        version,
+        description,
+        type,
+        script,
+        checksum,
+        installed_by,
+        installed_on,
+        execution_time,
+        success
+    )
+    SELECT COALESCE(MAX(installed_rank), 0) + 1,
+           '27',
+           'update paaminnelse table',
+           'SQL',
+           'V27__update_paaminnelse_table.sql',
+           -836683551,
+           current_user,
+           NOW(),
+           0,
+           TRUE
+    FROM flyway_schema_history;
+END
+$$;

--- a/src/test/kotlin/no/nav/syfo/application/database/V27RecoveryCallbackTest.kt
+++ b/src/test/kotlin/no/nav/syfo/application/database/V27RecoveryCallbackTest.kt
@@ -1,0 +1,86 @@
+package no.nav.syfo.application.database
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import no.nav.syfo.PsqlContainer
+import org.flywaydb.core.Flyway
+import java.sql.DriverManager
+import java.util.UUID
+
+class V27RecoveryCallbackTest :
+    FunSpec({
+        test("records canonical V27 history only when its complete schema already exists") {
+            PsqlContainer().use { container ->
+                container.start()
+
+                fun flyway(target: String) = Flyway.configure()
+                    .dataSource(container.jdbcUrl, container.username, container.password)
+                    .target(target)
+                    .load()
+
+                flyway("26").migrate()
+
+                val sykmeldingsperiodeId = UUID.randomUUID()
+                DriverManager.getConnection(container.jdbcUrl, container.username, container.password).use { connection ->
+                    connection.createStatement().use { statement ->
+                        statement.execute(
+                            """
+                            ALTER TABLE paaminnelse
+                                ADD COLUMN sykmeldingsperiode_id UUID NOT NULL REFERENCES sykmeldingsperiode(id);
+                            ALTER TABLE paaminnelse
+                                DROP COLUMN outbox_at;
+                            """.trimIndent(),
+                        )
+                    }
+                    connection.prepareStatement(
+                        """
+                        INSERT INTO sykmeldingsperiode (
+                            id, sykmeldt_fnr, organisasjonsnummer, sykmelding_id, fom, tom
+                        ) VALUES (?, '12345678901', '123456789', 'sykmelding-id', '2026-01-01', '2026-01-31')
+                        """.trimIndent(),
+                    ).use { statement ->
+                        statement.setObject(1, sykmeldingsperiodeId)
+                        statement.executeUpdate()
+                    }
+                    connection.prepareStatement(
+                        """
+                        INSERT INTO paaminnelse (
+                            organisasjonsnummer, sykmeldt_fnr, bestilt, sykmeldingsperiode_id
+                        ) VALUES ('123456789', '12345678901', TRUE, ?)
+                        """.trimIndent(),
+                    ).use { statement ->
+                        statement.setObject(1, sykmeldingsperiodeId)
+                        statement.executeUpdate()
+                    }
+                }
+
+                flyway("27").migrate().migrationsExecuted shouldBe 0
+
+                DriverManager.getConnection(container.jdbcUrl, container.username, container.password).use { connection ->
+                    connection.createStatement().use { statement ->
+                        statement.executeQuery(
+                            """
+                            SELECT
+                                (SELECT COUNT(*) FROM paaminnelse),
+                                EXISTS (
+                                    SELECT 1 FROM flyway_schema_history
+                                    WHERE version = '27'
+                                      AND description = 'update paaminnelse table'
+                                      AND type = 'SQL'
+                                      AND script = 'V27__update_paaminnelse_table.sql'
+                                      AND checksum = -836683551
+                                      AND success
+                                )
+                            """.trimIndent(),
+                        ).use { result ->
+                            result.next() shouldBe true
+                            result.getLong(1) shouldBe 1
+                            result.getBoolean(2) shouldBe true
+                        }
+                    }
+                }
+
+                flyway("27").migrate().migrationsExecuted shouldBe 0
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/application/database/V27RecoveryCallbackTest.kt
+++ b/src/test/kotlin/no/nav/syfo/application/database/V27RecoveryCallbackTest.kt
@@ -9,7 +9,7 @@ import java.util.UUID
 
 class V27RecoveryCallbackTest :
     FunSpec({
-        test("records canonical V27 history only when its complete schema already exists") {
+        test("records canonical V27 and V28 history only when their complete schemas already exist") {
             PsqlContainer().use { container ->
                 container.start()
 
@@ -29,6 +29,8 @@ class V27RecoveryCallbackTest :
                                 ADD COLUMN sykmeldingsperiode_id UUID NOT NULL REFERENCES sykmeldingsperiode(id);
                             ALTER TABLE paaminnelse
                                 DROP COLUMN outbox_at;
+                            ALTER TABLE unntaksvurdering
+                                ADD COLUMN organisasjonsnavn TEXT;
                             """.trimIndent(),
                         )
                     }
@@ -54,7 +56,7 @@ class V27RecoveryCallbackTest :
                     }
                 }
 
-                flyway("27").migrate().migrationsExecuted shouldBe 0
+                flyway("28").migrate().migrationsExecuted shouldBe 0
 
                 DriverManager.getConnection(container.jdbcUrl, container.username, container.password).use { connection ->
                     connection.createStatement().use { statement ->
@@ -70,17 +72,27 @@ class V27RecoveryCallbackTest :
                                       AND script = 'V27__update_paaminnelse_table.sql'
                                       AND checksum = -836683551
                                       AND success
+                                ),
+                                EXISTS (
+                                    SELECT 1 FROM flyway_schema_history
+                                    WHERE version = '28'
+                                      AND description = 'add organisasjonsnavn to unntaksvurdering'
+                                      AND type = 'SQL'
+                                      AND script = 'V28__add_organisasjonsnavn_to_unntaksvurdering.sql'
+                                      AND checksum = 954084108
+                                      AND success
                                 )
                             """.trimIndent(),
                         ).use { result ->
                             result.next() shouldBe true
                             result.getLong(1) shouldBe 1
                             result.getBoolean(2) shouldBe true
+                            result.getBoolean(3) shouldBe true
                         }
                     }
                 }
 
-                flyway("27").migrate().migrationsExecuted shouldBe 0
+                flyway("28").migrate().migrationsExecuted shouldBe 0
             }
         }
     })


### PR DESCRIPTION
Temporary dev-only recovery. **Do not merge this PR.**

Dev already has the complete schema changes from V27 and V28, but their Flyway history rows were removed. The application therefore attempts the migrations again and fails on columns that already exist.

The `beforeValidate` callback:

- does nothing when a migration is already recorded
- restores V27 only when the complete V27 `paaminnelse` schema is present
- restores V28 only when nullable TEXT `unntaksvurdering.organisasjonsnavn` is present
- inserts only the canonical Flyway history entries and checksums
- performs no DDL and preserves all schema and domain data
- serializes concurrent pod starts with a PostgreSQL advisory transaction lock

The recovery branch includes the exact canonical V28 migration so Flyway can validate the restored history. The integration test reconstructs the missing-history state, verifies that the existing `paaminnelse` row is preserved, and verifies that subsequent Flyway runs remain valid.

After one successful dev deploy: close this PR without merging, delete the branch, and rerun PR #416.
