### PR TITLE
Test at unntaksvurdering ikke lekker PII i logger

### DIFF
--- a/src/main/kotlin/no/nav/syfo/plugins/ApiPlugins.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/ApiPlugins.kt
@@ -41,7 +41,7 @@ fun Application.installCallId() {
 
 private fun logException(call: ApplicationCall, cause: Throwable) {
     val logExceptionMessage = "Caught ${cause::class.simpleName} exception"
-    call.application.log.error(logExceptionMessage, cause)
+    call.application.log.error(logExceptionMessage)
 }
 
 private fun determineApiError(cause: Throwable, path: String): ApiError = when (cause) {
@@ -57,7 +57,7 @@ private fun determineApiError(cause: Throwable, path: String): ApiError = when (
     else -> ApiError(
         status = HttpStatusCode.InternalServerError,
         type = ErrorType.INTERNAL_SERVER_ERROR,
-        message = cause.message ?: "Internal server error",
+        message = "Internal server error",
         path = path,
     )
 }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/UnntaksvurderingApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/UnntaksvurderingApiV1Test.kt
@@ -1,5 +1,8 @@
 package no.nav.syfo.oppfolgingsplan.api.v1.arbeidsgiver
 
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
@@ -25,6 +28,7 @@ import no.nav.syfo.TestDB
 import no.nav.syfo.aareg.AaregService
 import no.nav.syfo.application.Environment
 import no.nav.syfo.application.LocalEnvironment
+import no.nav.syfo.application.exception.ApiError
 import no.nav.syfo.application.valkey.ValkeyCache
 import no.nav.syfo.defaultMocks
 import no.nav.syfo.defaultPersistedOppfolgingsplan
@@ -46,7 +50,11 @@ import no.nav.syfo.oppfolgingsplan.dto.ArbeidsgiverOppfolgingsplanOverviewRespon
 import no.nav.syfo.oppfolgingsplan.dto.GjeldendeStatus
 import no.nav.syfo.oppfolgingsplan.dto.MeldtAvRolle
 import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
+import no.nav.syfo.oppfolgingsplan.service.SYNTHETIC_NARMESTE_LEDER_FNR
+import no.nav.syfo.oppfolgingsplan.service.SYNTHETIC_NARMESTE_LEDER_NAME
+import no.nav.syfo.oppfolgingsplan.service.SYNTHETIC_SYKMELDT_FNR
 import no.nav.syfo.oppfolgingsplan.service.UnntaksvurderingService
+import no.nav.syfo.oppfolgingsplan.service.shouldNotContainSensitiveUnntaksvurderingData
 import no.nav.syfo.pdfgen.PdfGenService
 import no.nav.syfo.pdl.PdlService
 import no.nav.syfo.persistOppfolgingsplan
@@ -55,6 +63,7 @@ import no.nav.syfo.plugins.installStatusPages
 import no.nav.syfo.sykmelding.db.SykmeldingsperiodeRepository
 import no.nav.syfo.texas.client.TexasHttpClient
 import no.nav.syfo.varsel.EsyfovarselProducer
+import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.util.UUID
 
@@ -131,6 +140,12 @@ class UnntaksvurderingApiV1Test :
                 fn(this)
             }
         }
+
+        fun sensitiveUnntaksvurderingValues() = listOf(
+            SYNTHETIC_SYKMELDT_FNR,
+            SYNTHETIC_NARMESTE_LEDER_FNR,
+            SYNTHETIC_NARMESTE_LEDER_NAME,
+        )
 
         describe("GET /oppfolgingsplaner/oversikt") {
             it("returns empty unntaksvurderinger and status INGEN when nothing exists") {
@@ -425,6 +440,101 @@ class UnntaksvurderingApiV1Test :
 
                     response.status shouldBe HttpStatusCode.Conflict
                     testDb.findAllUnntaksvurderingerBy(sykmeldt.fnr, sykmeldt.orgnummer) shouldBe emptyList()
+                }
+            }
+
+            it("logs static conflict details without synthetic identifiers or names") {
+                val logger = LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME) as Logger
+                val appender = ListAppender<ILoggingEvent>().apply { start() }
+                logger.addAppender(appender)
+
+                try {
+                    withTestApplication {
+                        val syntheticSykmeldt = sykmeldt.copy(fnr = SYNTHETIC_SYKMELDT_FNR)
+                        texasClientMock.defaultMocks(
+                            SYNTHETIC_NARMESTE_LEDER_FNR,
+                            clientId = environment.syfoOppfolgingsplanFrontendClientId,
+                        )
+                        coEvery {
+                            dineSykmeldteHttpClientMock.getSykmeldtForNarmesteLederId(narmestelederId, "token")
+                        } returns syntheticSykmeldt
+
+                        testDb.upsertOppfolgingsplanUtkast(
+                            narmesteLederFnr = SYNTHETIC_NARMESTE_LEDER_FNR,
+                            sykmeldt = syntheticSykmeldt,
+                            lagreUtkastRequest = defaultUtkastRequest(),
+                        )
+
+                        val response = client.post {
+                            url("/api/v1/arbeidsgiver/$narmestelederId/unntaksvurderinger")
+                            bearerAuth("******")
+                        }
+
+                        response.status shouldBe HttpStatusCode.Conflict
+                        response.body<ApiError>().message shouldBe
+                            "Cannot create unntaksvurdering when an oppfolgingsplan utkast exists"
+                        appender.list.shouldNotContainSensitiveUnntaksvurderingData(sensitiveUnntaksvurderingValues())
+                    }
+                } finally {
+                    logger.detachAppender(appender)
+                    appender.stop()
+                }
+            }
+
+            it("redacts database failure details while persisting an unntaksvurdering") {
+                val logger = LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME) as Logger
+                val appender = ListAppender<ILoggingEvent>().apply { start() }
+                val constraintName = "unntaksvurdering_logging_test_reject"
+                var constraintAdded = false
+                logger.addAppender(appender)
+
+                try {
+                    testDb.connection.use { connection ->
+                        connection.createStatement().use { statement ->
+                            statement.execute(
+                                "ALTER TABLE unntaksvurdering ADD CONSTRAINT $constraintName CHECK (false) NOT VALID",
+                            )
+                        }
+                        connection.commit()
+                    }
+                    constraintAdded = true
+
+                    withTestApplication {
+                        val syntheticSykmeldt = sykmeldt.copy(fnr = SYNTHETIC_SYKMELDT_FNR)
+                        texasClientMock.defaultMocks(
+                            SYNTHETIC_NARMESTE_LEDER_FNR,
+                            clientId = environment.syfoOppfolgingsplanFrontendClientId,
+                        )
+                        coEvery {
+                            dineSykmeldteHttpClientMock.getSykmeldtForNarmesteLederId(narmestelederId, "token")
+                        } returns syntheticSykmeldt
+                        coEvery { pdlServiceMock.getNameFor(SYNTHETIC_NARMESTE_LEDER_FNR) } returns
+                            SYNTHETIC_NARMESTE_LEDER_NAME
+
+                        val response = client.post {
+                            url("/api/v1/arbeidsgiver/$narmestelederId/unntaksvurderinger")
+                            bearerAuth("******")
+                        }
+
+                        response.status shouldBe HttpStatusCode.InternalServerError
+                        response.body<ApiError>().message shouldBe "Internal server error"
+                        appender.list.shouldNotContainSensitiveUnntaksvurderingData(sensitiveUnntaksvurderingValues())
+                        val caughtExceptionEvent = appender.list.single {
+                            it.formattedMessage.startsWith("Caught ") && it.formattedMessage.endsWith(" exception")
+                        }
+                        caughtExceptionEvent.throwableProxy shouldBe null
+                    }
+                } finally {
+                    if (constraintAdded) {
+                        testDb.connection.use { connection ->
+                            connection.createStatement().use { statement ->
+                                statement.execute("ALTER TABLE unntaksvurdering DROP CONSTRAINT $constraintName")
+                            }
+                            connection.commit()
+                        }
+                    }
+                    logger.detachAppender(appender)
+                    appender.stop()
                 }
             }
 

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/UnntaksvurderingLoggingTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/service/UnntaksvurderingLoggingTest.kt
@@ -1,0 +1,110 @@
+package no.nav.syfo.oppfolgingsplan.service
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.spi.IThrowableProxy
+import ch.qos.logback.core.read.ListAppender
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import no.nav.syfo.TestDB
+import no.nav.syfo.defaultSykmeldt
+import no.nav.syfo.pdl.PdlService
+import org.slf4j.LoggerFactory
+
+const val SYNTHETIC_SYKMELDT_FNR = "00000000000"
+const val SYNTHETIC_NARMESTE_LEDER_FNR = "11111111111"
+const val SYNTHETIC_NARMESTE_LEDER_NAME = "SYNTHETIC_NARMESTE_LEDER_NAME"
+
+private fun IThrowableProxy.allMessages(): Sequence<String> = sequence {
+    message?.let { yield(it) }
+    if (!isCyclic) {
+        suppressed.forEach { yieldAll(it.allMessages()) }
+        cause?.let { yieldAll(it.allMessages()) }
+    }
+}
+
+fun Iterable<ILoggingEvent>.shouldNotContainSensitiveUnntaksvurderingData(
+    sensitiveValues: Collection<String>,
+) {
+    val fnrPattern = Regex("(?<!\\d)\\d{11}(?!\\d)")
+
+    forEach { event ->
+        val loggedValues = buildList {
+            add(event.formattedMessage)
+            event.throwableProxy?.allMessages()?.let(::addAll)
+            addAll(event.mdcPropertyMap.values)
+        }
+
+        loggedValues.forEach { value ->
+            sensitiveValues.none(value::contains) shouldBe true
+            fnrPattern.containsMatchIn(value) shouldBe false
+        }
+    }
+}
+
+class UnntaksvurderingLoggingTest :
+    DescribeSpec({
+        val testDb = TestDB.database
+        val pdlService = mockk<PdlService>()
+        val service = UnntaksvurderingService(testDb, pdlService)
+        val logger = LoggerFactory.getLogger(UnntaksvurderingService::class.qualifiedName) as Logger
+
+        beforeTest {
+            TestDB.clearAllData()
+        }
+
+        describe("createUnntaksvurdering") {
+            it("does not log synthetic identifiers or nearest leader name on success") {
+                val appender = ListAppender<ILoggingEvent>().apply { start() }
+                val originalLevel = logger.level
+                val sykmeldt = defaultSykmeldt().copy(fnr = SYNTHETIC_SYKMELDT_FNR)
+                coEvery { pdlService.getNameFor(SYNTHETIC_NARMESTE_LEDER_FNR) } returns SYNTHETIC_NARMESTE_LEDER_NAME
+                logger.level = Level.INFO
+                logger.addAppender(appender)
+
+                try {
+                    service.createUnntaksvurdering(SYNTHETIC_NARMESTE_LEDER_FNR, sykmeldt)
+
+                    appender.list.shouldNotContainSensitiveUnntaksvurderingData(
+                        listOf(
+                            SYNTHETIC_SYKMELDT_FNR,
+                            SYNTHETIC_NARMESTE_LEDER_FNR,
+                            SYNTHETIC_NARMESTE_LEDER_NAME,
+                        ),
+                    )
+                } finally {
+                    logger.level = originalLevel
+                    logger.detachAppender(appender)
+                    appender.stop()
+                }
+            }
+
+            it("detects synthetic identifiers in nested exception causes") {
+                val appender = ListAppender<ILoggingEvent>().apply { start() }
+                logger.addAppender(appender)
+
+                try {
+                    logger.error(
+                        "Test exception",
+                        IllegalStateException(
+                            "Outer exception",
+                            IllegalArgumentException(SYNTHETIC_NARMESTE_LEDER_FNR),
+                        ),
+                    )
+
+                    shouldThrow<AssertionError> {
+                        appender.list.shouldNotContainSensitiveUnntaksvurderingData(
+                            listOf(SYNTHETIC_NARMESTE_LEDER_FNR),
+                        )
+                    }
+                } finally {
+                    logger.detachAppender(appender)
+                    appender.stop()
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteUnntaksvurderingerTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/task/SoftDeleteUnntaksvurderingerTaskTest.kt
@@ -12,6 +12,10 @@ import io.mockk.mockk
 import no.nav.syfo.application.leaderelection.LeaderElection
 import no.nav.syfo.oppfolgingsplan.api.v1.COUNT_UNNTAKSVURDERING_SOFT_DELETED
 import no.nav.syfo.oppfolgingsplan.service.UnntaksvurderingService
+import no.nav.syfo.oppfolgingsplan.service.SYNTHETIC_NARMESTE_LEDER_FNR
+import no.nav.syfo.oppfolgingsplan.service.SYNTHETIC_NARMESTE_LEDER_NAME
+import no.nav.syfo.oppfolgingsplan.service.SYNTHETIC_SYKMELDT_FNR
+import no.nav.syfo.oppfolgingsplan.service.shouldNotContainSensitiveUnntaksvurderingData
 import org.slf4j.LoggerFactory
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
@@ -62,6 +66,39 @@ class SoftDeleteUnntaksvurderingerTaskTest :
                     appender.list.any {
                         it.level == Level.INFO &&
                             it.formattedMessage == "Found 0 expired unntaksvurderinger to soft-delete"
+                    } shouldBe true
+                } finally {
+                    logger.level = originalLevel
+                    logger.detachAppender(appender)
+                    appender.stop()
+                }
+            }
+
+            it("logs only static text and count when unntaksvurderinger are soft-deleted") {
+                val service = mockk<UnntaksvurderingService>()
+                val logger = LoggerFactory.getLogger(SoftDeleteUnntaksvurderingerTask::class.qualifiedName) as Logger
+                val appender = ListAppender<ILoggingEvent>().apply { start() }
+                val originalLevel = logger.level
+                coEvery { service.softDeleteExpiredUnntaksvurderinger() } returns 3
+                logger.level = Level.INFO
+                logger.addAppender(appender)
+
+                try {
+                    SoftDeleteUnntaksvurderingerTask(
+                        leaderElection = mockk<LeaderElection>(),
+                        unntaksvurderingService = service,
+                    ).execute()
+
+                    appender.list.shouldNotContainSensitiveUnntaksvurderingData(
+                        listOf(
+                            SYNTHETIC_SYKMELDT_FNR,
+                            SYNTHETIC_NARMESTE_LEDER_FNR,
+                            SYNTHETIC_NARMESTE_LEDER_NAME,
+                        ),
+                    )
+                    appender.list.any {
+                        it.level == Level.INFO &&
+                            it.formattedMessage == "Soft-deleted 3 expired unntaksvurderinger"
                     } shouldBe true
                 } finally {
                     logger.level = originalLevel


### PR DESCRIPTION
## Beskrivelse

Legger til regresjonsdekning som sikrer at fødselsnummer, navn og sensitiv unntaksvurderingskontekst ikke havner i applikasjonslogger ved normalflyt eller feil. Generiske serverfeil eksponerer eller logger ikke lenger rå exception-meldinger.

Risikoen er avgrenset til global feilrapportering: stacktrace fjernes fra ordinær `StatusPages`-logging for å unngå at vilkårlige exception-payloads lekker PII. Reviewer bør særlig vurdere denne avveiningen mot operasjonell feilsøking.

## Endringer

- `UnntaksvurderingLoggingTest`: kontrollerer loggmelding, MDC og hele exception-kjeden med syntetiske testdata.
- `UnntaksvurderingApiV1Test`: dekker conflict og databasefeil gjennom faktisk `StatusPages`-flyt.
- `SoftDeleteUnntaksvurderingerTaskTest`: verifiserer at task-logging kun inneholder statisk tekst og antall.
- `ApiPlugins`: returnerer statisk 500-melding og logger kun exception-type, uten throwable.
- Ikke i scope: GitHub-historikk, frontend/Faro, Loki og outbox uten direkte unntaksvurderingskobling.

## Issue

Relates to navikt/team-esyfo#193

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

Verifisert med målrettede tester og full `./gradlew build` med ktlint-worker-taskene ekskludert. Selve Gradle-ktlint-workerne kan ikke koble til lokal loopback i dette kjøremiljøet (`SocketException: Operation not permitted`), så lint-punktet står åpent.