### PR TITLE
chore: oppgrader Budstikka-kontrakten til 0.4.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 
 val dataFakerVersion = "2.7.0"
-val budstikkaContractVersion = "0.3.0"
+val budstikkaContractVersion = "0.4.0"
 val exposedVersion = "1.4.0"
 val flywayVersion = "13.3.0"
 val hikariVersion = "7.1.0"

--- a/src/test/kotlin/no/nav/syfo/varsel/budstikka/BudstikkaProducerKafkaIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/syfo/varsel/budstikka/BudstikkaProducerKafkaIntegrationTest.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.varsel.budstikka
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import kotlinx.coroutines.runBlocking
 import no.nav.budstikka.contract.Arbeidsgivervarsel
 import no.nav.budstikka.contract.Budstikka
@@ -120,7 +121,7 @@ class BudstikkaProducerKafkaIntegrationTest :
                     record.key() shouldBe expectedDispatch.key
                     record.value() shouldBe expectedDispatch.value
                     record.value() shouldContain "\"oppgavetype\":\"OPPFOLGINGSPLAN_PAAMINNELSE\""
-                    record.value() shouldContain "\"link\":null"
+                    record.value() shouldNotContain "\"link\""
                     record.headers().associate { header ->
                         header.key() to header.value().toList()
                     } shouldBe expectedDispatch.headerBytes().mapValues { (_, value) ->

--- a/src/test/kotlin/no/nav/syfo/varsel/budstikka/BudstikkaProducerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/varsel/budstikka/BudstikkaProducerTest.kt
@@ -150,7 +150,7 @@ class BudstikkaProducerTest :
                             it.key() shouldBe expectedDispatch.key
                             it.value() shouldBe expectedDispatch.value
                             it.value() shouldContain "\"sendingWindow\":\"ONGOING\""
-                            it.value() shouldContain "\"link\":null"
+                            it.value() shouldNotContain "\"link\""
                             actualHeaders shouldBe expectedHeaders
                         },
                     )


### PR DESCRIPTION
## Sammendrag

- oppgraderer budstikka-kontrakt fra 0.3.0 til 0.4.0
- verifiserer at Dine Sykmeldte-payloaden ikke lenger inneholder link-feltet
- beholder øvrige varselkontrakter og klikklenker uendret

## Bakgrunn

Budstikka #259 er merget og ferdig rullet ut i dev og prod. Kontrakt 0.4.0 er publisert, attestert og verifisert gjennom Nav-speilet før denne bumpen.

Produksjonskallet brukte allerede overloaden uten link. Testene er oppdatert fra å forvente link: null til å kreve at feltet er helt fraværende i wireformatet.

## Verifisering

- ./gradlew build
- 332 tester