### PR TITLE
refactor(db): fjern kodeavhengighet til legacy outbox-kolonne

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
@@ -421,7 +421,6 @@ fun ResultSet.mapToOppfolgingsplan(): PersistedOppfolgingsplan = PersistedOppfol
     content = FormSnapshot.jsonToFormSnapshot(getString("content")),
     evalueringsdato = LocalDate.parse(this.getString("evalueringsdato")),
     evalueringPaaminnelse = this.getBoolean("evaluering_paaminnelse"),
-    evalueringPaaminnelseOutboxAt = this.getTimestamp("evaluering_paaminnelse_outbox_at")?.toInstant(),
     skalDelesMedLege = this.getBoolean("skal_deles_med_lege"),
     skalDelesMedVeileder = this.getBoolean("skal_deles_med_veileder"),
     deltMedLegeTidspunkt = this.getTimestamp("delt_med_lege_tidspunkt")?.toInstant(),

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanFinalizationRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanFinalizationRepository.kt
@@ -61,7 +61,6 @@ class OppfolgingsplanFinalizationRepository(
                 command.createOppfolgingsplanRequest.evalueringsdato
             it[OppfolgingsplanTable.evalueringPaaminnelse] =
                 command.createOppfolgingsplanRequest.evalueringPaaminnelse
-            it[OppfolgingsplanTable.evalueringPaaminnelseOutboxAt] = null
             it[OppfolgingsplanTable.skalDelesMedLege] = false
             it[OppfolgingsplanTable.skalDelesMedVeileder] = false
             it[OppfolgingsplanTable.utkastCreatedAt] = utkastCreatedAt

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanTables.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanTables.kt
@@ -32,7 +32,6 @@ internal object OppfolgingsplanTable : Table("oppfolgingsplan") {
     val feilregistrert = timestampWithTimeZone("feilregistrert").nullable()
     val feilregistrertAarsak = text("feilregistrert_aarsak").nullable()
     val evalueringPaaminnelse = bool("evaluering_paaminnelse").default(false)
-    val evalueringPaaminnelseOutboxAt = timestampWithTimeZone("evaluering_paaminnelse_outbox_at").nullable()
     val eventId = javaUUID("event_id").nullable()
     val varselPublishedAt = timestampWithTimeZone("varsel_published_at").nullable()
 

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/domain/PersistedOppfolgingsplan.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/domain/PersistedOppfolgingsplan.kt
@@ -25,7 +25,6 @@ data class PersistedOppfolgingsplan(
     val content: FormSnapshot,
     val evalueringsdato: LocalDate,
     val evalueringPaaminnelse: Boolean = false,
-    val evalueringPaaminnelseOutboxAt: Instant? = null,
     val skalDelesMedLege: Boolean,
     val skalDelesMedVeileder: Boolean,
     val deltMedLegeTidspunkt: Instant? = null,

--- a/src/test/kotlin/no/nav/syfo/TestDb.kt
+++ b/src/test/kotlin/no/nav/syfo/TestDb.kt
@@ -145,14 +145,13 @@ fun DatabaseInterface.persistOppfolgingsplan(
             content,
             evalueringsdato,
             evaluering_paaminnelse,
-            evaluering_paaminnelse_outbox_at,
             skal_deles_med_lege,
             skal_deles_med_veileder,
             created_at,
             skjult_fra,
             feilregistrert,
             feilregistrert_aarsak
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         RETURNING uuid
     """.trimIndent()
 
@@ -170,25 +169,20 @@ fun DatabaseInterface.persistOppfolgingsplan(
             it.setObject(10, persistedOppfolgingsplan.content.toJsonString(), Types.OTHER)
             it.setDate(11, Date.valueOf(persistedOppfolgingsplan.evalueringsdato.toString()))
             it.setBoolean(12, persistedOppfolgingsplan.evalueringPaaminnelse)
-            if (persistedOppfolgingsplan.evalueringPaaminnelseOutboxAt != null) {
-                it.setTimestamp(13, Timestamp.from(persistedOppfolgingsplan.evalueringPaaminnelseOutboxAt))
-            } else {
-                it.setNull(13, Types.TIMESTAMP_WITH_TIMEZONE)
-            }
-            it.setBoolean(14, persistedOppfolgingsplan.skalDelesMedLege)
-            it.setBoolean(15, persistedOppfolgingsplan.skalDelesMedVeileder)
-            it.setTimestamp(16, Timestamp.from(persistedOppfolgingsplan.createdAt))
+            it.setBoolean(13, persistedOppfolgingsplan.skalDelesMedLege)
+            it.setBoolean(14, persistedOppfolgingsplan.skalDelesMedVeileder)
+            it.setTimestamp(15, Timestamp.from(persistedOppfolgingsplan.createdAt))
             if (persistedOppfolgingsplan.skjultFra != null) {
-                it.setTimestamp(17, Timestamp.from(persistedOppfolgingsplan.skjultFra))
+                it.setTimestamp(16, Timestamp.from(persistedOppfolgingsplan.skjultFra))
+            } else {
+                it.setNull(16, Types.TIMESTAMP_WITH_TIMEZONE)
+            }
+            if (persistedOppfolgingsplan.feilregistrert != null) {
+                it.setTimestamp(17, Timestamp.from(persistedOppfolgingsplan.feilregistrert))
             } else {
                 it.setNull(17, Types.TIMESTAMP_WITH_TIMEZONE)
             }
-            if (persistedOppfolgingsplan.feilregistrert != null) {
-                it.setTimestamp(18, Timestamp.from(persistedOppfolgingsplan.feilregistrert))
-            } else {
-                it.setNull(18, Types.TIMESTAMP_WITH_TIMEZONE)
-            }
-            it.setString(19, persistedOppfolgingsplan.feilregistrertAarsak)
+            it.setString(18, persistedOppfolgingsplan.feilregistrertAarsak)
             val resultSet = it.executeQuery()
             connection.commit()
             resultSet.next()

--- a/src/test/kotlin/no/nav/syfo/TestUtils.kt
+++ b/src/test/kotlin/no/nav/syfo/TestUtils.kt
@@ -66,7 +66,6 @@ fun defaultPersistedOppfolgingsplan() = PersistedOppfolgingsplan(
     stillingsprosent = BigDecimal("100.00"),
     content = defaultFormSnapshot(),
     evalueringPaaminnelse = false,
-    evalueringPaaminnelseOutboxAt = null,
     skalDelesMedLege = false,
     skalDelesMedVeileder = false,
     uuid = UUID.randomUUID(),

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
@@ -498,7 +498,6 @@ class OppfolgingsplanApiV1Test :
                     persisted.first().content.toString() shouldBe oppfolgingsplan.content.toString()
                     persisted.first().evalueringsdato.toString() shouldBe oppfolgingsplan.evalueringsdato.toString()
                     persisted.first().evalueringPaaminnelse shouldBe false
-                    persisted.first().evalueringPaaminnelseOutboxAt shouldBe null
                     persisted.first().sykmeldtFullName shouldBe "Navn Sykmeldt"
                     persisted.first().organisasjonsnavn shouldBe "Test AS"
                     persisted.first().stillingstittel shouldBe "Systemutvikler"

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanSchemaTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanSchemaTest.kt
@@ -3,7 +3,6 @@ package no.nav.syfo.oppfolgingsplan.db
 import io.kotest.assertions.withClue
 import io.kotest.core.annotation.Isolate
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -16,7 +15,7 @@ import org.jetbrains.exposed.v1.migration.jdbc.MigrationUtils
 class OppfolgingsplanSchemaTest :
     DescribeSpec({
         describe("oppfolgingsplan schema") {
-            it("keeps the Exposed mappings aligned with the Flyway schema") {
+            it("keeps only the deployment 1 legacy column outside the Exposed mappings") {
                 val drift = transaction(TestDB.database.exposedDatabase) {
                     MigrationUtils.statementsRequiredForDatabaseMigration(
                         OppfolgingsplanTable,
@@ -26,7 +25,9 @@ class OppfolgingsplanSchemaTest :
                 }
 
                 withClue("Oppfolgingsplan schema drift:\n${drift.joinToString("\n")}") {
-                    drift.shouldBeEmpty()
+                    drift shouldBe listOf(
+                        "ALTER TABLE oppfolgingsplan DROP COLUMN evaluering_paaminnelse_outbox_at",
+                    )
                 }
             }
 
@@ -47,7 +48,7 @@ class OppfolgingsplanSchemaTest :
                     "(sykmeldt_fnr, organisasjonsnummer, created_at DESC) WHERE (skjult_fra IS NULL)"
             }
 
-            it("should add evaluering paaminnelse columns only on oppfolgingsplan") {
+            it("keeps the nullable legacy outbox column during deployment 1") {
                 val oppfolgingsplanColumns = TestDB.database.connection.use { connection ->
                     connection.metaData.getColumns(null, null, "oppfolgingsplan", null).use { resultSet ->
                         buildList {


### PR DESCRIPTION
## Sammendrag

Første deploy-steg for #432:

- fjerner alle lesinger og skrivinger av den gamle `evaluering_paaminnelse_outbox_at`-kolonnen
- fjerner feltet fra `PersistedOppfolgingsplan` og testdata
- beholder den nullable databasekolonnen og V20-migrasjonen under rullerende deploy

Kolonnen droppes i et separat deploy-steg etter at denne versjonen er rullet ut i produksjon og gamle pods er borte. Det gjør migreringen trygg for rullerende deploy.

## Verifisering

- `./gradlew build`
- rebased på `main` etter merge av #438

Refs #432
