### PR TITLE
Fiks tekst i epost for evalueringspåminnelse

### DIFF
--- a/src/main/kotlin/no/nav/syfo/varsel/budstikka/infrastructure/BudstikkaEmailTemplates.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/budstikka/infrastructure/BudstikkaEmailTemplates.kt
@@ -13,8 +13,8 @@ val EVALUERINGS_PAAMINNELSE_EMAIL_HTML = """
         <tr>
           <td style="padding: 32px; font-size: 18px; line-height: 1.5;">
             <p style="margin: 0 0 24px;">Hei,</p>
-            <p style="margin: 0 0 32px;">Det er tid for å vurdere om situasjonen til den som er sykmeldt er annerledes enn tidligere og at det derfor er riktig å gjøre endringer i oppfølgingsplanen. Ta en prat for å finne ut om det er aktuelt nå eller at dere lager en ny avtale litt frem i tid.</p>
-            <p style="margin: 0 0 24px; font-weight: 700;">Gå til Min side – arbeidsgiver på nav.no for å oppdatere oppfølgingsplanen.</p>
+            <p style="margin: 0 0 32px;">Det er tid for å vurdere om situasjonen til den som er sykmeldt er annerledes enn tidligere, og om det derfor er riktig å gjøre endringer i oppfølgingsplanen. Ta en prat for å finne ut om det er aktuelt nå, eller om dere skal lage en ny avtale litt frem i tid.</p>
+            <p style="margin: 0 0 24px; font-weight: 700;">Gå til Min side – arbeidsgiver hos Nav for å oppdatere oppfølgingsplanen.</p>
             <hr style="margin: 0 0 24px; border: 0; border-top: 1px solid #d8d8d8;">
             <p style="margin: 0 0 20px;">Har du spørsmål? Ring oss på 55 55 33 36.</p>
             <p style="margin: 0 0 20px;">Du kan ikke svare på denne meldingen.</p>


### PR DESCRIPTION
## Beskrivelse

Fjerner lenke til nav.no i epost-teksten, og justerer på teksten ihht. Figma/Slack.

## Endringer

`BudstikkaEmailTemplates`

## Issue

Closes #464

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
