### PR TITLE
Filtrer outbox-varsler på ferske køsnapshots

### DIFF
--- a/nais/alerts-dev.yaml
+++ b/nais/alerts-dev.yaml
@@ -30,7 +30,7 @@ spec:
             namespace: team-esyfo
             severity: warning
         - alert: OppfolgingsplanOutboxOldestDueTooOld
-          expr: syfo_oppfolgingsplan_backend_outbox_oldest_due_age_seconds{namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} > 900
+          expr: max by (app, message_type) (syfo_oppfolgingsplan_backend_outbox_oldest_due_age_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} and on (pod, message_type) (time() - syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} < 180)) > 900
           for: 10m
           annotations:
             consequence: Oppfølgingsplanvarsler til Budstikka har vært klare for levering i mer enn 15 minutter.
@@ -40,7 +40,7 @@ spec:
             namespace: team-esyfo
             severity: warning
         - alert: OppfolgingsplanOutboxExpiredClaims
-          expr: syfo_oppfolgingsplan_backend_outbox_expired_claims{namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} > 0
+          expr: max by (app, message_type) (syfo_oppfolgingsplan_backend_outbox_expired_claims{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} and on (pod, message_type) (time() - syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} < 180)) > 0
           for: 10m
           annotations:
             consequence: Outbox-claims har forblitt utløpt og kan gi forsinkelse eller duplikate leveringsforsøk.
@@ -50,7 +50,7 @@ spec:
             namespace: team-esyfo
             severity: warning
         - alert: OppfolgingsplanOutboxPersistentFailures
-          expr: syfo_oppfolgingsplan_backend_outbox_retrying{namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} > 0
+          expr: max by (app, message_type) (syfo_oppfolgingsplan_backend_outbox_retrying{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} and on (pod, message_type) (time() - syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} < 180)) > 0
           for: 15m
           annotations:
             consequence: Minst ett oppfølgingsplanvarsel har hatt en uløst teknisk feil i minst 15 minutter, også om meldingen for øyeblikket venter i backoff.

--- a/nais/alerts-dev.yaml
+++ b/nais/alerts-dev.yaml
@@ -29,7 +29,7 @@ spec:
           labels:
             namespace: team-esyfo
             severity: warning
-        - alert: OutboxQueueSnapshotStale
+        - alert: OppfolgingsplanOutboxQueueSnapshotStale
           expr: >-
             (time() - max by (app, message_type) (syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"}) > 300)
             or absent(syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_CREATED"})

--- a/nais/alerts-dev.yaml
+++ b/nais/alerts-dev.yaml
@@ -29,6 +29,20 @@ spec:
           labels:
             namespace: team-esyfo
             severity: warning
+        - alert: OutboxQueueSnapshotStale
+          expr: >-
+            (time() - max by (app, message_type) (syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"}) > 300)
+            or absent(syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_CREATED"})
+            or absent(syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_EVALUERING_PAAMINNELSE_MIN_SIDE_ARBEIDSGIVER"})
+            or absent(syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_EVALUERING_PAAMINNELSE_DINE_SYKMELDTE"})
+          for: 10m
+          annotations:
+            consequence: Køtilstanden for minst én outbox-meldingstype er UKJENT fordi ingen pod har publisert et vellykket snapshot de siste fem minuttene, eller serien mangler.
+            action: "Sjekk outbox-task, databaseforbindelse, podlogger og metrics-target. Ikke tolk fravær av de andre outbox-alertene som frisk kø før snapshotet er tilbake."
+            summary: Oppfølgingsplan-outboxens køsnapshot er utdatert eller mangler.
+          labels:
+            namespace: team-esyfo
+            severity: warning
         - alert: OppfolgingsplanOutboxOldestDueTooOld
           expr: max by (app, message_type) (syfo_oppfolgingsplan_backend_outbox_oldest_due_age_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} and on (pod, message_type) (time() - syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} < 180)) > 900
           for: 10m

--- a/nais/alerts-prod.yaml
+++ b/nais/alerts-prod.yaml
@@ -29,7 +29,7 @@ spec:
           labels:
             namespace: team-esyfo
             severity: warning
-        - alert: OutboxQueueSnapshotStale
+        - alert: OppfolgingsplanOutboxQueueSnapshotStale
           expr: >-
             (time() - max by (app, message_type) (syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"}) > 300)
             or absent(syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_CREATED"})

--- a/nais/alerts-prod.yaml
+++ b/nais/alerts-prod.yaml
@@ -30,7 +30,7 @@ spec:
             namespace: team-esyfo
             severity: warning
         - alert: OppfolgingsplanOutboxOldestDueTooOld
-          expr: syfo_oppfolgingsplan_backend_outbox_oldest_due_age_seconds{namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} > 900
+          expr: max by (app, message_type) (syfo_oppfolgingsplan_backend_outbox_oldest_due_age_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} and on (pod, message_type) (time() - syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} < 180)) > 900
           for: 10m
           annotations:
             consequence: Oppfølgingsplanvarsler til Budstikka har vært klare for levering i mer enn 15 minutter.
@@ -40,7 +40,7 @@ spec:
             namespace: team-esyfo
             severity: critical
         - alert: OppfolgingsplanOutboxExpiredClaims
-          expr: syfo_oppfolgingsplan_backend_outbox_expired_claims{namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} > 0
+          expr: max by (app, message_type) (syfo_oppfolgingsplan_backend_outbox_expired_claims{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} and on (pod, message_type) (time() - syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} < 180)) > 0
           for: 10m
           annotations:
             consequence: Outbox-claims har forblitt utløpt og kan gi forsinkelse eller duplikate leveringsforsøk.
@@ -50,7 +50,7 @@ spec:
             namespace: team-esyfo
             severity: warning
         - alert: OppfolgingsplanOutboxPersistentFailures
-          expr: syfo_oppfolgingsplan_backend_outbox_retrying{namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} > 0
+          expr: max by (app, message_type) (syfo_oppfolgingsplan_backend_outbox_retrying{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} and on (pod, message_type) (time() - syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} < 180)) > 0
           for: 15m
           annotations:
             consequence: Minst ett oppfølgingsplanvarsel har hatt en uløst teknisk feil i minst 15 minutter, også om meldingen for øyeblikket venter i backoff.

--- a/nais/alerts-prod.yaml
+++ b/nais/alerts-prod.yaml
@@ -29,6 +29,20 @@ spec:
           labels:
             namespace: team-esyfo
             severity: warning
+        - alert: OutboxQueueSnapshotStale
+          expr: >-
+            (time() - max by (app, message_type) (syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"}) > 300)
+            or absent(syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_CREATED"})
+            or absent(syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_EVALUERING_PAAMINNELSE_MIN_SIDE_ARBEIDSGIVER"})
+            or absent(syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_EVALUERING_PAAMINNELSE_DINE_SYKMELDTE"})
+          for: 10m
+          annotations:
+            consequence: Køtilstanden for minst én outbox-meldingstype er UKJENT fordi ingen pod har publisert et vellykket snapshot de siste fem minuttene, eller serien mangler.
+            action: "Sjekk outbox-task, databaseforbindelse, podlogger og metrics-target. Ikke tolk fravær av de andre outbox-alertene som frisk kø før snapshotet er tilbake."
+            summary: Oppfølgingsplan-outboxens køsnapshot er utdatert eller mangler.
+          labels:
+            namespace: team-esyfo
+            severity: warning
         - alert: OppfolgingsplanOutboxOldestDueTooOld
           expr: max by (app, message_type) (syfo_oppfolgingsplan_backend_outbox_oldest_due_age_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} and on (pod, message_type) (time() - syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"} < 180)) > 900
           for: 10m

--- a/src/test/kotlin/no/nav/syfo/application/metric/PrometheusAlertContractTest.kt
+++ b/src/test/kotlin/no/nav/syfo/application/metric/PrometheusAlertContractTest.kt
@@ -110,7 +110,7 @@ private fun field(
 
 private const val DESERIALIZATION_ALERT = "SykmeldingConsumerDeserializationErrors"
 private const val RUNTIME_ALERT = "SykmeldingConsumerRuntimeErrors"
-private const val OUTBOX_SNAPSHOT_STALE_ALERT = "OutboxQueueSnapshotStale"
+private const val OUTBOX_SNAPSHOT_STALE_ALERT = "OppfolgingsplanOutboxQueueSnapshotStale"
 private const val OUTBOX_OLDEST_DUE_ALERT = "OppfolgingsplanOutboxOldestDueTooOld"
 private const val OUTBOX_EXPIRED_CLAIMS_ALERT = "OppfolgingsplanOutboxExpiredClaims"
 private const val OUTBOX_PERSISTENT_FAILURES_ALERT = "OppfolgingsplanOutboxPersistentFailures"

--- a/src/test/kotlin/no/nav/syfo/application/metric/PrometheusAlertContractTest.kt
+++ b/src/test/kotlin/no/nav/syfo/application/metric/PrometheusAlertContractTest.kt
@@ -43,6 +43,17 @@ class PrometheusAlertContractTest :
                     expression(alertBlock(rules, alert)) shouldBe expectedExpression
                 }
             }
+
+            test("$environment alerts when every pod snapshot is stale or a closed message type is absent") {
+                val staleSnapshot = alertBlock(rules, OUTBOX_SNAPSHOT_STALE_ALERT)
+
+                expression(staleSnapshot) shouldBe OUTBOX_SNAPSHOT_STALE_EXPRESSION
+                duration(staleSnapshot) shouldBe "10m"
+                alertLabels(staleSnapshot) shouldBe mapOf(
+                    "namespace" to "team-esyfo",
+                    "severity" to "warning",
+                )
+            }
         }
     })
 
@@ -54,11 +65,39 @@ private fun alertBlock(
     ?.value
     ?: error("Alert $alert is missing")
 
-private fun expression(block: String): String = field(block, "expr")
+private fun expression(block: String): String {
+    val lines = block.lines()
+    val expressionIndex = lines.indexOfFirst { it.trimStart().startsWith("expr: ") }
+    require(expressionIndex >= 0) { "Field expr is missing" }
+    val expressionLine = lines[expressionIndex]
+    val expressionValue = expressionLine.substringAfter("expr: ")
+    if (expressionValue != ">-") {
+        return expressionValue
+    }
+    val expressionIndent = expressionLine.indexOfFirst { !it.isWhitespace() }
+    return lines
+        .drop(expressionIndex + 1)
+        .takeWhile { line -> line.indexOfFirst { !it.isWhitespace() } > expressionIndent }
+        .joinToString(" ") { it.trim() }
+}
 
 private fun duration(block: String): String = field(block, "for")
 
 private fun severity(block: String): String = field(block, "severity")
+
+private fun alertLabels(block: String): Map<String, String> {
+    val lines = block.lines()
+    val labelsIndex = lines.indexOfFirst { it.trim() == "labels:" }
+    require(labelsIndex >= 0) { "Alert labels are missing" }
+    val labelsIndent = lines[labelsIndex].indexOfFirst { !it.isWhitespace() }
+    return lines
+        .drop(labelsIndex + 1)
+        .takeWhile { line -> line.indexOfFirst { !it.isWhitespace() } > labelsIndent }
+        .associate { line ->
+            val (name, value) = line.trim().split(": ", limit = 2)
+            name to value
+        }
+}
 
 private fun field(
     block: String,
@@ -71,6 +110,7 @@ private fun field(
 
 private const val DESERIALIZATION_ALERT = "SykmeldingConsumerDeserializationErrors"
 private const val RUNTIME_ALERT = "SykmeldingConsumerRuntimeErrors"
+private const val OUTBOX_SNAPSHOT_STALE_ALERT = "OutboxQueueSnapshotStale"
 private const val OUTBOX_OLDEST_DUE_ALERT = "OppfolgingsplanOutboxOldestDueTooOld"
 private const val OUTBOX_EXPIRED_CLAIMS_ALERT = "OppfolgingsplanOutboxExpiredClaims"
 private const val OUTBOX_PERSISTENT_FAILURES_ALERT = "OppfolgingsplanOutboxPersistentFailures"
@@ -91,3 +131,14 @@ private const val OUTBOX_SELECTOR =
     """{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"}"""
 private const val OUTBOX_FRESHNESS_METRIC =
     "syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds"
+private val OUTBOX_SNAPSHOT_STALE_EXPRESSION =
+    "(time() - max by (app, message_type) ($OUTBOX_FRESHNESS_METRIC$OUTBOX_SELECTOR) > 300)" +
+        " or absent($OUTBOX_FRESHNESS_METRIC$OUTBOX_CREATED_SELECTOR)" +
+        " or absent($OUTBOX_FRESHNESS_METRIC$OUTBOX_MIN_SIDE_ARBEIDSGIVER_SELECTOR)" +
+        " or absent($OUTBOX_FRESHNESS_METRIC$OUTBOX_DINE_SYKMELDTE_SELECTOR)"
+private const val OUTBOX_CREATED_SELECTOR =
+    """{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_CREATED"}"""
+private const val OUTBOX_MIN_SIDE_ARBEIDSGIVER_SELECTOR =
+    """{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_EVALUERING_PAAMINNELSE_MIN_SIDE_ARBEIDSGIVER"}"""
+private const val OUTBOX_DINE_SYKMELDTE_SELECTOR =
+    """{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type="OPPFOLGINGSPLAN_EVALUERING_PAAMINNELSE_DINE_SYKMELDTE"}"""

--- a/src/test/kotlin/no/nav/syfo/application/metric/PrometheusAlertContractTest.kt
+++ b/src/test/kotlin/no/nav/syfo/application/metric/PrometheusAlertContractTest.kt
@@ -13,6 +13,12 @@ class PrometheusAlertContractTest :
                 "dev" to mapOf(DESERIALIZATION_ALERT to "warning", RUNTIME_ALERT to "warning"),
                 "prod" to mapOf(DESERIALIZATION_ALERT to "warning", RUNTIME_ALERT to "warning"),
             )
+        val outboxExpressions =
+            mapOf(
+                OUTBOX_OLDEST_DUE_ALERT to outboxExpression("outbox_oldest_due_age_seconds", "900"),
+                OUTBOX_EXPIRED_CLAIMS_ALERT to outboxExpression("outbox_expired_claims", "0"),
+                OUTBOX_PERSISTENT_FAILURES_ALERT to outboxExpression("outbox_retrying", "0"),
+            )
 
         environments.forEach { (environment, severities) ->
             val rules = Files.readString(Path.of("nais", "alerts-$environment.yaml"))
@@ -30,6 +36,12 @@ class PrometheusAlertContractTest :
 
                 deserialization shouldNotContain "rate("
                 runtime shouldNotContain "rate("
+            }
+
+            test("$environment outbox alerts filter each pod snapshot for freshness before max aggregation") {
+                outboxExpressions.forEach { (alert, expectedExpression) ->
+                    expression(alertBlock(rules, alert)) shouldBe expectedExpression
+                }
             }
         }
     })
@@ -59,7 +71,23 @@ private fun field(
 
 private const val DESERIALIZATION_ALERT = "SykmeldingConsumerDeserializationErrors"
 private const val RUNTIME_ALERT = "SykmeldingConsumerRuntimeErrors"
+private const val OUTBOX_OLDEST_DUE_ALERT = "OppfolgingsplanOutboxOldestDueTooOld"
+private const val OUTBOX_EXPIRED_CLAIMS_ALERT = "OppfolgingsplanOutboxExpiredClaims"
+private const val OUTBOX_PERSISTENT_FAILURES_ALERT = "OppfolgingsplanOutboxPersistentFailures"
 private const val DESERIALIZATION_EXPRESSION =
     """sum by (app) (increase(syfo_oppfolgingsplan_backend_sykmelding_deserialization_error_total{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo"}[15m])) > 0"""
 private const val RUNTIME_EXPRESSION =
     """sum by (app) (increase(syfo_oppfolgingsplan_backend_sykmelding_runtime_error_total{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo"}[7m])) > 0"""
+
+private fun outboxExpression(
+    metricSuffix: String,
+    threshold: String,
+): String = "max by (app, message_type) (" +
+    "syfo_oppfolgingsplan_backend_$metricSuffix$OUTBOX_SELECTOR " +
+    "and on (pod, message_type) " +
+    "(time() - $OUTBOX_FRESHNESS_METRIC$OUTBOX_SELECTOR < 180)) > $threshold"
+
+private const val OUTBOX_SELECTOR =
+    """{app="syfo-oppfolgingsplan-backend",namespace="team-esyfo",message_type=~"OPPFOLGINGSPLAN_.*"}"""
+private const val OUTBOX_FRESHNESS_METRIC =
+    "syfo_oppfolgingsplan_backend_outbox_queue_snapshot_last_success_timestamp_seconds"


### PR DESCRIPTION
## Hvorfor

Outbox-køgaugene er pod-lokale snapshots av samme globale databasekø. Hvis en worker slutter å oppdatere snapshotet, kan en gammel positiv verdi ellers fortsette å evaluere som om den var aktuell. #451 eksponerte et siste-vellykket-tidsstempel per pod og `message_type`; alertene må bruke det før de aggregerer replikaene.

## Hva

- bruker `outbox_queue_snapshot_last_success_timestamp_seconds` i alle tre outbox-alertene i både dev og prod
- beholder bare køserier med snapshot yngre enn 180 sekunder
- matcher kø og freshness på samme `pod` og `message_type`
- tar deretter `max by (app, message_type)`, siden poddene observerer samme globale kø og aldri skal summeres
- avgrenser begge selectors eksplisitt til app, namespace og `OPPFOLGINGSPLAN_.*`
- legger til `OppfolgingsplanOutboxQueueSnapshotStale`: ferskeste pod per `app/message_type` må være eldre enn 300 sekunder i 10 minutter før warning
- oppdager også helt manglende serie eksplisitt for alle tre lukkede `message_type`-verdiene
- låser hele PromQL-uttrykket for alle eksisterende alertforekomster, samt stale-regelens PromQL, labels, severity og varighet, med eksakte kontrakttester

`OppfolgingsplanOutboxQueueSnapshotStale` er et datakvalitetssignal: tilstanden er **UKJENT**, ikke en bevist leveringsstans eller en tom kø. `max` over timestamps gjør at én gammel pod ikke gir alarm når en annen pod fortsatt observerer køen. Warning brukes innledningsvis i både dev og prod. PR-en endrer ikke terskler, `for`-perioder eller severity for de tre eksisterende køalertene, og endrer ikke worker-adferd.

## Verifisering

- `./gradlew test --tests no.nav.syfo.application.metric.PrometheusAlertContractTest --no-daemon`
- `./gradlew check --no-daemon`
- `git diff --check`

Alt er grønt lokalt.

## Gjenstående merge-gate

- menneskelig review
- etter dev-deploy: bekreft at de tre `message_type`-seriene evalueres per fersk pod, at stale-regelen normalt er inaktiv, og at en kunstig/utdatert podserie blir filtrert bort før `max`
