### PR TITLE
Gjør sykmelding-consumeralarmene backoff-tolerante

### DIFF
--- a/nais/alerts-dev.yaml
+++ b/nais/alerts-dev.yaml
@@ -10,22 +10,22 @@ spec:
     - name: syfo-oppfolgingsplan-backend
       rules:
         - alert: SykmeldingConsumerDeserializationErrors
-          expr: rate(syfo_oppfolgingsplan_backend_sykmelding_deserialization_error_total{namespace="team-esyfo"}[5m]) > 0.1
-          for: 5m
+          expr: sum by (app) (increase(syfo_oppfolgingsplan_backend_sykmelding_deserialization_error_total{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo"}[15m])) > 0
+          for: 1m
           annotations:
-            consequence: Kafka consumer for sykmeldingsperioder forkaster meldinger permanent. Mulig schema-endring fra teamsykmelding.
-            action: "Sjekk logger for deserialization errors. Verifiser at SendtSykmeldingKafkaMessage-modellen matcher topic-kontrakten."
-            summary: Sykmelding Kafka consumer forkaster meldinger (poison pills).
+            consequence: Kafka-consumeren har sett minst én malformed eller kontraktugyldig record. I en blandet poll kan recorden være permanent forkastet; en hel poison-batch blir lest på nytt.
+            action: "Sjekk logger for deserialization errors. Verifiser topic-kontrakten, SendtSykmeldingKafkaMessage-modellen og eventuelle tombstones uten key."
+            summary: Sykmelding Kafka-consumeren har en malformed eller kontraktugyldig record.
           labels:
             namespace: team-esyfo
             severity: warning
         - alert: SykmeldingConsumerRuntimeErrors
-          expr: rate(syfo_oppfolgingsplan_backend_sykmelding_runtime_error_total{namespace="team-esyfo"}[5m]) > 0.05
-          for: 10m
+          expr: sum by (app) (increase(syfo_oppfolgingsplan_backend_sykmelding_runtime_error_total{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo"}[7m])) > 0
+          for: 15m
           annotations:
-            consequence: Kafka consumer opplever gjentatte transiente feil (connection, commit, etc). Consumer kjører med backoff.
-            action: "Sjekk logger for exceptions. Verifiser Kafka-tilkobling, database-tilgang og nettverkspolicyer."
-            summary: Sykmelding Kafka consumer har transiente runtime-feil.
+            consequence: Consumerarbeidet har samlet ikke hatt en 7-minutters periode uten registrerte runtime-feil gjennom 15 minutter. Feilene kan komme fra én eller flere replikaer; dette beviser ikke at hele consumergruppen er nede nå.
+            action: "Sjekk først deserialization-alarmen og -telleren for en mulig poison-batch. Sjekk deretter exceptions, Kafka-tilkobling, database-tilgang og nettverkspolicyer."
+            summary: Sykmelding Kafka-consumeren har vedvarende runtime-feil.
           labels:
             namespace: team-esyfo
             severity: warning

--- a/nais/alerts-prod.yaml
+++ b/nais/alerts-prod.yaml
@@ -10,22 +10,22 @@ spec:
     - name: syfo-oppfolgingsplan-backend
       rules:
         - alert: SykmeldingConsumerDeserializationErrors
-          expr: rate(syfo_oppfolgingsplan_backend_sykmelding_deserialization_error_total{namespace="team-esyfo"}[5m]) > 0.1
-          for: 5m
+          expr: sum by (app) (increase(syfo_oppfolgingsplan_backend_sykmelding_deserialization_error_total{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo"}[15m])) > 0
+          for: 1m
           annotations:
-            consequence: Kafka consumer for sykmeldingsperioder forkaster meldinger permanent. Mulig schema-endring fra teamsykmelding.
-            action: "Sjekk logger for deserialization errors. Verifiser at SendtSykmeldingKafkaMessage-modellen matcher topic-kontrakten."
-            summary: Sykmelding Kafka consumer forkaster meldinger (poison pills).
+            consequence: Kafka-consumeren har sett minst én malformed eller kontraktugyldig record. I en blandet poll kan recorden være permanent forkastet; en hel poison-batch blir lest på nytt.
+            action: "Sjekk logger for deserialization errors. Verifiser topic-kontrakten, SendtSykmeldingKafkaMessage-modellen og eventuelle tombstones uten key."
+            summary: Sykmelding Kafka-consumeren har en malformed eller kontraktugyldig record.
           labels:
             namespace: team-esyfo
-            severity: critical
+            severity: warning
         - alert: SykmeldingConsumerRuntimeErrors
-          expr: rate(syfo_oppfolgingsplan_backend_sykmelding_runtime_error_total{namespace="team-esyfo"}[5m]) > 0.05
-          for: 10m
+          expr: sum by (app) (increase(syfo_oppfolgingsplan_backend_sykmelding_runtime_error_total{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo"}[7m])) > 0
+          for: 15m
           annotations:
-            consequence: Kafka consumer opplever gjentatte transiente feil (connection, commit, etc). Consumer kjører med backoff.
-            action: "Sjekk logger for exceptions. Verifiser Kafka-tilkobling, database-tilgang og nettverkspolicyer."
-            summary: Sykmelding Kafka consumer har transiente runtime-feil.
+            consequence: Consumerarbeidet har samlet ikke hatt en 7-minutters periode uten registrerte runtime-feil gjennom 15 minutter. Feilene kan komme fra én eller flere replikaer; dette beviser ikke at hele consumergruppen er nede nå.
+            action: "Sjekk først deserialization-alarmen og -telleren for en mulig poison-batch. Sjekk deretter exceptions, Kafka-tilkobling, database-tilgang og nettverkspolicyer."
+            summary: Sykmelding Kafka-consumeren har vedvarende runtime-feil.
           labels:
             namespace: team-esyfo
             severity: warning

--- a/src/test/kotlin/no/nav/syfo/application/metric/PrometheusAlertContractTest.kt
+++ b/src/test/kotlin/no/nav/syfo/application/metric/PrometheusAlertContractTest.kt
@@ -1,0 +1,65 @@
+package no.nav.syfo.application.metric
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
+import java.nio.file.Files
+import java.nio.file.Path
+
+class PrometheusAlertContractTest :
+    FunSpec({
+        val environments =
+            mapOf(
+                "dev" to mapOf(DESERIALIZATION_ALERT to "warning", RUNTIME_ALERT to "warning"),
+                "prod" to mapOf(DESERIALIZATION_ALERT to "warning", RUNTIME_ALERT to "warning"),
+            )
+
+        environments.forEach { (environment, severities) ->
+            val rules = Files.readString(Path.of("nais", "alerts-$environment.yaml"))
+
+            test("$environment sykmelding consumer alerts keep their event and recovery semantics") {
+                val deserialization = alertBlock(rules, DESERIALIZATION_ALERT)
+                expression(deserialization) shouldBe DESERIALIZATION_EXPRESSION
+                duration(deserialization) shouldBe "1m"
+                severity(deserialization) shouldBe severities.getValue(DESERIALIZATION_ALERT)
+
+                val runtime = alertBlock(rules, RUNTIME_ALERT)
+                expression(runtime) shouldBe RUNTIME_EXPRESSION
+                duration(runtime) shouldBe "15m"
+                severity(runtime) shouldBe severities.getValue(RUNTIME_ALERT)
+
+                deserialization shouldNotContain "rate("
+                runtime shouldNotContain "rate("
+            }
+        }
+    })
+
+private fun alertBlock(
+    rules: String,
+    alert: String,
+): String = Regex("""(?ms)^        - alert: ${Regex.escape(alert)}\n.*?(?=^        - alert:|\z)""")
+    .find(rules)
+    ?.value
+    ?: error("Alert $alert is missing")
+
+private fun expression(block: String): String = field(block, "expr")
+
+private fun duration(block: String): String = field(block, "for")
+
+private fun severity(block: String): String = field(block, "severity")
+
+private fun field(
+    block: String,
+    name: String,
+): String = Regex("""(?m)^\s+$name: (.+)$""")
+    .find(block)
+    ?.groupValues
+    ?.get(1)
+    ?: error("Field $name is missing")
+
+private const val DESERIALIZATION_ALERT = "SykmeldingConsumerDeserializationErrors"
+private const val RUNTIME_ALERT = "SykmeldingConsumerRuntimeErrors"
+private const val DESERIALIZATION_EXPRESSION =
+    """sum by (app) (increase(syfo_oppfolgingsplan_backend_sykmelding_deserialization_error_total{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo"}[15m])) > 0"""
+private const val RUNTIME_EXPRESSION =
+    """sum by (app) (increase(syfo_oppfolgingsplan_backend_sykmelding_runtime_error_total{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo"}[7m])) > 0"""


### PR DESCRIPTION
## Hva

Retter to consumer-alarmer som i praksis kan overse hendelsene de skal oppdage:

- deserialiseringsregelen krevde over 30 feil per fem minutter over tid og kunne derfor overse én malformed record som ble permanent forkastet i en blandet poll
- runtime-regelen krevde over 15 feil per fem minutter, mens consumerens backoff kan øke til fem minutter

Nye regler:

- malformed/kontraktugyldig record: minst én observert hendelse i 15 minutter, med ett minutts hold
- runtime: minst én feil i hvert rullerende sjuminuttersvindu gjennom 15 minutter; en enkel transient feil rekker dermed ikke å varsle
- begge aggregerer per `app` på tvers av replikaer og er `warning` i både dev og prod mens signalet evalueres

Runtime-regelen viser vedvarende registrerte exceptions, ikke at hele consumergruppen sikkert er nede. En hel poison-batch kan gi begge alarmene; action-teksten ber derfor om å sjekke deserialisering først.

## Verifisering

- kontrakttest låser uttrykk, vinduer, holdetid og severity i begge manifester
- begge manifester er parsede som gyldig YAML
- `./gradlew build --no-daemon`

Relatert til shadow- og pager-evalueringen i navikt/team-esyfo#217.
