### PR TITLE
feat: add narmesteleder client

### DIFF
--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -79,6 +79,7 @@ spec:
         - application: syfo-dokumentporten
         - application: syfooppdfgen
         - application: dinesykmeldte-backend
+        - application: esyfo-narmesteleder
         - application: isdialogmelding
           namespace: teamsykefravr
         - application: istilgangskontroll
@@ -127,5 +128,9 @@ spec:
       value: dev-gcp:team-esyfo:syfo-oppfolgingsplan-frontend
     - name: MIN_SIDE_SYKMELDT_OPPFOLGINGSPLAN_URL
       value: https://www.ekstern.dev.nav.no/syk/oppfolgingsplan/sykmeldt
+    - name: NARMESTELEDER_URL
+      value: http://esyfo-narmesteleder.team-esyfo
+    - name: NARMESTELEDER_SCOPE
+      value: api://dev-gcp.team-esyfo.esyfo-narmesteleder/.default
     - name: DINE_SYKMELDTE_OVERSIKT_URL
       value: https://www.ekstern.dev.nav.no/arbeidsgiver/sykmeldte

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -75,6 +75,7 @@ spec:
         - application: syfo-dokumentporten
         - application: syfooppdfgen
         - application: dinesykmeldte-backend
+        - application: esyfo-narmesteleder
         - application: isdialogmelding
           namespace: teamsykefravr
         - application: istilgangskontroll
@@ -123,5 +124,9 @@ spec:
       value: prod-gcp:team-esyfo:syfo-oppfolgingsplan-frontend
     - name: MIN_SIDE_SYKMELDT_OPPFOLGINGSPLAN_URL
       value: https://www.nav.no/syk/oppfolgingsplan/sykmeldt
+    - name: NARMESTELEDER_URL
+      value: http://esyfo-narmesteleder.team-esyfo
+    - name: NARMESTELEDER_SCOPE
+      value: api://prod-gcp.team-esyfo.esyfo-narmesteleder/.default
     - name: DINE_SYKMELDTE_OVERSIKT_URL
       value: https://www.nav.no/arbeidsgiver/sykmeldte

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -25,6 +25,8 @@ interface Environment {
     val aaregScope: String
     val pdlBaseUrl: String
     val pdlScope: String
+    val narmestelederBaseUrl: String
+    val narmestelederScope: String
     val kafka: KafkaEnv
     val electorPath: String
     val syfomodiapersonClientId: String
@@ -72,6 +74,8 @@ data class NaisEnvironment(
     override val aaregScope: String = getEnvVar("AAREG_SCOPE"),
     override val pdlBaseUrl: String = getEnvVar("PDL_BASE_URL"),
     override val pdlScope: String = getEnvVar("PDL_SCOPE"),
+    override val narmestelederBaseUrl: String = getEnvVar("NARMESTELEDER_URL"),
+    override val narmestelederScope: String = getEnvVar("NARMESTELEDER_SCOPE"),
     override val kafka: KafkaEnv = KafkaEnv.createFromEnvVars(),
     override val electorPath: String = getEnvVar("ELECTOR_PATH"),
     override val syfomodiapersonClientId: String = getEnvVar("SYFOMODIAPERSON_CLIENT_ID"),
@@ -126,6 +130,8 @@ data class LocalEnvironment(
     override val pdfGenUrl: String = "http://localhost:9091",
     override val pdlBaseUrl: String = "https://pdl-api.dev.intern.nav.no",
     override val pdlScope: String = "pdl",
+    override val narmestelederBaseUrl: String = "http://localhost:8081",
+    override val narmestelederScope: String = "api://dev-gcp.team-esyfo.esyfo-narmesteleder/.default",
     override val kafka: KafkaEnv = KafkaEnv.createForLocal(),
     override val electorPath: String = "/elector",
     override val syfomodiapersonClientId: String = "dev-gcp:teamsykefravr:syfomodiaperson",

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/client/NarmestelederClient.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/client/NarmestelederClient.kt
@@ -1,0 +1,80 @@
+package no.nav.syfo.narmesteleder.client
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.ktor.client.HttpClient
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.contentType
+import no.nav.syfo.texas.client.TexasHttpClient
+import no.nav.syfo.util.configuredJacksonMapper
+import java.util.UUID
+
+private const val IDENTITY_PROVIDER = "azuread"
+private const val INVALID_RESPONSE_MESSAGE = "Narmesteleder returned an invalid response"
+const val NARMESTELEDER_LOOKUP_PATH = "/internal/api/v1/lookup"
+
+interface INarmestelederClient {
+    suspend fun findActiveNarmesteleder(
+        sykmeldtFnr: String,
+        organisasjonsnummer: String,
+    ): Narmesteleder?
+}
+
+class FakeNarmestelederClient : INarmestelederClient {
+    override suspend fun findActiveNarmesteleder(
+        sykmeldtFnr: String,
+        organisasjonsnummer: String,
+    ): Narmesteleder? = null
+}
+
+class NarmestelederClient(
+    private val httpClient: HttpClient,
+    private val narmestelederBaseUrl: String,
+    private val texasHttpClient: TexasHttpClient,
+    private val scope: String,
+) : INarmestelederClient {
+    override suspend fun findActiveNarmesteleder(
+        sykmeldtFnr: String,
+        organisasjonsnummer: String,
+    ): Narmesteleder? {
+        val token = texasHttpClient.systemToken(IDENTITY_PROVIDER, scope).accessToken
+        val responseBody = httpClient
+            .post("$narmestelederBaseUrl$NARMESTELEDER_LOOKUP_PATH") {
+                contentType(ContentType.Application.Json)
+                header(HttpHeaders.Authorization, "Bearer $token")
+                setBody(
+                    NarmestelederLookupRequest(
+                        employeeNationalIdentificationNumber = sykmeldtFnr,
+                        organizationNumber = organisasjonsnummer,
+                    ),
+                )
+            }
+            .bodyAsText()
+
+        return try {
+            configuredJacksonMapper.readValue<NarmestelederLookupResponse>(responseBody).lineManager
+        } catch (_: JsonProcessingException) {
+            throw IllegalStateException(INVALID_RESPONSE_MESSAGE)
+        }
+    }
+}
+
+data class NarmestelederLookupRequest(
+    val employeeNationalIdentificationNumber: String,
+    val organizationNumber: String,
+)
+
+data class NarmestelederLookupResponse(
+    val lineManager: Narmesteleder?,
+)
+
+data class Narmesteleder(
+    val id: UUID,
+    val nationalIdentificationNumber: String,
+    val emailAddresses: List<String>,
+)

--- a/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
@@ -40,6 +40,9 @@ import no.nav.syfo.isdialogmelding.client.IsDialogmeldingClient
 import no.nav.syfo.istilgangskontroll.IsTilgangskontrollService
 import no.nav.syfo.istilgangskontroll.client.FakeIsTilgangskontrollClient
 import no.nav.syfo.istilgangskontroll.client.IsTilgangskontrollClient
+import no.nav.syfo.narmesteleder.client.FakeNarmestelederClient
+import no.nav.syfo.narmesteleder.client.INarmestelederClient
+import no.nav.syfo.narmesteleder.client.NarmestelederClient
 import no.nav.syfo.oppfolgingsplan.db.EvalueringspaaminnelseSourceRepository
 import no.nav.syfo.oppfolgingsplan.db.OppfolgingsplanFinalizationRepository
 import no.nav.syfo.oppfolgingsplan.outbox.DineSykmeldteEvalueringspaaminnelseHandler
@@ -181,6 +184,18 @@ private fun clientsModule() = module {
             IsTilgangskontrollClient(
                 get(),
                 env().isTilgangskontrollBaseUrl,
+            )
+        }
+    }
+    single<INarmestelederClient> {
+        if (isLocalEnv()) {
+            FakeNarmestelederClient()
+        } else {
+            NarmestelederClient(
+                httpClient = get(),
+                narmestelederBaseUrl = env().narmestelederBaseUrl,
+                texasHttpClient = get(),
+                scope = env().narmestelederScope,
             )
         }
     }

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/client/NarmestelederClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/client/NarmestelederClientTest.kt
@@ -1,0 +1,157 @@
+package no.nav.syfo.narmesteleder.client
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
+import io.ktor.http.HttpHeaders
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import no.nav.syfo.texas.client.TexasHttpClient
+import no.nav.syfo.texas.client.TexasResponse
+import no.nav.syfo.util.httpClientDefault
+import java.util.UUID
+
+class NarmestelederClientTest :
+    DescribeSpec({
+        val texasHttpClient = mockk<TexasHttpClient>()
+        val wireMockServer = WireMockServer(options().dynamicPort())
+
+        fun client() = NarmestelederClient(
+            httpClient = httpClientDefault(),
+            narmestelederBaseUrl = wireMockServer.baseUrl(),
+            texasHttpClient = texasHttpClient,
+            scope = "api://dev-gcp.team-esyfo.esyfo-narmesteleder/.default",
+        )
+
+        beforeTest {
+            clearAllMocks(currentThreadOnly = true)
+            wireMockServer.start()
+            coEvery {
+                texasHttpClient.systemToken("azuread", "api://dev-gcp.team-esyfo.esyfo-narmesteleder/.default")
+            } returns TexasResponse(
+                accessToken = "token",
+                expiresIn = 3600,
+                tokenType = "Bearer",
+            )
+        }
+
+        afterTest {
+            wireMockServer.resetAll()
+            wireMockServer.stop()
+        }
+
+        it("looks up an active narmesteleder with a system token") {
+            wireMockServer.stubFor(
+                post(urlPathEqualTo(NARMESTELEDER_LOOKUP_PATH))
+                    .withHeader(HttpHeaders.Authorization, equalTo("Bearer token"))
+                    .withRequestBody(
+                        equalToJson(
+                            """
+                            {"employeeNationalIdentificationNumber":"12345678901","organizationNumber":"123456789"}
+                            """.trimIndent(),
+                        ),
+                    )
+                    .willReturn(
+                        aResponse()
+                            .withHeader(HttpHeaders.ContentType, "application/json")
+                            .withBody(
+                                """
+                                {
+                                  "lineManager": {
+                                    "id": "c8d10801-a0cc-4d94-a9ab-0088e850d4f4",
+                                    "nationalIdentificationNumber": "10987654321",
+                                    "emailAddresses": ["leder@eksempel.no"]
+                                  }
+                                }
+                                """.trimIndent(),
+                            ),
+                    ),
+            )
+
+            val narmesteleder = client().findActiveNarmesteleder("12345678901", "123456789")
+
+            narmesteleder?.id shouldBe UUID.fromString("c8d10801-a0cc-4d94-a9ab-0088e850d4f4")
+            narmesteleder?.nationalIdentificationNumber shouldBe "10987654321"
+            narmesteleder?.emailAddresses shouldBe listOf("leder@eksempel.no")
+            coVerify(exactly = 1) {
+                texasHttpClient.systemToken("azuread", "api://dev-gcp.team-esyfo.esyfo-narmesteleder/.default")
+            }
+        }
+
+        it("returns null when no active narmesteleder exists") {
+            wireMockServer.stubFor(
+                post(urlPathEqualTo(NARMESTELEDER_LOOKUP_PATH))
+                    .willReturn(
+                        aResponse()
+                            .withHeader(HttpHeaders.ContentType, "application/json")
+                            .withBody("""{"lineManager":null}"""),
+                    ),
+            )
+
+            client().findActiveNarmesteleder("12345678901", "123456789").shouldBeNull()
+        }
+
+        it("does not expose response data when the response is malformed") {
+            val responseBody = """{"lineManager":{"nationalIdentificationNumber":"10987654321","emailAddresses":["leder@eksempel.no"]"""
+            wireMockServer.stubFor(
+                post(urlPathEqualTo(NARMESTELEDER_LOOKUP_PATH))
+                    .willReturn(
+                        aResponse()
+                            .withHeader(HttpHeaders.ContentType, "application/json")
+                            .withBody(responseBody),
+                    ),
+            )
+
+            val exception = shouldThrow<IllegalStateException> {
+                client().findActiveNarmesteleder("12345678901", "123456789")
+            }
+
+            exception.message shouldBe "Narmesteleder returned an invalid response"
+            exception.message.orEmpty() shouldNotContain "10987654321"
+            exception.message.orEmpty() shouldNotContain "leder@eksempel.no"
+            exception.message.orEmpty() shouldNotContain responseBody
+            exception.cause.shouldBeNull()
+        }
+
+        it("does not expose response data when a response field has an invalid format") {
+            val responseBody =
+                """
+                {
+                  "lineManager": {
+                    "id": "not-a-uuid",
+                    "nationalIdentificationNumber": "10987654321",
+                    "emailAddresses": ["leder@eksempel.no"]
+                  }
+                }
+                """.trimIndent()
+            wireMockServer.stubFor(
+                post(urlPathEqualTo(NARMESTELEDER_LOOKUP_PATH))
+                    .willReturn(
+                        aResponse()
+                            .withHeader(HttpHeaders.ContentType, "application/json")
+                            .withBody(responseBody),
+                    ),
+            )
+
+            val exception = shouldThrow<IllegalStateException> {
+                client().findActiveNarmesteleder("12345678901", "123456789")
+            }
+
+            exception.message shouldBe "Narmesteleder returned an invalid response"
+            exception.message.orEmpty() shouldNotContain "10987654321"
+            exception.message.orEmpty() shouldNotContain "leder@eksempel.no"
+            exception.message.orEmpty() shouldNotContain responseBody
+            exception.cause.shouldBeNull()
+        }
+    })


### PR DESCRIPTION
## Beskrivelse

Legger til en klient for å hente aktiv nærmeste leder fra `esyfo-narmesteleder`. Oppslaget bruker Azure systemtoken og sender fødselsnummer og organisasjonsnummer til det interne lookup-endepunktet.

Responsen inneholder relasjonens ID, nærmeste leders fødselsnummer og registrerte e-postadresser.

## Endringer

- Legger til `NarmestelederClient` med request- og responsmodeller.
- Konfigurerer intern URL og Azure-scope for dev og prod.
- Gir applikasjonen utgående tilgang til `esyfo-narmesteleder`.
- Registrerer ekte og lokal fake-klient i Koin.
- Tester systemtoken, request-kontrakt, aktiv relasjon og manglende aktiv nærmeste leder.

Avhenger av [navikt/esyfo-narmesteleder#491](https://github.com/navikt/esyfo-narmesteleder/pull/491), som utvider responskontrakten med relasjons-ID og gir denne applikasjonen inbound- og Azure-tilgang.

## Issue

Ingen direkte issue-kobling.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet automatisk
- [ ] Ingen sensitiv data eksponert i logger eller feilrespons fra den nye klienten