### PR TITLE
feat(sykmeldt): inkluder aktive sykmeldinger i oversikt

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -21,6 +21,7 @@ import no.nav.syfo.pdfgen.PdfGenService
 import no.nav.syfo.plugins.installCallId
 import no.nav.syfo.plugins.installContentNegotiation
 import no.nav.syfo.plugins.installStatusPages
+import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
 import no.nav.syfo.texas.client.TexasHttpClient
 import org.koin.ktor.ext.inject
 
@@ -37,6 +38,7 @@ fun Application.configureRouting() {
     val isTilgangskontrollService by inject<IsTilgangskontrollService>()
     val dokarkivService by inject<DokarkivService>()
     val environment by inject<Environment>()
+    val sykmeldingsperiodeRepository by inject<SykmeldingsperiodeRepository>()
 
     installCallId()
     installContentNegotiation()
@@ -61,6 +63,7 @@ fun Application.configureRouting() {
             isTilgangskontrollService = isTilgangskontrollService,
             dokarkivService = dokarkivService,
             environment = environment,
+            sykmeldingsperiodeRepository = sykmeldingsperiodeRepository,
         )
         registerOpprettOppfolgingsplanPaaminnelseApi(
             dineSykmeldteService = dineSykmeldteService,

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/ApiV1.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/ApiV1.kt
@@ -16,9 +16,12 @@ import no.nav.syfo.oppfolgingsplan.api.v1.veileder.registerVeilederOppfolgingspl
 import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
 import no.nav.syfo.oppfolgingsplan.service.UnntaksvurderingService
 import no.nav.syfo.pdfgen.PdfGenService
+import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
 import no.nav.syfo.texas.TexasAzureADAuthPlugin
 import no.nav.syfo.texas.TexasTokenXAuthPlugin
 import no.nav.syfo.texas.client.TexasHttpClient
+import java.time.Clock
+import java.time.ZoneId
 
 @Suppress("LongParameterList")
 fun Route.registerApiV1(
@@ -31,6 +34,8 @@ fun Route.registerApiV1(
     isTilgangskontrollService: IsTilgangskontrollService,
     dokarkivService: DokarkivService,
     environment: Environment,
+    sykmeldingsperiodeRepository: SykmeldingsperiodeRepository,
+    sykmeldtOverviewClock: Clock = Clock.system(ZoneId.of("Europe/Oslo")),
 ) {
     route("/api/v1/arbeidsgiver") {
         install(TexasTokenXAuthPlugin) {
@@ -70,6 +75,8 @@ fun Route.registerApiV1(
             oppfolgingsplanService,
             unntaksvurderingService,
             pdfGenService,
+            sykmeldingsperiodeRepository,
+            sykmeldtOverviewClock,
         )
     }
     route("/api/v1/veileder") {

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/ApiV1.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/ApiV1.kt
@@ -20,8 +20,6 @@ import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
 import no.nav.syfo.texas.TexasAzureADAuthPlugin
 import no.nav.syfo.texas.TexasTokenXAuthPlugin
 import no.nav.syfo.texas.client.TexasHttpClient
-import java.time.Clock
-import java.time.ZoneId
 
 @Suppress("LongParameterList")
 fun Route.registerApiV1(
@@ -35,7 +33,6 @@ fun Route.registerApiV1(
     dokarkivService: DokarkivService,
     environment: Environment,
     sykmeldingsperiodeRepository: SykmeldingsperiodeRepository,
-    sykmeldtOverviewClock: Clock = Clock.system(ZoneId.of("Europe/Oslo")),
 ) {
     route("/api/v1/arbeidsgiver") {
         install(TexasTokenXAuthPlugin) {
@@ -76,7 +73,6 @@ fun Route.registerApiV1(
             unntaksvurderingService,
             pdfGenService,
             sykmeldingsperiodeRepository,
-            sykmeldtOverviewClock,
         )
     }
     route("/api/v1/veileder") {

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/SykmeldtOppfolgingsplanApiV1.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/SykmeldtOppfolgingsplanApiV1.kt
@@ -15,8 +15,12 @@ import no.nav.syfo.oppfolgingsplan.domain.Fodselsnummer
 import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
 import no.nav.syfo.oppfolgingsplan.service.UnntaksvurderingService
 import no.nav.syfo.pdfgen.PdfGenService
+import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
 import no.nav.syfo.texas.client.TexasHttpClient
 import no.nav.syfo.util.logger
+import java.time.Clock
+import java.time.LocalDate
+import java.time.ZoneId
 import java.util.UUID
 
 fun Route.registerSykmeldtOppfolgingsplanApiV1(
@@ -24,6 +28,8 @@ fun Route.registerSykmeldtOppfolgingsplanApiV1(
     oppfolgingsplanService: OppfolgingsplanService,
     unntaksvurderingService: UnntaksvurderingService,
     pdfGenService: PdfGenService,
+    sykmeldingsperiodeRepository: SykmeldingsperiodeRepository,
+    clock: Clock = Clock.system(ZoneId.of("Europe/Oslo")),
 ) {
     val logger = logger()
 
@@ -54,8 +60,19 @@ fun Route.registerSykmeldtOppfolgingsplanApiV1(
             val brukerFnr = call.attributes[CALL_ATTRIBUTE_SYKMELDT_BRUKER_FODSELSNUMMER]
             val oppfolgingsplaner = oppfolgingsplanService.getPersistedOppfolgingsplanListBy(brukerFnr.value)
             val unntaksvurderinger = unntaksvurderingService.getUnntaksvurderingerForSykmeldt(brukerFnr.value)
+            val virksomhetsnumreMedAktivSykmelding =
+                sykmeldingsperiodeRepository.findOrganisasjonsnumreMedAktivSykmelding(
+                    sykmeldtFnr = brukerFnr.value,
+                    today = LocalDate.now(clock),
+                )
 
-            call.respond(HttpStatusCode.OK, oppfolgingsplaner.toSykmeldtOppfolgingsplanOverviewResponse(unntaksvurderinger))
+            call.respond(
+                HttpStatusCode.OK,
+                oppfolgingsplaner.toSykmeldtOppfolgingsplanOverviewResponse(
+                    unntaksvurderinger = unntaksvurderinger,
+                    virksomhetsnumreMedAktivSykmelding = virksomhetsnumreMedAktivSykmelding,
+                ),
+            )
         }
 
         /**

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/SykmeldtOppfolgingsplanApiV1.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/SykmeldtOppfolgingsplanApiV1.kt
@@ -18,10 +18,11 @@ import no.nav.syfo.pdfgen.PdfGenService
 import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
 import no.nav.syfo.texas.client.TexasHttpClient
 import no.nav.syfo.util.logger
-import java.time.Clock
 import java.time.LocalDate
 import java.time.ZoneId
 import java.util.UUID
+
+private val ZONE_OSLO: ZoneId = ZoneId.of("Europe/Oslo")
 
 fun Route.registerSykmeldtOppfolgingsplanApiV1(
     texasHttpClient: TexasHttpClient,
@@ -29,7 +30,6 @@ fun Route.registerSykmeldtOppfolgingsplanApiV1(
     unntaksvurderingService: UnntaksvurderingService,
     pdfGenService: PdfGenService,
     sykmeldingsperiodeRepository: SykmeldingsperiodeRepository,
-    clock: Clock = Clock.system(ZoneId.of("Europe/Oslo")),
 ) {
     val logger = logger()
 
@@ -63,7 +63,7 @@ fun Route.registerSykmeldtOppfolgingsplanApiV1(
             val virksomhetsnumreMedAktivSykmelding =
                 sykmeldingsperiodeRepository.findOrganisasjonsnumreMedAktivSykmelding(
                     sykmeldtFnr = brukerFnr.value,
-                    today = LocalDate.now(clock),
+                    today = LocalDate.now(ZONE_OSLO),
                 )
 
             call.respond(

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/domain/SykmeldtOppfolgingsplanOverview.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/domain/SykmeldtOppfolgingsplanOverview.kt
@@ -11,6 +11,7 @@ import java.time.Instant
 
 fun List<PersistedOppfolgingsplan>.toSykmeldtOppfolgingsplanOverviewResponse(
     unntaksvurderinger: List<UnntaksvurderingMetadata>,
+    virksomhetsnumreMedAktivSykmelding: List<String>,
 ): SykmeldtOppfolgingsplanOverviewResponse {
     val planhendelser = map { it.toSykmeldtHendelse() }
     val unntakshendelser = unntaksvurderinger.map { it.toSykmeldtHendelse() }
@@ -22,7 +23,10 @@ fun List<PersistedOppfolgingsplan>.toSykmeldtOppfolgingsplanOverviewResponse(
         .sortedWith(virksomhetsoversiktComparator)
         .map { it.oversikt }
 
-    return SykmeldtOppfolgingsplanOverviewResponse(virksomheter)
+    return SykmeldtOppfolgingsplanOverviewResponse(
+        virksomheter = virksomheter,
+        virksomhetsnumreMedAktivSykmelding = virksomhetsnumreMedAktivSykmelding,
+    )
 }
 
 private fun PersistedOppfolgingsplan.toSykmeldtHendelse() = HendelseMedVirksomhet(

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/SykmeldtOppfolgingsplanOverviewResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/SykmeldtOppfolgingsplanOverviewResponse.kt
@@ -10,6 +10,7 @@ import java.util.UUID
 
 data class SykmeldtOppfolgingsplanOverviewResponse(
     val virksomheter: List<SykmeldtVirksomhetsoversikt>,
+    val virksomhetsnumreMedAktivSykmelding: List<String>,
 )
 
 data class SykmeldtVirksomhetsoversikt(

--- a/src/main/kotlin/no/nav/syfo/sykmelding/db/SykmeldingsperiodeRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/db/SykmeldingsperiodeRepository.kt
@@ -1,8 +1,16 @@
 package no.nav.syfo.sykmelding.db
 
 import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.application.database.exposedTransaction
 import no.nav.syfo.sykmelding.db.domain.PersistedSykmeldingsperiode
 import no.nav.syfo.sykmelding.db.domain.SykmeldingsperiodeToStore
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.greaterEq
+import org.jetbrains.exposed.v1.core.isNull
+import org.jetbrains.exposed.v1.core.lessEq
+import org.jetbrains.exposed.v1.jdbc.select
 import java.sql.Date
 import java.sql.ResultSet
 import java.sql.Statement
@@ -68,6 +76,22 @@ class SykmeldingsperiodeRepository(
             connection.commit()
             updatedRows
         }
+    }
+
+    suspend fun findOrganisasjonsnumreMedAktivSykmelding(
+        sykmeldtFnr: String,
+        today: LocalDate,
+    ): List<String> = database.exposedTransaction(readOnly = true) {
+        SykmeldingsperiodeTable
+            .select(SykmeldingsperiodeTable.organisasjonsnummer)
+            .where {
+                (SykmeldingsperiodeTable.sykmeldtFnr eq sykmeldtFnr) and
+                    SykmeldingsperiodeTable.invalidatedAt.isNull() and
+                    (SykmeldingsperiodeTable.fom lessEq today) and
+                    (SykmeldingsperiodeTable.tom greaterEq today)
+            }.orderBy(SykmeldingsperiodeTable.organisasjonsnummer to SortOrder.ASC)
+            .withDistinct()
+            .map { it[SykmeldingsperiodeTable.organisasjonsnummer] }
     }
 
     fun findBySykmeldingId(

--- a/src/main/resources/openapi/sykmeldt.yaml
+++ b/src/main/resources/openapi/sykmeldt.yaml
@@ -241,12 +241,19 @@ components:
       type: object
       required:
         - virksomheter
+        - virksomhetsnumreMedAktivSykmelding
       properties:
         virksomheter:
           type: array
           description: Virksomheter med minst én ferdigstilt plan eller synlig unntaksvurdering, sortert etter nyeste hendelse.
           items:
             $ref: '#/components/schemas/SykmeldtVirksomhetsoversikt'
+        virksomhetsnumreMedAktivSykmelding:
+          type: array
+          uniqueItems: true
+          description: Organisasjonsnumre med minst én ikke-invalidert sykmeldingsperiode som inkluderer dagens dato i Europe/Oslo, sortert stigende.
+          items:
+            type: string
 
     SykmeldtVirksomhetsoversikt:
       type: object

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
@@ -68,6 +68,7 @@ import no.nav.syfo.pdl.PdlService
 import no.nav.syfo.persistOppfolgingsplan
 import no.nav.syfo.plugins.installContentNegotiation
 import no.nav.syfo.plugins.installStatusPages
+import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
 import no.nav.syfo.returnsNotFound
 import no.nav.syfo.texas.client.TexasHttpClient
 import no.nav.syfo.texas.client.TexasIntrospectionResponse
@@ -144,6 +145,7 @@ class OppfolgingsplanApiV1Test :
                             dokarkivService = dokarkivServiceMock,
                             isTilgangskontrollService = isTilgangskontrollServiceMock,
                             environment = environment,
+                            sykmeldingsperiodeRepository = SykmeldingsperiodeRepository(testDb),
                         )
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanUtkastApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanUtkastApiV1Test.kt
@@ -53,6 +53,7 @@ import no.nav.syfo.pdl.PdlService
 import no.nav.syfo.pdl.client.PdlClient
 import no.nav.syfo.plugins.installContentNegotiation
 import no.nav.syfo.plugins.installStatusPages
+import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
 import no.nav.syfo.texas.client.TexasHttpClient
 import no.nav.syfo.util.applyStandardConfiguration
 import no.nav.syfo.varsel.EsyfovarselProducer
@@ -121,6 +122,7 @@ class OppfolgingsplanUtkastApiV1Test :
                             dokarkivService = dokarkivServiceMock,
                             isTilgangskontrollService = isTilgangskontrollServiceMock,
                             environment = environment,
+                            sykmeldingsperiodeRepository = SykmeldingsperiodeRepository(testDb),
                         )
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/UnntaksvurderingApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/UnntaksvurderingApiV1Test.kt
@@ -52,6 +52,7 @@ import no.nav.syfo.pdl.PdlService
 import no.nav.syfo.persistOppfolgingsplan
 import no.nav.syfo.plugins.installContentNegotiation
 import no.nav.syfo.plugins.installStatusPages
+import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
 import no.nav.syfo.texas.client.TexasHttpClient
 import no.nav.syfo.varsel.EsyfovarselProducer
 import java.time.Instant
@@ -123,6 +124,7 @@ class UnntaksvurderingApiV1Test :
                             dokarkivService = dokarkivServiceMock,
                             isTilgangskontrollService = isTilgangskontrollServiceMock,
                             environment = environment,
+                            sykmeldingsperiodeRepository = SykmeldingsperiodeRepository(testDb),
                         )
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/OppfolgingsplanApiV1Test.kt
@@ -62,12 +62,13 @@ import no.nav.syfo.sykmelding.db.domain.SykmeldingsperiodeToStore
 import no.nav.syfo.texas.client.TexasHttpClient
 import no.nav.syfo.texas.client.TexasIntrospectionResponse
 import no.nav.syfo.varsel.EsyfovarselProducer
-import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import java.util.UUID
+
+private val ZONE_OSLO: ZoneId = ZoneId.of("Europe/Oslo")
 
 class OppfolgingsplanApiV1Test :
     DescribeSpec({
@@ -87,10 +88,6 @@ class OppfolgingsplanApiV1Test :
         val unntaksvurderingService = UnntaksvurderingService(testDb, pdlServiceMock)
         val environment: Environment = LocalEnvironment()
         val aaregServiceMock = mockk<AaregService>(relaxed = true)
-        val overviewClock = Clock.fixed(
-            Instant.parse("2025-06-20T12:00:00Z"),
-            ZoneId.of("Europe/Oslo"),
-        )
 
         beforeTest {
             clearAllMocks(currentThreadOnly = true)
@@ -135,7 +132,6 @@ class OppfolgingsplanApiV1Test :
                             isTilgangskontrollService = isTilgangskontrollServiceMock,
                             environment = environment,
                             sykmeldingsperiodeRepository = SykmeldingsperiodeRepository(testDb),
-                            sykmeldtOverviewClock = overviewClock,
                         )
                     }
                 }
@@ -416,14 +412,15 @@ class OppfolgingsplanApiV1Test :
                             pid = sykmeldtFnr,
                             clientId = environment.syfoOppfolgingsplanFrontendClientId,
                         )
+                        val today = LocalDate.now(ZONE_OSLO)
                         SykmeldingsperiodeRepository(testDb).storeSykmeldingsperioder(
                             listOf(
                                 SykmeldingsperiodeToStore(
                                     sykmeldtFnr = sykmeldtFnr,
                                     organisasjonsnummer = activeOrganization,
                                     sykmeldingId = "active-sykmelding",
-                                    fom = LocalDate.now(overviewClock).minusDays(1),
-                                    tom = LocalDate.now(overviewClock).plusDays(1),
+                                    fom = today.minusDays(7),
+                                    tom = today.plusDays(7),
                                 ),
                             ),
                         )

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/OppfolgingsplanApiV1Test.kt
@@ -62,8 +62,10 @@ import no.nav.syfo.sykmelding.db.domain.SykmeldingsperiodeToStore
 import no.nav.syfo.texas.client.TexasHttpClient
 import no.nav.syfo.texas.client.TexasIntrospectionResponse
 import no.nav.syfo.varsel.EsyfovarselProducer
+import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import java.util.UUID
 
@@ -85,6 +87,10 @@ class OppfolgingsplanApiV1Test :
         val unntaksvurderingService = UnntaksvurderingService(testDb, pdlServiceMock)
         val environment: Environment = LocalEnvironment()
         val aaregServiceMock = mockk<AaregService>(relaxed = true)
+        val overviewClock = Clock.fixed(
+            Instant.parse("2025-06-20T12:00:00Z"),
+            ZoneId.of("Europe/Oslo"),
+        )
 
         beforeTest {
             clearAllMocks(currentThreadOnly = true)
@@ -128,6 +134,8 @@ class OppfolgingsplanApiV1Test :
                             dokarkivService = dokarkivServiceMock,
                             isTilgangskontrollService = isTilgangskontrollServiceMock,
                             environment = environment,
+                            sykmeldingsperiodeRepository = SykmeldingsperiodeRepository(testDb),
+                            sykmeldtOverviewClock = overviewClock,
                         )
                     }
                 }
@@ -398,6 +406,37 @@ class OppfolgingsplanApiV1Test :
                         response.status shouldBe HttpStatusCode.OK
                         val overview = response.body<SykmeldtOppfolgingsplanOverviewResponse>()
                         overview.virksomheter shouldBe emptyList()
+                    }
+                }
+                it("GET /oppfolgingsplaner/oversikt should return active organizations when virksomheter is empty") {
+                    val sykmeldtFnr = "12345678901"
+                    val activeOrganization = "987654321"
+                    withTestApplication {
+                        texasClientMock.defaultMocks(
+                            pid = sykmeldtFnr,
+                            clientId = environment.syfoOppfolgingsplanFrontendClientId,
+                        )
+                        SykmeldingsperiodeRepository(testDb).storeSykmeldingsperioder(
+                            listOf(
+                                SykmeldingsperiodeToStore(
+                                    sykmeldtFnr = sykmeldtFnr,
+                                    organisasjonsnummer = activeOrganization,
+                                    sykmeldingId = "active-sykmelding",
+                                    fom = LocalDate.now(overviewClock).minusDays(1),
+                                    tom = LocalDate.now(overviewClock).plusDays(1),
+                                ),
+                            ),
+                        )
+
+                        val response = client.get {
+                            url("/api/v1/sykmeldt/oppfolgingsplaner/oversikt")
+                            bearerAuth("******")
+                        }
+
+                        response.status shouldBe HttpStatusCode.OK
+                        val overview = response.body<SykmeldtOppfolgingsplanOverviewResponse>()
+                        overview.virksomheter shouldBe emptyList()
+                        overview.virksomhetsnumreMedAktivSykmelding shouldBe listOf(activeOrganization)
                     }
                 }
             }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederApiV1TestFixture.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/veileder/VeilederApiV1TestFixture.kt
@@ -31,6 +31,7 @@ import no.nav.syfo.oppfolgingsplan.service.UnntaksvurderingService
 import no.nav.syfo.pdfgen.PdfGenService
 import no.nav.syfo.plugins.installContentNegotiation
 import no.nav.syfo.plugins.installStatusPages
+import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
 import no.nav.syfo.texas.client.TexasHttpClient
 import no.nav.syfo.varsel.EsyfovarselProducer
 import java.util.UUID
@@ -93,6 +94,7 @@ class VeilederApiV1TestFixture {
                         dokarkivService = dokarkivServiceMock,
                         isTilgangskontrollService = isTilgangskontrollServiceMock,
                         environment = this@VeilederApiV1TestFixture.environment,
+                        sykmeldingsperiodeRepository = SykmeldingsperiodeRepository(testDb),
                     )
                 }
             }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/db/PersistedOppfolgingsplanTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/db/PersistedOppfolgingsplanTest.kt
@@ -326,9 +326,13 @@ class PersistedOppfolgingsplanTest :
         describe("toSykmeldtOppfolgingsplanOverviewResponse") {
             it("returnerer ingen virksomheter når det ikke finnes hendelser") {
                 val result = emptyList<PersistedOppfolgingsplan>()
-                    .toSykmeldtOppfolgingsplanOverviewResponse(emptyList())
+                    .toSykmeldtOppfolgingsplanOverviewResponse(
+                        unntaksvurderinger = emptyList(),
+                        virksomhetsnumreMedAktivSykmelding = listOf("123456789"),
+                    )
 
                 result.virksomheter.shouldBeEmpty()
+                result.virksomhetsnumreMedAktivSykmelding shouldBe listOf("123456789")
             }
 
             it("grupperer planer per virksomhet og sorterer nyeste hendelse først") {
@@ -345,7 +349,10 @@ class PersistedOppfolgingsplanTest :
                     createdAt = Instant.parse("2024-06-01T10:00:00Z"),
                 )
 
-                val result = listOf(olderPlan, newerPlan).toSykmeldtOppfolgingsplanOverviewResponse(emptyList())
+                val result = listOf(olderPlan, newerPlan).toSykmeldtOppfolgingsplanOverviewResponse(
+                    unntaksvurderinger = emptyList(),
+                    virksomhetsnumreMedAktivSykmelding = emptyList(),
+                )
 
                 result.virksomheter shouldHaveSize 1
                 result.virksomheter.single().virksomhet shouldBe OrganizationDetails("org1", "Virksomhet 1")
@@ -372,7 +379,10 @@ class PersistedOppfolgingsplanTest :
                 )
 
                 val result = listOf(plan)
-                    .toSykmeldtOppfolgingsplanOverviewResponse(listOf(olderUnntak, newerUnntak))
+                    .toSykmeldtOppfolgingsplanOverviewResponse(
+                        unntaksvurderinger = listOf(olderUnntak, newerUnntak),
+                        virksomhetsnumreMedAktivSykmelding = emptyList(),
+                    )
 
                 val hendelser = result.virksomheter.single().oppfolgingsplanhendelser
                 hendelser.map { it.id } shouldBe listOf(newerUnntak.id, plan.uuid, olderUnntak.id)
@@ -399,7 +409,8 @@ class PersistedOppfolgingsplanTest :
                 )
 
                 val result = listOf(olderPlan).toSykmeldtOppfolgingsplanOverviewResponse(
-                    listOf(middleUnntak, newestUnntak),
+                    unntaksvurderinger = listOf(middleUnntak, newestUnntak),
+                    virksomhetsnumreMedAktivSykmelding = emptyList(),
                 )
 
                 result.virksomheter.map { it.virksomhet.orgNumber } shouldBe listOf("org1", "org2")

--- a/src/test/kotlin/no/nav/syfo/sykmelding/db/SykmeldingsperiodeRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmelding/db/SykmeldingsperiodeRepositoryTest.kt
@@ -111,6 +111,76 @@ class SykmeldingsperiodeRepositoryTest :
             }
         }
 
+        describe("findOrganisasjonsnumreMedAktivSykmelding") {
+            it("includes both date boundaries, sorts ascending, and deduplicates organizations") {
+                repository.storeSykmeldingsperioder(
+                    listOf(
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = sykmeldtFnr,
+                            organisasjonsnummer = "222222222",
+                            sykmeldingId = "starts-today",
+                            fom = today,
+                            tom = today.plusDays(10),
+                        ),
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = sykmeldtFnr,
+                            organisasjonsnummer = "222222222",
+                            sykmeldingId = "duplicate-organization",
+                            fom = today.minusDays(10),
+                            tom = today.plusDays(10),
+                        ),
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = sykmeldtFnr,
+                            organisasjonsnummer = "111111111",
+                            sykmeldingId = "ends-today",
+                            fom = today.minusDays(10),
+                            tom = today,
+                        ),
+                        SykmeldingsperiodeToStore(
+                            sykmeldtFnr = "10987654321",
+                            organisasjonsnummer = "000000000",
+                            sykmeldingId = "other-user",
+                            fom = today.minusDays(1),
+                            tom = today.plusDays(1),
+                        ),
+                    ),
+                )
+
+                repository.findOrganisasjonsnumreMedAktivSykmelding(
+                    sykmeldtFnr = sykmeldtFnr,
+                    today = today,
+                ) shouldBe listOf("111111111", "222222222")
+            }
+
+            it("excludes future, ended, and invalidated periods") {
+                repository.storeSykmeldingsperioder(
+                    listOf(
+                        sykmeldingsperiodeToStore(
+                            sykmeldingId = "future",
+                            fom = today.plusDays(1),
+                            tom = today.plusDays(10),
+                        ),
+                        sykmeldingsperiodeToStore(
+                            sykmeldingId = "ended",
+                            fom = today.minusDays(10),
+                            tom = today.minusDays(1),
+                        ),
+                        sykmeldingsperiodeToStore(
+                            sykmeldingId = "invalidated",
+                            fom = today.minusDays(1),
+                            tom = today.plusDays(1),
+                        ),
+                    ),
+                )
+                repository.invalidateSykmelding("invalidated")
+
+                repository.findOrganisasjonsnumreMedAktivSykmelding(
+                    sykmeldtFnr = sykmeldtFnr,
+                    today = today,
+                ) shouldBe emptyList()
+            }
+        }
+
         describe("findEarliestSykmeldingsperiode") {
             it("returns earliest fom in a continuous chain ending in an active period today") {
                 repository.storeSykmeldingsperioder(


### PR DESCRIPTION
## Beskrivelse

Utvider oversikten for sykmeldte med virksomhetsnumre fra aktive sykmeldinger sendt til arbeidsgiver. Dermed kan frontend avgjøre tiltakspakke-tilhørighet uavhengig av om brukeren har en oppfølgingsplan.

Feltet er påkrevd i frontendkontrakten. Denne PR-en må derfor deployes før den tilhørende frontend-PR-en. Rollback er å rulle tilbake frontend først, deretter backend.

## Endringer

- `SykmeldingsperiodeRepository`: Henter unike virksomhetsnumre for ikke-invaliderte perioder der `fom <= i dag <= tom`, sortert stigende.
- `oppfolgingsplaner/oversikt`: Returnerer `virksomhetsnumreMedAktivSykmelding` for den tokenavledede brukeren med dato fra `Europe/Oslo`.
- DTO og OpenAPI: Dokumenterer den additive responsendringen.
- Tester: Dekker datogrenser, invalidering, deduplisering, sortering og tom planoversikt.

Ingen Aareg-integrasjon, virksomhetsnavn eller arbeidsforholdsobjekter er lagt til.

Lokal Gradle-verifikasjon var blokkert av CLI-miljøets loopback-begrensning for Gradle-daemonen. `jar-app`-CI har verifisert test, build, analyse, CodeQL og merge gate på den publiserte committen. Backend-commit `5ae3b80` er deployet til dev, og uavhengig R3-inspeksjon er godkjent.

## Issue

Ingen tilknyttet issue.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
