### PR TITLE
Stans oppfølgingsplanpåminnelse ved unntaksvurdering

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/UnntaksvurderingDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/UnntaksvurderingDAO.kt
@@ -15,6 +15,8 @@ import org.jetbrains.exposed.v1.jdbc.insertReturning
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.update
 import java.sql.Connection
+import java.sql.Timestamp
+import java.time.Instant
 import java.util.UUID
 
 suspend fun DatabaseInterface.persistUnntaksvurdering(
@@ -58,6 +60,35 @@ suspend fun DatabaseInterface.findAllUnntaksvurderingerBySykmeldtFnr(
             UnntaksvurderingTable.uuid to SortOrder.DESC,
         )
         .map { it.toPersistedUnntaksvurdering() }
+}
+
+fun DatabaseInterface.existsUnntaksvurderingCreatedAfter(
+    sykmeldtFnr: String,
+    organisasjonsnummer: String,
+    createdAfter: Instant,
+): Boolean {
+    val statement = """
+        SELECT EXISTS (
+            SELECT 1
+            FROM unntaksvurdering
+            WHERE sykmeldt_fnr = ?
+              AND organisasjonsnummer = ?
+              AND created_at >= ?
+              AND skjult_fra IS NULL
+        )
+    """.trimIndent()
+
+    return connection.use { connection ->
+        connection.prepareStatement(statement).use { preparedStatement ->
+            preparedStatement.setString(1, sykmeldtFnr)
+            preparedStatement.setString(2, organisasjonsnummer)
+            preparedStatement.setTimestamp(3, Timestamp.from(createdAfter))
+            preparedStatement.executeQuery().use { resultSet ->
+                resultSet.next()
+                resultSet.getBoolean(1)
+            }
+        }
+    }
 }
 
 suspend fun DatabaseInterface.softDeleteExpiredUnntaksvurderinger(

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OpprettOppfolgingsplanPaaminnelseService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OpprettOppfolgingsplanPaaminnelseService.kt
@@ -11,6 +11,7 @@ import no.nav.syfo.oppfolgingsplan.db.deactivateOpprettOppfolgingsplanPaaminnels
 import no.nav.syfo.oppfolgingsplan.db.domain.PersistedOpprettOppfolgingsplanPaaminnelse
 import no.nav.syfo.oppfolgingsplan.db.domain.isOpprettOppfolgingsplanPaaminnelseBestiltInCurrentSykemeldingsperiode
 import no.nav.syfo.oppfolgingsplan.db.existsOppfolgingsplanCreatedAfter
+import no.nav.syfo.oppfolgingsplan.db.existsUnntaksvurderingCreatedAfter
 import no.nav.syfo.oppfolgingsplan.db.findOpprettOppfolgingsplanPaaminnelseBy
 import no.nav.syfo.oppfolgingsplan.db.upsertOpprettOppfolgingsplanPaaminnelseAndEnqueue
 import no.nav.syfo.oppfolgingsplan.dto.OpprettOppfolgingsplanPaaminnelseStatus
@@ -128,6 +129,17 @@ class OpprettOppfolgingsplanPaaminnelseService(
             createdAfter = sykmeldingsperiodeFom.atStartOfDay(clock.zone).toInstant(),
         )
         if (harAktivOppfolgingsplan) return OpprettOppfolgingsplanPaaminnelseStatusInternal.Utilgjengelig(OutboxCancellationReason.SOURCE_NO_LONGER_ELIGIBLE)
+
+        val harRelevantUnntaksvurdering = database.existsUnntaksvurderingCreatedAfter(
+            sykmeldtFnr = sykmeldtFnr,
+            organisasjonsnummer = organisasjonsnummer,
+            createdAfter = sykmeldingsperiodeFom.atStartOfDay(clock.zone).toInstant(),
+        )
+        if (harRelevantUnntaksvurdering) {
+            return OpprettOppfolgingsplanPaaminnelseStatusInternal.Utilgjengelig(
+                OutboxCancellationReason.SOURCE_NO_LONGER_ELIGIBLE,
+            )
+        }
 
         return OpprettOppfolgingsplanPaaminnelseStatusInternal.Tilgjengelig(
             sykmeldingsperiodeId = earliestSykmeldingsperiode.id,

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/OpprettOppfolgingsplanPaaminnelseApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/narmesteleder/OpprettOppfolgingsplanPaaminnelseApiTest.kt
@@ -34,6 +34,7 @@ import no.nav.syfo.defaultSykmeldt
 import no.nav.syfo.dinesykmeldte.DineSykmeldteService
 import no.nav.syfo.dinesykmeldte.client.DineSykmeldteHttpClient
 import no.nav.syfo.oppfolgingsplan.db.findOpprettOppfolgingsplanPaaminnelseBy
+import no.nav.syfo.oppfolgingsplan.db.persistUnntaksvurdering
 import no.nav.syfo.oppfolgingsplan.db.upsertOpprettOppfolgingsplanPaaminnelse
 import no.nav.syfo.oppfolgingsplan.dto.OpprettOppfolgingsplanPaaminnelseStatus
 import no.nav.syfo.oppfolgingsplan.dto.OpprettOppfolgingsplanPaaminnelseStatusDto
@@ -182,6 +183,31 @@ class OpprettOppfolgingsplanPaaminnelseApiTest :
                 }
             }
 
+            it("GET should return SKJULT when an unntaksvurdering exists in the current syketilfelle") {
+                withTestApplication {
+                    seedAktivtSyketilfelle()
+                    testDb.persistUnntaksvurdering(
+                        narmesteLederFnr = pidInnloggetBruker,
+                        sykmeldt = defaultSykmeldt(),
+                        narmesteLederFullName = "Maren Hegna",
+                    )
+                    texasClientMock.defaultMocks(
+                        pid = pidInnloggetBruker,
+                        clientId = environment.dinesykmeldteClientId,
+                    )
+                    dineSykmeldteHttpClientMock.defaultMocks(narmestelederId = narmestelederId)
+
+                    val response = client.get {
+                        url("/api/v1/narmesteleder/$narmestelederId/oppfolgingsplaner/paaminnelse")
+                        bearerAuth("******")
+                    }
+
+                    response.status shouldBe HttpStatusCode.OK
+                    response.body<OpprettOppfolgingsplanPaaminnelseStatusDto>().status shouldBe
+                        OpprettOppfolgingsplanPaaminnelseStatus.SKJULT
+                }
+            }
+
             it("GET should return SKJULT when an oppfolgingsplan already exists in the current syketilfelle") {
                 withTestApplication {
                     val startDato = LocalDate.now().minusDays(7)
@@ -234,6 +260,32 @@ class OpprettOppfolgingsplanPaaminnelseApiTest :
                     persisted?.sykmeldtFnr shouldBe "12345678901"
                     persisted?.organisasjonsnummer shouldBe "orgnummer"
                     persisted?.sykmeldingsperiodeId shouldBe repository.findBySykmeldingId("sykmelding-1").single().id
+                }
+            }
+
+            it("POST should respond with BadRequest when an unntaksvurdering exists in the current syketilfelle") {
+                withTestApplication {
+                    seedAktivtSyketilfelle()
+                    testDb.persistUnntaksvurdering(
+                        narmesteLederFnr = pidInnloggetBruker,
+                        sykmeldt = defaultSykmeldt(),
+                        narmesteLederFullName = "Maren Hegna",
+                    )
+                    texasClientMock.defaultMocks(
+                        pid = pidInnloggetBruker,
+                        clientId = environment.dinesykmeldteClientId,
+                    )
+                    dineSykmeldteHttpClientMock.defaultMocks(narmestelederId = narmestelederId)
+
+                    val response = client.post {
+                        url("/api/v1/narmesteleder/$narmestelederId/oppfolgingsplaner/paaminnelse")
+                        bearerAuth("******")
+                    }
+
+                    response.status shouldBe HttpStatusCode.BadRequest
+                    response.body<ApiError>().type shouldBe ErrorType.BAD_REQUEST
+                    countPaaminnelseRows() shouldBe 0
+                    countOutboxRows() shouldBe 0
                 }
             }
 

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/outbox/OpprettOppfolgingsplanPaaminnelseOutboxIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/outbox/OpprettOppfolgingsplanPaaminnelseOutboxIntegrationTest.kt
@@ -18,6 +18,7 @@ import no.nav.syfo.defaultSykmeldt
 import no.nav.syfo.narmesteleder.client.INarmestelederClient
 import no.nav.syfo.narmesteleder.client.Narmesteleder
 import no.nav.syfo.oppfolgingsplan.db.findOpprettOppfolgingsplanPaaminnelseBy
+import no.nav.syfo.oppfolgingsplan.db.persistUnntaksvurdering
 import no.nav.syfo.oppfolgingsplan.service.OPPRETT_OPPFOLGINGSPLAN_PAAMINNELSE_ETTER_DAGER
 import no.nav.syfo.oppfolgingsplan.service.OpprettOppfolgingsplanPaaminnelseService
 import no.nav.syfo.persistOppfolgingsplan
@@ -480,6 +481,54 @@ class OpprettOppfolgingsplanPaaminnelseOutboxIntegrationTest :
             }
         }
 
+        it("cancels both reminders when an unntaksvurdering is created before delivery") {
+            service.activateOpprettOppfolgingsplanPaaminnelse(defaultSykmeldt())
+            val opprettOppfolgingsplanPaaminnelse =
+                TestDB.database.findOpprettOppfolgingsplanPaaminnelseBy(
+                    defaultSykmeldt().fnr,
+                    defaultSykmeldt().orgnummer,
+                ).shouldNotBeNull()
+            val unntaksvurderingUuid = TestDB.database.persistUnntaksvurdering(
+                narmesteLederFnr = "10987654321",
+                sykmeldt = defaultSykmeldt(),
+                narmesteLederFullName = "Maren Hegna",
+            )
+            TestDB.database.setUnntaksvurderingCreatedAt(
+                uuid = unntaksvurderingUuid,
+                createdAt = availableAt.minusSeconds(1),
+            )
+            val publisher = mockk<BudstikkaPublisher>(relaxed = true)
+            val worker = OutboxWorker(
+                database = TestDB.database,
+                handlers = listOf(
+                    arbeidsgiverHandler(publisher),
+                    OpprettOppfolgingsplanPaaminnelseDineSykmeldteOutboxHandler(
+                        TestDB.database,
+                        service,
+                        publisher,
+                    ),
+                ),
+                clock = Clock.fixed(availableAt, zone),
+            )
+
+            val result = worker.runOnce()
+
+            result.cancelled shouldBe 2
+            result.sent shouldBe 0
+            TestDB.database.findOpprettOppfolgingsplanPaaminnelseOutboxStates(
+                opprettOppfolgingsplanPaaminnelse.uuid,
+            ).count {
+                it.first == OutboxStatus.CANCELLED &&
+                    it.second == OutboxCancellationReason.SOURCE_NO_LONGER_ELIGIBLE
+            } shouldBe 2
+            coVerify(exactly = 0) {
+                publisher.publishOpprettOppfolgingsplanPaaminnelse(any(), any(), any(), any(), any())
+            }
+            coVerify(exactly = 0) {
+                publisher.publishOpprettOppfolgingsplanPaaminnelseToDineSykmeldte(any(), any(), any(), any())
+            }
+        }
+
         it("cancels a reminder when its sykmeldingsperiode is no longer active") {
             service.activateOpprettOppfolgingsplanPaaminnelse(defaultSykmeldt())
             val opprettOppfolgingsplanPaaminnelse =
@@ -591,6 +640,20 @@ private fun DatabaseInterface.deleteOpprettOppfolgingsplanPaaminnelse(
         statement.setObject(1, opprettOppfolgingsplanPaaminnelseUuid)
         statement.executeUpdate()
     }.also {
+        connection.commit()
+    }
+}
+
+private fun DatabaseInterface.setUnntaksvurderingCreatedAt(
+    uuid: UUID,
+    createdAt: Instant,
+) {
+    connection.use { connection ->
+        connection.prepareStatement("UPDATE unntaksvurdering SET created_at = ? WHERE uuid = ?").use { statement ->
+            statement.setTimestamp(1, Timestamp.from(createdAt))
+            statement.setObject(2, uuid)
+            statement.executeUpdate()
+        }
         connection.commit()
     }
 }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OpprettOppfolgingsplanPaaminnelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OpprettOppfolgingsplanPaaminnelseServiceTest.kt
@@ -7,12 +7,15 @@ import io.ktor.server.plugins.BadRequestException
 import no.nav.syfo.TestDB
 import no.nav.syfo.defaultPersistedOppfolgingsplan
 import no.nav.syfo.defaultSykmeldt
+import no.nav.syfo.dinesykmeldte.client.Sykmeldt
 import no.nav.syfo.oppfolgingsplan.db.findOpprettOppfolgingsplanPaaminnelseBy
+import no.nav.syfo.oppfolgingsplan.db.persistUnntaksvurdering
 import no.nav.syfo.oppfolgingsplan.db.upsertOpprettOppfolgingsplanPaaminnelse
 import no.nav.syfo.oppfolgingsplan.dto.OpprettOppfolgingsplanPaaminnelseStatus
 import no.nav.syfo.persistOppfolgingsplan
 import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
 import no.nav.syfo.sykmelding.db.domain.SykmeldingsperiodeToStore
+import java.sql.Timestamp
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
@@ -47,6 +50,27 @@ class OpprettOppfolgingsplanPaaminnelseServiceTest :
                     ),
                 ),
             )
+        }
+
+        suspend fun persistUnntaksvurdering(
+            createdAt: Instant,
+            sykmeldt: Sykmeldt = defaultSykmeldt(),
+        ) {
+            val uuid = TestDB.database.persistUnntaksvurdering(
+                narmesteLederFnr = "10987654321",
+                sykmeldt = sykmeldt,
+                narmesteLederFullName = "Maren Hegna",
+            )
+            TestDB.database.connection.use { connection ->
+                connection.prepareStatement(
+                    "UPDATE unntaksvurdering SET created_at = ? WHERE uuid = ?",
+                ).use { statement ->
+                    statement.setTimestamp(1, Timestamp.from(createdAt))
+                    statement.setObject(2, uuid)
+                    statement.executeUpdate()
+                }
+                connection.commit()
+            }
         }
 
         describe("getOpprettOppfolgingsplanPaaminnelseStatus") {
@@ -84,6 +108,55 @@ class OpprettOppfolgingsplanPaaminnelseServiceTest :
                 seedSyketilfelle(
                     startDato = LocalDate.of(2025, 6, 1),
                     tom = LocalDate.of(2025, 6, 30),
+                )
+
+                val status = service.getOpprettOppfolgingsplanPaaminnelseStatus(defaultSykmeldt())
+
+                status.status shouldBe OpprettOppfolgingsplanPaaminnelseStatus.TILGJENGELIG
+            }
+
+            it("returns SKJULT when an unntaksvurdering exists in the current syketilfelle") {
+                val syketilfelleStart = LocalDate.of(2025, 6, 1)
+                seedSyketilfelle(
+                    startDato = syketilfelleStart,
+                    tom = LocalDate.of(2025, 6, 30),
+                )
+                persistUnntaksvurdering(
+                    createdAt = syketilfelleStart.atStartOfDay(fixedClock.zone).toInstant(),
+                )
+
+                val status = service.getOpprettOppfolgingsplanPaaminnelseStatus(defaultSykmeldt())
+
+                status.status shouldBe OpprettOppfolgingsplanPaaminnelseStatus.SKJULT
+            }
+
+            it("ignores an unntaksvurdering from a previous syketilfelle") {
+                val syketilfelleStart = LocalDate.of(2025, 6, 1)
+                seedSyketilfelle(
+                    startDato = syketilfelleStart,
+                    tom = LocalDate.of(2025, 6, 30),
+                )
+                persistUnntaksvurdering(
+                    createdAt = syketilfelleStart
+                        .atStartOfDay(fixedClock.zone)
+                        .toInstant()
+                        .minusSeconds(1),
+                )
+
+                val status = service.getOpprettOppfolgingsplanPaaminnelseStatus(defaultSykmeldt())
+
+                status.status shouldBe OpprettOppfolgingsplanPaaminnelseStatus.TILGJENGELIG
+            }
+
+            it("ignores an unntaksvurdering for a different underenhet") {
+                val syketilfelleStart = LocalDate.of(2025, 6, 1)
+                seedSyketilfelle(
+                    startDato = syketilfelleStart,
+                    tom = LocalDate.of(2025, 6, 30),
+                )
+                persistUnntaksvurdering(
+                    createdAt = syketilfelleStart.atStartOfDay(fixedClock.zone).toInstant(),
+                    sykmeldt = defaultSykmeldt().copy(orgnummer = "annen-underenhet"),
                 )
 
                 val status = service.getOpprettOppfolgingsplanPaaminnelseStatus(defaultSykmeldt())
@@ -258,6 +331,23 @@ class OpprettOppfolgingsplanPaaminnelseServiceTest :
                     defaultPersistedOppfolgingsplan().copy(
                         createdAt = synligFra.atStartOfDay(fixedClock.zone).toInstant(),
                     ),
+                )
+
+                shouldThrow<BadRequestException> {
+                    service.activateOpprettOppfolgingsplanPaaminnelse(defaultSykmeldt())
+                }
+
+                TestDB.database.findOpprettOppfolgingsplanPaaminnelseBy("12345678901", "orgnummer") shouldBe null
+            }
+
+            it("rejects activation when an unntaksvurdering exists in the current syketilfelle") {
+                val syketilfelleStart = LocalDate.of(2025, 6, 1)
+                seedSyketilfelle(
+                    startDato = syketilfelleStart,
+                    tom = LocalDate.of(2025, 6, 30),
+                )
+                persistUnntaksvurdering(
+                    createdAt = syketilfelleStart.atStartOfDay(fixedClock.zone).toInstant(),
                 )
 
                 shouldThrow<BadRequestException> {


### PR DESCRIPTION
## Beskrivelse

Stanser den frivillige påminnelsen om å lage oppfølgingsplan når det finnes en relevant unntaksvurdering for samme sykmeldte, underenhet og sykefraværsforløp.

## Endringer

- Returnerer `SKJULT` og avviser nye bestillinger ved relevant unntaksvurdering.
- Gjenbruker den felles tilgjengelighetsregelen ved publisering, slik at begge outbox-meldinger kanselleres før utsending.
- Avgrenser vurderingen mot starten på gjeldende sammenhengende sykefraværsforløp.
- Dekker API-, service- og outbox-flyten med tester.

## Issue

Closes #456

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet automatisk
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)