### PR TITLE
Skill terminale sykmeldingsavvisninger fra retry

### DIFF
--- a/src/main/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumer.kt
@@ -30,6 +30,7 @@ class SykmeldingsperiodeConsumer(
     private val sykmeldingsperiodeRepository: SykmeldingsperiodeRepository,
     private val kafkaEnv: KafkaEnv,
     private val clock: Clock = Clock.system(ZONE_OSLO),
+    private val recordMetrics: SykmeldingsperiodeRecordMetrics = SykmeldingsperiodeRecordMetrics(),
 ) {
     private val log = logger()
 
@@ -58,28 +59,7 @@ class SykmeldingsperiodeConsumer(
 
                 while (currentCoroutineContext().isActive && running) {
                     val records = kafkaConsumer.poll(POLL_DURATION)
-                    var deserializationErrors = 0
-
-                    records.forEach { record ->
-                        try {
-                            processRecord(record)
-                        } catch (ex: JsonProcessingException) {
-                            deserializationErrors++
-                            COUNT_SYKMELDING_DESERIALIZATION_ERROR.increment()
-                            log.warn(
-                                "Failed to deserialize sykmelding at partition=${record.partition()}, offset=${record.offset()}",
-                                ex,
-                            )
-                        }
-                    }
-
-                    if (deserializationErrors > 0 && deserializationErrors >= records.count()) {
-                        error("All ${records.count()} records failed deserialization — likely a systematic DTO mismatch")
-                    }
-
-                    if (!records.isEmpty) {
-                        kafkaConsumer.commitSync()
-                    }
+                    processBatch(records) { kafkaConsumer.commitSync() }
                 }
             } catch (ex: CancellationException) {
                 throw ex
@@ -105,13 +85,54 @@ class SykmeldingsperiodeConsumer(
         consumer?.wakeup()
     }
 
+    internal fun processBatch(
+        records: Iterable<ConsumerRecord<String, String>>,
+        commitOffsets: () -> Unit,
+    ) {
+        var recordCount = 0
+        var deserializationErrors = 0
+        var invalidTombstones = 0
+
+        records.forEach { record ->
+            recordCount++
+            try {
+                if (processRecord(record) == SykmeldingsperiodeRecordOutcome.INVALID_TOMBSTONE) {
+                    invalidTombstones++
+                }
+            } catch (ex: JsonProcessingException) {
+                deserializationErrors++
+                COUNT_SYKMELDING_DESERIALIZATION_ERROR.increment()
+                log.warn(
+                    "Failed to deserialize sykmelding at partition=${record.partition()}, offset=${record.offset()}",
+                    ex,
+                )
+            }
+        }
+
+        if (deserializationErrors > 0 && deserializationErrors >= recordCount) {
+            recordMetrics.recordDeserializationRetryBatchAttempt()
+            error("All $recordCount records failed deserialization — likely a systematic DTO mismatch")
+        }
+
+        if (recordCount > 0) {
+            commitOffsets()
+            recordMetrics.recordTerminallyRejected(
+                reason = SykmeldingsperiodeRejectionReason.DESERIALIZATION,
+                count = deserializationErrors,
+            )
+            recordMetrics.recordTerminallyRejected(
+                reason = SykmeldingsperiodeRejectionReason.INVALID_TOMBSTONE,
+                count = invalidTombstones,
+            )
+        }
+    }
+
     internal fun processRecord(
         record: ConsumerRecord<String, String>,
-    ) {
+    ): SykmeldingsperiodeRecordOutcome {
         val recordValue = record.value()
         if (recordValue == null) {
-            processTombstone(record)
-            return
+            return processTombstone(record)
         }
 
         val kafkaMessage = configuredJacksonMapper.readValue<SendtSykmeldingKafkaMessage>(recordValue)
@@ -122,7 +143,7 @@ class SykmeldingsperiodeConsumer(
             log.warn(
                 "Skipping sykmelding Kafka message without arbeidsgiver for sykmeldingId=$sykmeldingId",
             )
-            return
+            return SykmeldingsperiodeRecordOutcome.PROCESSED
         }
 
         val cutoffDate = LocalDate.now(clock).minusYears(2)
@@ -140,29 +161,31 @@ class SykmeldingsperiodeConsumer(
 
         if (sykmeldingsperioderToStore.isEmpty()) {
             log.debug("Skipping historical sykmeldingId=$sykmeldingId because all periods are older than retention")
-            return
+            return SykmeldingsperiodeRecordOutcome.PROCESSED
         }
 
         val insertedRows = sykmeldingsperiodeRepository.storeSykmeldingsperioder(sykmeldingsperioderToStore)
         if (insertedRows > 0) {
             COUNT_SYKMELDING_CONSUMED.increment(insertedRows.toDouble())
         }
+        return SykmeldingsperiodeRecordOutcome.PROCESSED
     }
 
     internal fun processTombstone(
         record: ConsumerRecord<String, String>,
-    ) {
+    ): SykmeldingsperiodeRecordOutcome {
         val sykmeldingId = record.key()
         if (sykmeldingId.isNullOrBlank()) {
             COUNT_SYKMELDING_DESERIALIZATION_ERROR.increment()
             log.warn(
                 "Skipping sykmelding tombstone without key at topic=${record.topic()}, partition=${record.partition()}, offset=${record.offset()}",
             )
-            return
+            return SykmeldingsperiodeRecordOutcome.INVALID_TOMBSTONE
         }
 
         sykmeldingsperiodeRepository.invalidateSykmelding(sykmeldingId)
         COUNT_SYKMELDING_TOMBSTONE.increment()
+        return SykmeldingsperiodeRecordOutcome.PROCESSED
     }
 
     private companion object {
@@ -176,4 +199,9 @@ class SykmeldingsperiodeConsumer(
             return delaySeconds.seconds.coerceAtMost(MAX_RETRY_DELAY)
         }
     }
+}
+
+internal enum class SykmeldingsperiodeRecordOutcome {
+    PROCESSED,
+    INVALID_TOMBSTONE,
 }

--- a/src/main/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeMetrics.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeMetrics.kt
@@ -1,8 +1,50 @@
 package no.nav.syfo.sykmelding.kafka
 
 import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
 import no.nav.syfo.application.metric.METRICS_NS
 import no.nav.syfo.application.metric.METRICS_REGISTRY
+
+internal const val SYKMELDING_TERMINALLY_REJECTED_RECORDS_METRIC =
+    "${METRICS_NS}_sykmelding_terminally_rejected_records"
+internal const val SYKMELDING_DESERIALIZATION_RETRY_BATCH_ATTEMPTS_METRIC =
+    "${METRICS_NS}_sykmelding_deserialization_retry_batch_attempts"
+
+internal enum class SykmeldingsperiodeRejectionReason(
+    val labelValue: String,
+) {
+    DESERIALIZATION("deserialization"),
+    INVALID_TOMBSTONE("invalid_tombstone"),
+}
+
+class SykmeldingsperiodeRecordMetrics(
+    registry: MeterRegistry = METRICS_REGISTRY,
+) {
+    private val terminallyRejectedCounters =
+        SykmeldingsperiodeRejectionReason.entries.associateWith { reason ->
+            Counter.builder(SYKMELDING_TERMINALLY_REJECTED_RECORDS_METRIC)
+                .description("Counts sykmelding Kafka records permanently rejected after their offsets were committed")
+                .tag("reason", reason.labelValue)
+                .register(registry)
+        }
+    private val deserializationRetryBatchAttempts =
+        Counter.builder(SYKMELDING_DESERIALIZATION_RETRY_BATCH_ATTEMPTS_METRIC)
+            .description("Counts batch attempts where every record failed deserialization and offsets were not committed")
+            .register(registry)
+
+    internal fun recordTerminallyRejected(
+        reason: SykmeldingsperiodeRejectionReason,
+        count: Int,
+    ) {
+        if (count > 0) {
+            terminallyRejectedCounters.getValue(reason).increment(count.toDouble())
+        }
+    }
+
+    internal fun recordDeserializationRetryBatchAttempt() {
+        deserializationRetryBatchAttempts.increment()
+    }
+}
 
 val COUNT_SYKMELDING_CONSUMED: Counter = Counter.builder("${METRICS_NS}_sykmelding_consumed")
     .description("Counts the number of sykmeldingsperioder stored from Kafka")
@@ -11,7 +53,7 @@ val COUNT_SYKMELDING_TOMBSTONE: Counter = Counter.builder("${METRICS_NS}_sykmeld
     .description("Counts the number of sykmelding tombstones processed from Kafka")
     .register(METRICS_REGISTRY)
 val COUNT_SYKMELDING_DESERIALIZATION_ERROR: Counter = Counter.builder("${METRICS_NS}_sykmelding_deserialization_error")
-    .description("Counts the number of sykmelding Kafka messages that failed deserialization (poison pills)")
+    .description("Legacy attempt counter for sykmelding records that fail deserialization or have an invalid tombstone key")
     .register(METRICS_REGISTRY)
 val COUNT_SYKMELDING_RUNTIME_ERROR: Counter = Counter.builder("${METRICS_NS}_sykmelding_runtime_error")
     .description("Counts transient consumer runtime errors (connection, commit, etc.)")

--- a/src/test/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmelding/kafka/SykmeldingsperiodeConsumerTest.kt
@@ -5,6 +5,10 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -29,14 +33,192 @@ class SykmeldingsperiodeConsumerTest :
     DescribeSpec({
         val repository = mockk<SykmeldingsperiodeRepository>()
         val fixedClock = Clock.fixed(Instant.parse("2025-06-01T00:00:00Z"), ZoneId.of("Europe/Oslo"))
-        val consumer = SykmeldingsperiodeConsumer(
-            sykmeldingsperiodeRepository = repository,
-            kafkaEnv = KafkaEnv.createForLocal(),
-            clock = fixedClock,
-        )
+        lateinit var metricsRegistry: SimpleMeterRegistry
+        lateinit var consumer: SykmeldingsperiodeConsumer
 
         beforeTest {
             clearAllMocks(currentThreadOnly = true)
+            metricsRegistry = SimpleMeterRegistry()
+            consumer = SykmeldingsperiodeConsumer(
+                sykmeldingsperiodeRepository = repository,
+                kafkaEnv = KafkaEnv.createForLocal(),
+                clock = fixedClock,
+                recordMetrics = SykmeldingsperiodeRecordMetrics(metricsRegistry),
+            )
+        }
+
+        fun terminallyRejectedCount(reason: String): Double = metricsRegistry
+            .get(SYKMELDING_TERMINALLY_REJECTED_RECORDS_METRIC)
+            .tag("reason", reason)
+            .counter()
+            .count()
+
+        fun retryBatchAttemptCount(): Double = metricsRegistry
+            .get(SYKMELDING_DESERIALIZATION_RETRY_BATCH_ATTEMPTS_METRIC)
+            .counter()
+            .count()
+
+        describe("processBatch") {
+            it("records deserialization rejection only after a mixed batch is committed") {
+                every { repository.storeSykmeldingsperioder(any()) } returns 1
+                var commits = 0
+
+                consumer.processBatch(
+                    records = listOf(
+                        ConsumerRecord(
+                            SYKMELDINGSPERIODE_TOPIC,
+                            0,
+                            10L,
+                            "invalid",
+                            "{invalid-json}",
+                        ),
+                        ConsumerRecord(
+                            SYKMELDINGSPERIODE_TOPIC,
+                            0,
+                            11L,
+                            "valid",
+                            kafkaMessage(
+                                perioder = listOf(
+                                    SykmeldingsperiodeAGDTO(
+                                        fom = LocalDate.of(2025, 1, 1),
+                                        tom = LocalDate.of(2025, 1, 31),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                    commitOffsets = { commits++ },
+                )
+
+                commits shouldBe 1
+                terminallyRejectedCount("deserialization") shouldBe 1.0
+                terminallyRejectedCount("invalid_tombstone") shouldBe 0.0
+                retryBatchAttemptCount() shouldBe 0.0
+            }
+
+            it("records a retry attempt and does not commit when every record fails deserialization") {
+                var commits = 0
+
+                shouldThrow<IllegalStateException> {
+                    consumer.processBatch(
+                        records = listOf(
+                            ConsumerRecord(
+                                SYKMELDINGSPERIODE_TOPIC,
+                                0,
+                                20L,
+                                "invalid-1",
+                                "{invalid-json}",
+                            ),
+                            ConsumerRecord(
+                                SYKMELDINGSPERIODE_TOPIC,
+                                0,
+                                21L,
+                                "invalid-2",
+                                "{also-invalid-json}",
+                            ),
+                        ),
+                        commitOffsets = { commits++ },
+                    )
+                }
+
+                commits shouldBe 0
+                terminallyRejectedCount("deserialization") shouldBe 0.0
+                retryBatchAttemptCount() shouldBe 1.0
+            }
+
+            it("does not record a terminal rejection when offset commit fails") {
+                every { repository.storeSykmeldingsperioder(any()) } returns 1
+
+                shouldThrow<IllegalStateException> {
+                    consumer.processBatch(
+                        records = listOf(
+                            ConsumerRecord(
+                                SYKMELDINGSPERIODE_TOPIC,
+                                0,
+                                30L,
+                                "invalid",
+                                "{invalid-json}",
+                            ),
+                            ConsumerRecord(
+                                SYKMELDINGSPERIODE_TOPIC,
+                                0,
+                                31L,
+                                "valid",
+                                kafkaMessage(
+                                    perioder = listOf(
+                                        SykmeldingsperiodeAGDTO(
+                                            fom = LocalDate.of(2025, 2, 1),
+                                            tom = LocalDate.of(2025, 2, 28),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                        commitOffsets = { error("commit failed") },
+                    )
+                }
+
+                terminallyRejectedCount("deserialization") shouldBe 0.0
+                retryBatchAttemptCount() shouldBe 0.0
+            }
+
+            it("records an invalid tombstone only after its offset is committed") {
+                var commits = 0
+
+                consumer.processBatch(
+                    records = listOf(
+                        ConsumerRecord(
+                            SYKMELDINGSPERIODE_TOPIC,
+                            0,
+                            40L,
+                            null,
+                            null,
+                        ),
+                    ),
+                    commitOffsets = { commits++ },
+                )
+
+                commits shouldBe 1
+                terminallyRejectedCount("deserialization") shouldBe 0.0
+                terminallyRejectedCount("invalid_tombstone") shouldBe 1.0
+            }
+
+            it("exposes only bounded rejection reasons and no record-derived labels") {
+                metricsRegistry.find(SYKMELDING_TERMINALLY_REJECTED_RECORDS_METRIC)
+                    .counters()
+                    .map { counter -> counter.id.tags.associate { it.key to it.value } }
+                    .toSet() shouldBe setOf(
+                    mapOf("reason" to "deserialization"),
+                    mapOf("reason" to "invalid_tombstone"),
+                )
+                metricsRegistry.get(SYKMELDING_DESERIALIZATION_RETRY_BATCH_ATTEMPTS_METRIC)
+                    .counter()
+                    .id
+                    .tags
+                    .isEmpty() shouldBe true
+            }
+
+            it("exports stable Prometheus counter names and reason labels") {
+                val prometheusRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+                val recordMetrics = SykmeldingsperiodeRecordMetrics(prometheusRegistry)
+                recordMetrics.recordTerminallyRejected(
+                    SykmeldingsperiodeRejectionReason.DESERIALIZATION,
+                    1,
+                )
+                recordMetrics.recordTerminallyRejected(
+                    SykmeldingsperiodeRejectionReason.INVALID_TOMBSTONE,
+                    1,
+                )
+                recordMetrics.recordDeserializationRetryBatchAttempt()
+
+                val scrape = prometheusRegistry.scrape()
+                scrape shouldContain
+                    """syfo_oppfolgingsplan_backend_sykmelding_terminally_rejected_records_total{reason="deserialization"} 1.0"""
+                scrape shouldContain
+                    """syfo_oppfolgingsplan_backend_sykmelding_terminally_rejected_records_total{reason="invalid_tombstone"} 1.0"""
+                scrape shouldContain
+                    "syfo_oppfolgingsplan_backend_sykmelding_deserialization_retry_batch_attempts_total 1.0"
+            }
         }
 
         describe("processRecord") {


### PR DESCRIPTION
## Hva

- skiller terminalt avviste sykmeldingsrecords fra batcher som blir forsøkt på nytt
- teller deserialiseringsfeil og ugyldige tombstones som terminale først etter vellykket offset-commit
- teller batchforsøk der alle records feiler deserialisering, uten å endre dagens retry- og commit-oppførsel
- beholder det eksisterende legacy-signalet uendret for bakoverkompatibilitet
- tester blandede og helt ugyldige batcher, commit-feil, tombstones, bounded labels og faktisk Prometheus-eksport

## Avgrensning

Dette er en avgrenset del av #449. PR-en endrer ikke dashboard, alert, pager, deploy eller recovery/reconciliation. Etter deploy og verifisering av live-data kan Control Room flyttes fra legacy-telleren til de nye signalene.

## Verifisert

- `./gradlew check --rerun-tasks`
- `./gradlew shadowJar`

Bidrar til #449.