### PR TITLE
La outbox eie event-ID for oppfølgingsplanvarsler

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanFinalizationRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanFinalizationRepository.kt
@@ -39,7 +39,6 @@ class OppfolgingsplanFinalizationRepository(
                 OppfolgingsplanUtkastTable.narmesteLederId eq command.sykmeldt.narmestelederId
             }.singleOrNull()
             ?.get(OppfolgingsplanUtkastTable.createdAt)
-        val eventId = UUID.randomUUID()
 
         val insertedOppfolgingsplanRow = OppfolgingsplanTable.insertReturning(
             returning = listOf(
@@ -65,7 +64,6 @@ class OppfolgingsplanFinalizationRepository(
             it[OppfolgingsplanTable.skalDelesMedVeileder] = false
             it[OppfolgingsplanTable.utkastCreatedAt] = utkastCreatedAt
             it[OppfolgingsplanTable.createdAt] = CurrentTimestampWithTimeZone
-            it[OppfolgingsplanTable.eventId] = eventId
         }.single()
 
         val oppfolgingsplanUuid = insertedOppfolgingsplanRow[OppfolgingsplanTable.uuid]
@@ -81,7 +79,6 @@ class OppfolgingsplanFinalizationRepository(
         check(
             enqueueOutboxMessage(
                 NewOutboxMessage(
-                    uuid = eventId,
                     messageType = OppfolgingsplanOutboxMessageType.CREATED,
                     dedupKey = oppfolgingsplanUuid.toString(),
                     externalRef = oppfolgingsplanUuid.toString(),

--- a/src/test/kotlin/no/nav/syfo/TestDb.kt
+++ b/src/test/kotlin/no/nav/syfo/TestDb.kt
@@ -267,7 +267,7 @@ fun DatabaseInterface.findOppfolgingsplanUtkastByNarmesteLederId(
     }
 }
 
-fun DatabaseInterface.findEventId(oppfolgingsplanId: UUID): UUID? = connection.use { connection ->
+fun DatabaseInterface.findLegacyEventId(oppfolgingsplanId: UUID): UUID? = connection.use { connection ->
     connection.prepareStatement(
         """
         SELECT event_id

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -46,7 +47,7 @@ import no.nav.syfo.defaultUtkastRequest
 import no.nav.syfo.dinesykmeldte.DineSykmeldteService
 import no.nav.syfo.dinesykmeldte.client.DineSykmeldteHttpClient
 import no.nav.syfo.dokarkiv.DokarkivService
-import no.nav.syfo.findEventId
+import no.nav.syfo.findLegacyEventId
 import no.nav.syfo.generatedPdfStandin
 import no.nav.syfo.isdialogmelding.IsDialogmeldingService
 import no.nav.syfo.isdialogmelding.client.IsDialogmeldingClient
@@ -504,13 +505,12 @@ class OppfolgingsplanApiV1Test :
                     persisted.first().organisasjonsnavn shouldBe "Test AS"
                     persisted.first().stillingstittel shouldBe "Systemutvikler"
                     persisted.first().stillingsprosent shouldBe BigDecimal("100.00")
-                    val persistedEventId = testDb.findEventId(persisted.first().uuid)
-                    persistedEventId.shouldNotBeNull()
+                    testDb.findLegacyEventId(persisted.first().uuid).shouldBeNull()
                     val outboxMessage = testDb.findOutboxMessage(
                         OppfolgingsplanOutboxMessageType.CREATED,
                         persisted.first().uuid.toString(),
                     ).shouldNotBeNull()
-                    outboxMessage.uuid shouldBe persistedEventId
+                    outboxMessage.uuid shouldNotBe persisted.first().uuid
                     outboxMessage.status shouldBe OutboxStatus.READY
                 }
             }
@@ -553,12 +553,11 @@ class OppfolgingsplanApiV1Test :
 
                     val persistedUtkast = testDb.findOppfolgingsplanUtkastBy(sykmeldt.fnr, sykmeldt.orgnummer)
                     persistedUtkast shouldBe null
-                    val persistedEventId = testDb.findEventId(persistedOppfolgingsplaner.first().uuid)
-                    persistedEventId.shouldNotBeNull()
+                    testDb.findLegacyEventId(persistedOppfolgingsplaner.first().uuid).shouldBeNull()
                     testDb.findOutboxMessage(
                         OppfolgingsplanOutboxMessageType.CREATED,
                         persistedOppfolgingsplaner.first().uuid.toString(),
-                    ).shouldNotBeNull().uuid shouldBe persistedEventId
+                    ).shouldNotBeNull().uuid shouldNotBe persistedOppfolgingsplaner.first().uuid
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/outbox/OppfolgingsplanCreatedOutboxIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/outbox/OppfolgingsplanCreatedOutboxIntegrationTest.kt
@@ -7,8 +7,10 @@ import ch.qos.logback.core.read.ListAppender
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -16,6 +18,7 @@ import io.mockk.mockk
 import no.nav.syfo.TestDB
 import no.nav.syfo.aareg.AaregService
 import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.application.outbox.MutableClock
 import no.nav.syfo.application.outbox.OutboxWorker
 import no.nav.syfo.application.outbox.db.findOutboxMessage
 import no.nav.syfo.application.outbox.domain.OutboxCancellationReason
@@ -23,7 +26,7 @@ import no.nav.syfo.application.outbox.domain.OutboxStatus
 import no.nav.syfo.defaultOppfolgingsplan
 import no.nav.syfo.defaultPersistedOppfolgingsplanUtkast
 import no.nav.syfo.defaultSykmeldt
-import no.nav.syfo.findEventId
+import no.nav.syfo.findLegacyEventId
 import no.nav.syfo.findOppfolgingsplanUtkastByNarmesteLederId
 import no.nav.syfo.oppfolgingsplan.db.OppfolgingsplanFinalizationRepository
 import no.nav.syfo.oppfolgingsplan.db.findAllOppfolgingsplanerBy
@@ -36,9 +39,11 @@ import no.nav.syfo.varsel.EsyfovarselProducer
 import no.nav.syfo.varsel.budstikka.infrastructure.BudstikkaPublisher
 import org.slf4j.LoggerFactory
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.time.ZoneOffset
 import java.util.UUID
+import java.util.concurrent.TimeoutException
 
 class OppfolgingsplanCreatedOutboxIntegrationTest :
     DescribeSpec({
@@ -59,7 +64,8 @@ class OppfolgingsplanCreatedOutboxIntegrationTest :
                     OppfolgingsplanOutboxMessageType.CREATED,
                     planUuid.toString(),
                 ).shouldNotBeNull()
-                message.uuid shouldBe TestDB.database.findEventId(planUuid)
+                TestDB.database.findLegacyEventId(planUuid).shouldBeNull()
+                message.uuid shouldNotBe planUuid
                 message.externalRef shouldBe planUuid.toString()
                 message.availableAt shouldBe plan.createdAt
                 message.status shouldBe OutboxStatus.READY
@@ -114,22 +120,36 @@ class OppfolgingsplanCreatedOutboxIntegrationTest :
                 }
             }
 
-            it("retries a technical publish failure") {
+            it("keeps the outbox uuid as the Budstikka event ID across retries") {
                 val planUuid = TestDB.database.createOppfolgingsplan()
+                val originalMessage = TestDB.database.findCreatedMessage(planUuid)
+                val observedEventIds = mutableListOf<UUID>()
+                var publishAttempt = 0
                 val publisher = mockk<BudstikkaPublisher>()
-                coEvery { publisher.publishOppfolgingsplanCreated(any(), any(), any()) } throws RuntimeException("broker down")
+                coEvery {
+                    publisher.publishOppfolgingsplanCreated(any(), any(), capture(observedEventIds))
+                } coAnswers {
+                    publishAttempt++
+                    if (publishAttempt == 1) throw TimeoutException("Forced Budstikka timeout")
+                }
+                val retryClock = MutableClock(now)
                 val worker = OutboxWorker(
                     database = TestDB.database,
                     handlers = listOf(OppfolgingsplanCreatedOutboxHandler(TestDB.database, publisher)),
-                    clock = clock,
+                    clock = retryClock,
                 )
 
                 worker.runOnce().retryScheduled shouldBe 1
 
-                TestDB.database.findCreatedMessage(planUuid).let { message ->
-                    message.status shouldBe OutboxStatus.READY
-                    message.failureCount shouldBe 1
-                }
+                val retryingMessage = TestDB.database.findCreatedMessage(planUuid)
+                retryingMessage.uuid shouldBe originalMessage.uuid
+                retryingMessage.status shouldBe OutboxStatus.READY
+                retryingMessage.failureCount shouldBe 1
+
+                retryClock.advance(Duration.between(retryClock.instant(), retryingMessage.availableAt).plusMillis(1))
+                worker.runOnce().sent shouldBe 1
+
+                observedEventIds shouldBe listOf(originalMessage.uuid, originalMessage.uuid)
             }
 
             it("cancels a notification when the plan is no longer eligible") {

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanServiceTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -18,7 +19,7 @@ import no.nav.syfo.defaultOppfolgingsplan
 import no.nav.syfo.defaultPersistedOppfolgingsplan
 import no.nav.syfo.defaultPersistedOppfolgingsplanUtkast
 import no.nav.syfo.defaultSykmeldt
-import no.nav.syfo.findEventId
+import no.nav.syfo.findLegacyEventId
 import no.nav.syfo.findOppfolgingsplanUtkastByNarmesteLederId
 import no.nav.syfo.oppfolgingsplan.db.OppfolgingsplanFinalizationRepository
 import no.nav.syfo.oppfolgingsplan.db.deleteExpiredOppfolgingsplanUtkast
@@ -173,13 +174,12 @@ class OppfolgingsplanServiceTest :
                     val persisted = service.getPersistedOppfolgingsplanByUuid(uuid)
                     persisted.stillingstittel shouldBe "Systemutvikler"
                     persisted.stillingsprosent shouldBe BigDecimal("80.50")
-                    val eventId = TestDB.database.findEventId(uuid)
-                    eventId.shouldNotBeNull()
+                    TestDB.database.findLegacyEventId(uuid).shouldBeNull()
                     val outboxMessage = TestDB.database.findOutboxMessage(
                         OppfolgingsplanOutboxMessageType.CREATED,
                         uuid.toString(),
                     ).shouldNotBeNull()
-                    outboxMessage.uuid shouldBe eventId
+                    outboxMessage.uuid shouldNotBe uuid
                     outboxMessage.status shouldBe OutboxStatus.READY
                 }
 


### PR DESCRIPTION
## Beskrivelse

Lar `outbox.uuid` være eneste event-ID for nye `OPPFOLGINGSPLAN_CREATED`-varsler. Opprettelse av en oppfølgingsplan skriver ikke lenger til den eldre `oppfolgingsplan.event_id`-kolonnen.

Dette gjør opprettelsesvarselet konsistent med evalueringspåminnelsene: hver outbox-rad eier sin egen Budstikka event-ID, mens oppfølgingsplanens UUID fortsatt brukes som `external_ref` og dedupliseringsnøkkel innenfor meldingstypen.

## Endringer

- Fjerner koblingen mellom `oppfolgingsplan.event_id` og UUID-en til opprettelsesvarselets outbox-rad.
- Beholder samme outbox-UUID gjennom nye publiseringsforsøk, slik at Budstikka-idempotens bevares.
- Oppdaterer integrasjons- og API-tester til å verifisere det nye eierskapet.

## Utrulling

Den nullable `event_id`-kolonnen beholdes i denne endringen for kompatibilitet under rullerende deploy. Kolonnen kan fjernes med en egen Flyway-migrering etter at denne versjonen er produksjonssatt på alle podder.

## Verifisering

- `./gradlew cleanTest test assemble --console=plain` — bestått.
- `git diff --check` — bestått.
- `./gradlew build --console=plain` — kompilering og tester fullførte, men ktlint-workerne kunne ikke starte fordi Copilot-miljøet blokkerer localhost-IPC (`SocketException: Operation not permitted`). CI må bekrefte ktlint.