### PR TITLE
fix(varsel): wait for Kafka delivery confirmation

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/application/kafka/KafkaConfig.kt
@@ -12,6 +12,10 @@ import java.util.Properties
 const val JAVA_KEYSTORE = "JKS"
 const val PKCS12 = "PKCS12"
 const val SSL = "SSL"
+internal const val BUDSTIKKA_MAX_BLOCK_MILLIS = 5_000
+internal const val BUDSTIKKA_REQUEST_TIMEOUT_MILLIS = 10_000
+internal const val BUDSTIKKA_DELIVERY_TIMEOUT_MILLIS = 20_000
+internal const val BUDSTIKKA_SEND_TIMEOUT_MILLIS = 25_000L
 
 fun commonProperties(env: KafkaEnv): Properties {
     val sslConfig = env.sslConfig
@@ -53,6 +57,13 @@ fun stringProducerProperties(env: KafkaEnv): Properties {
         put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer::class.java)
         put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer::class.java)
     }
+}
+
+internal fun budstikkaProducerProperties(env: KafkaEnv): Properties = stringProducerProperties(env).apply {
+    put(ProducerConfig.MAX_BLOCK_MS_CONFIG, BUDSTIKKA_MAX_BLOCK_MILLIS)
+    put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, BUDSTIKKA_REQUEST_TIMEOUT_MILLIS)
+    put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, BUDSTIKKA_DELIVERY_TIMEOUT_MILLIS)
+    put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true)
 }
 
 fun consumerProperties(env: KafkaEnv, groupId: String): Properties {

--- a/src/main/kotlin/no/nav/syfo/application/outbox/OutboxWorker.kt
+++ b/src/main/kotlin/no/nav/syfo/application/outbox/OutboxWorker.kt
@@ -22,6 +22,14 @@ import java.time.Duration.between
 import java.time.Instant
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
+import org.apache.kafka.common.errors.TimeoutException as KafkaTimeoutException
+
+internal const val OUTBOX_MESSAGE_PROCESSING_FAILED_EVENT = "outbox_message_processing_failed"
+internal const val OUTBOX_MESSAGE_RETRY_SCHEDULED_EVENT = "outbox_message_retry_scheduled"
+internal const val OUTBOX_BATCH_ABORTED_EVENT = "outbox_batch_aborted"
+internal const val PROCESS_OUTBOX_MESSAGE_OPERATION = "process_outbox_message"
+internal const val PROCESS_OUTBOX_BATCH_OPERATION = "process_outbox_batch"
+private const val CONSECUTIVE_FAILURE_LIMIT_REACHED = "CONSECUTIVE_FAILURE_LIMIT_REACHED"
 
 data class OutboxBatchResult(
     val sent: Int = 0,
@@ -145,10 +153,12 @@ class OutboxWorker(
                 consecutiveFailures++
                 incrementMetric(handler.messageType, "processing_failed")
                 log.error(
-                    "Failed to process claimed outbox message {} {} {}",
+                    "Failed to process claimed outbox message {} {} {} {} {}",
+                    kv("event_type", OUTBOX_MESSAGE_PROCESSING_FAILED_EVENT),
+                    kv("operation", PROCESS_OUTBOX_MESSAGE_OPERATION),
                     kv("outbox_uuid", message.uuid),
                     kv("message_type", handler.messageType.value),
-                    kv("error_type", e.javaClass.name),
+                    kv("exception_type", e.safeExceptionType()),
                 )
                 if (consecutiveFailures >= config.maxConsecutiveFailures) {
                     logBatchAbort(handler.messageType, consecutiveFailures)
@@ -167,11 +177,13 @@ class OutboxWorker(
                     consecutiveFailures++
                     result = result.copy(retryScheduled = result.retryScheduled + 1)
                     incrementMetric(handler.messageType, "retry_scheduled")
-                    log.error(
-                        "Failed to handle outbox message; retry scheduled {} {} {}",
+                    log.warn(
+                        "Failed to handle outbox message; retry scheduled {} {} {} {} {}",
+                        kv("event_type", OUTBOX_MESSAGE_RETRY_SCHEDULED_EVENT),
+                        kv("operation", PROCESS_OUTBOX_MESSAGE_OPERATION),
                         kv("outbox_uuid", message.uuid),
                         kv("message_type", handler.messageType.value),
-                        kv("error_type", attempt.cause.javaClass.name),
+                        kv("exception_type", attempt.cause.safeExceptionType()),
                     )
                 }
                 ProcessAttempt.ClaimLost -> {
@@ -227,7 +239,10 @@ class OutboxWorker(
 
     private fun logBatchAbort(messageType: OutboxMessageType, consecutiveFailures: Int) {
         log.error(
-            "Aborting outbox batch after consecutive failures {} {}",
+            "Aborting outbox batch after consecutive failures {} {} {} {} {}",
+            kv("event_type", OUTBOX_BATCH_ABORTED_EVENT),
+            kv("error_code", CONSECUTIVE_FAILURE_LIMIT_REACHED),
+            kv("operation", PROCESS_OUTBOX_BATCH_OPERATION),
             kv("message_type", messageType.value),
             kv("consecutive_failure_count", consecutiveFailures),
         )
@@ -261,6 +276,14 @@ class OutboxWorker(
             is OutboxResult.Cancelled -> "cancelled"
             is OutboxResult.Deferred -> "deferred"
         }
+
+    private fun Throwable.safeExceptionType(): String = when (this) {
+        is java.util.concurrent.TimeoutException -> "FutureTimeoutException"
+        is KafkaTimeoutException -> "KafkaTimeoutException"
+        is IllegalArgumentException -> "IllegalArgumentException"
+        is IllegalStateException -> "IllegalStateException"
+        else -> "UnknownException"
+    }
 
     private sealed interface ProcessAttempt {
         data class Processed(val outcome: OutboxResult) : ProcessAttempt

--- a/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
@@ -15,8 +15,8 @@ import no.nav.syfo.application.database.DatabaseConfig
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.application.isLocalEnv
 import no.nav.syfo.application.isProdEnv
+import no.nav.syfo.application.kafka.budstikkaProducerProperties
 import no.nav.syfo.application.kafka.producerProperties
-import no.nav.syfo.application.kafka.stringProducerProperties
 import no.nav.syfo.application.leaderelection.LeaderElection
 import no.nav.syfo.application.outbox.OutboxRetentionPolicy
 import no.nav.syfo.application.outbox.OutboxRetentionTask
@@ -72,7 +72,6 @@ import no.nav.syfo.varsel.budstikka.infrastructure.BudstikkaProducer
 import no.nav.syfo.varsel.budstikka.infrastructure.BudstikkaPublisher
 import no.nav.syfo.varsel.domain.EsyfovarselHendelse
 import org.apache.kafka.clients.producer.KafkaProducer
-import org.apache.kafka.clients.producer.ProducerConfig
 import org.koin.core.scope.Scope
 import org.koin.dsl.module
 import org.koin.ktor.plugin.Koin
@@ -232,10 +231,7 @@ private fun kafkeProducerModule() = module {
     single<BudstikkaPublisher> {
         BudstikkaProducer(
             KafkaProducer<String, String>(
-                stringProducerProperties(env().kafka)
-                    .apply {
-                        put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 5000)
-                    },
+                budstikkaProducerProperties(env().kafka),
             ),
             env().minSideSykmeldtOppfolgingsplanUrl,
             env().dineSykmeldteOversiktUrl,

--- a/src/main/kotlin/no/nav/syfo/varsel/budstikka/infrastructure/BudstikkaProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/budstikka/infrastructure/BudstikkaProducer.kt
@@ -20,8 +20,6 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import java.util.UUID
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
-import org.apache.kafka.common.errors.TimeoutException as KafkaTimeoutException
 
 private const val BRUKERVARSEL_CREATE = "BrukervarselCreate"
 private const val LEDERVARSEL_CREATE = "LedervarselCreate"
@@ -170,54 +168,9 @@ class BudstikkaProducer(
         )
         try {
             producer.send(record).get(BUDSTIKKA_SEND_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
-        } catch (e: TimeoutException) {
-            log.error(
-                "Publisert til akkumulator, timeout på get. Ukjent utfall {}, {}, {}",
-                kv("topic", dispatch.topic),
-                dispatchContext,
-                kv("event_id", eventId),
-                e,
-            )
-            throw e
-        } catch (e: KafkaTimeoutException) {
-            log.error(
-                "Publisering av Budstikka dispatch timet ut. Ikke levert {}, {}, {}",
-                kv("topic", dispatch.topic),
-                dispatchContext,
-                kv("event_id", eventId),
-                e,
-            )
-            throw e
         } catch (e: ExecutionException) {
             // Future.get wraps failures completed asynchronously by the Kafka producer.
-            val cause = e.cause as? Exception ?: e
-            if (cause is KafkaTimeoutException) {
-                log.error(
-                    "Publisering av Budstikka dispatch timet ut. Ikke levert {}, {}, {}",
-                    kv("topic", dispatch.topic),
-                    dispatchContext,
-                    kv("event_id", eventId),
-                    cause,
-                )
-            } else {
-                log.error(
-                    "Feilet ved publisering av Budstikka dispatch til {}, {}, {}",
-                    kv("topic", dispatch.topic),
-                    dispatchContext,
-                    kv("event_id", eventId),
-                    cause,
-                )
-            }
-            throw cause
-        } catch (e: Exception) {
-            log.error(
-                "Feilet ved publisering av Budstikka dispatch til {}, {}, {}",
-                kv("topic", dispatch.topic),
-                dispatchContext,
-                kv("event_id", eventId),
-                e,
-            )
-            throw e
+            throw (e.cause as? Exception ?: e)
         }
     }
 

--- a/src/main/kotlin/no/nav/syfo/varsel/budstikka/infrastructure/BudstikkaProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/budstikka/infrastructure/BudstikkaProducer.kt
@@ -13,10 +13,12 @@ import no.nav.budstikka.contract.Orgnummer
 import no.nav.budstikka.contract.PersonIdentifier
 import no.nav.budstikka.contract.SendingWindow
 import no.nav.budstikka.contract.Varseltype
+import no.nav.syfo.application.kafka.BUDSTIKKA_SEND_TIMEOUT_MILLIS
 import no.nav.syfo.util.logger
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import java.util.UUID
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import org.apache.kafka.common.errors.TimeoutException as KafkaTimeoutException
@@ -24,7 +26,6 @@ import org.apache.kafka.common.errors.TimeoutException as KafkaTimeoutException
 private const val BRUKERVARSEL_CREATE = "BrukervarselCreate"
 private const val LEDERVARSEL_CREATE = "LedervarselCreate"
 private const val ARBEIDSGIVERVARSEL_CREATE = "ArbeidsgivervarselCreate"
-private const val BUDSTIKKA_SEND_TIMEOUT_MILLIS = 250L
 private const val OPPFOLGING_TAG = "Oppfølging"
 const val OPPFOLGINGSPLAN_CREATED_BUDSTIKKA_TEXT = "Din arbeidsgiver har laget en oppfølgingsplan for deg"
 const val EVALUERINGS_PAAMINNELSE_TEXT = "Oppdater oppfølgingsplan"
@@ -187,6 +188,27 @@ class BudstikkaProducer(
                 e,
             )
             throw e
+        } catch (e: ExecutionException) {
+            // Future.get wraps failures completed asynchronously by the Kafka producer.
+            val cause = e.cause as? Exception ?: e
+            if (cause is KafkaTimeoutException) {
+                log.error(
+                    "Publisering av Budstikka dispatch timet ut. Ikke levert {}, {}, {}",
+                    kv("topic", dispatch.topic),
+                    dispatchContext,
+                    kv("event_id", eventId),
+                    cause,
+                )
+            } else {
+                log.error(
+                    "Feilet ved publisering av Budstikka dispatch til {}, {}, {}",
+                    kv("topic", dispatch.topic),
+                    dispatchContext,
+                    kv("event_id", eventId),
+                    cause,
+                )
+            }
+            throw cause
         } catch (e: Exception) {
             log.error(
                 "Feilet ved publisering av Budstikka dispatch til {}, {}, {}",

--- a/src/test/kotlin/no/nav/syfo/application/kafka/KafkaConfigTest.kt
+++ b/src/test/kotlin/no/nav/syfo/application/kafka/KafkaConfigTest.kt
@@ -1,0 +1,19 @@
+package no.nav.syfo.application.kafka
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.apache.kafka.clients.producer.ProducerConfig
+
+class KafkaConfigTest :
+    FunSpec({
+        test("Budstikka producer waits for Kafka's bounded delivery result") {
+            val properties = budstikkaProducerProperties(KafkaEnv.createForLocal())
+
+            properties[ProducerConfig.MAX_BLOCK_MS_CONFIG] shouldBe BUDSTIKKA_MAX_BLOCK_MILLIS
+            properties[ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG] shouldBe BUDSTIKKA_REQUEST_TIMEOUT_MILLIS
+            properties[ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG] shouldBe BUDSTIKKA_DELIVERY_TIMEOUT_MILLIS
+            properties[ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG] shouldBe true
+            (BUDSTIKKA_DELIVERY_TIMEOUT_MILLIS > BUDSTIKKA_REQUEST_TIMEOUT_MILLIS) shouldBe true
+            (BUDSTIKKA_SEND_TIMEOUT_MILLIS > BUDSTIKKA_DELIVERY_TIMEOUT_MILLIS) shouldBe true
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/application/outbox/OutboxWorkerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/application/outbox/OutboxWorkerTest.kt
@@ -1,5 +1,10 @@
 package no.nav.syfo.application.outbox
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.date.shouldBeAfter
@@ -11,6 +16,11 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import net.logstash.logback.encoder.LogstashEncoder
 import no.nav.syfo.TestDB
 import no.nav.syfo.application.metric.METRICS_NS
 import no.nav.syfo.application.metric.METRICS_REGISTRY
@@ -18,9 +28,11 @@ import no.nav.syfo.application.outbox.db.findOutboxMessage
 import no.nav.syfo.application.outbox.domain.OutboxCancellationReason
 import no.nav.syfo.application.outbox.domain.OutboxMessageType
 import no.nav.syfo.application.outbox.domain.OutboxStatus
+import org.slf4j.LoggerFactory
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
+import java.time.ZoneId
 import java.time.ZoneOffset
 import kotlin.time.Duration.Companion.INFINITE
 
@@ -133,6 +145,27 @@ class OutboxWorkerTest :
         }
 
         describe("technical failure and recovery") {
+            it("logs one canonical error when claimed message processing crashes") {
+                val message = TestDB.database.enqueueTestOutboxMessage()
+                val clock = FailOnceClock(now, failOnInvocation = 3)
+
+                val (result, logEvents) = captureOutboxWorkerLogs {
+                    OutboxWorker(TestDB.database, listOf(TestOutboxHandler()), clock).runOnce()
+                }
+
+                result shouldBe OutboxBatchResult()
+                TestDB.database.findOutboxMessage(message)?.status shouldBe OutboxStatus.CLAIMED
+
+                val errorLogs = logEvents.filter { it.level == Level.ERROR }.map { it.serializedJson() }
+                errorLogs.size shouldBe 1
+                errorLogs.single().value("event_type") shouldBe OUTBOX_MESSAGE_PROCESSING_FAILED_EVENT
+                errorLogs.single().value("operation") shouldBe PROCESS_OUTBOX_MESSAGE_OPERATION
+                errorLogs.single().value("message_type") shouldBe TEST_IMMEDIATE_MESSAGE.value
+                errorLogs.single().value("exception_type") shouldBe "IllegalStateException"
+                errorLogs.single().value("outbox_uuid") shouldBe message.uuid.toString()
+                errorLogs.single().toString().contains("synthetic clock failure") shouldBe false
+            }
+
             it("records a handler failure and applies the handler retry policy") {
                 val message = TestDB.database.enqueueTestOutboxMessage()
                 val retryAt = now.plusSeconds(15 * 60)
@@ -178,7 +211,9 @@ class OutboxWorkerTest :
                 val handler = TestOutboxHandler(outcome = { _, _ -> error("downstream unavailable") })
                 val config = OutboxWorkerConfig(maxConsecutiveFailures = 3)
 
-                val result = OutboxWorker(TestDB.database, listOf(handler), fixedClock, config).runOnce()
+                val (result, logEvents) = captureOutboxWorkerLogs {
+                    OutboxWorker(TestDB.database, listOf(handler), fixedClock, config).runOnce()
+                }
 
                 result shouldBe OutboxBatchResult(retryScheduled = 3)
                 messages.take(3).forEach { message ->
@@ -187,6 +222,24 @@ class OutboxWorkerTest :
                     persisted.failureCount shouldBeExactly 1
                 }
                 TestDB.database.findOutboxMessage(messages.last())?.status shouldBe OutboxStatus.CLAIMED
+
+                val retryLogs = logEvents.filter { it.level == Level.WARN }.map { it.serializedJson() }
+                retryLogs.size shouldBe 3
+                retryLogs.forEach { logEvent ->
+                    logEvent.value("event_type") shouldBe OUTBOX_MESSAGE_RETRY_SCHEDULED_EVENT
+                    logEvent.value("operation") shouldBe PROCESS_OUTBOX_MESSAGE_OPERATION
+                    logEvent.value("message_type") shouldBe TEST_IMMEDIATE_MESSAGE.value
+                    logEvent.value("exception_type") shouldBe "IllegalStateException"
+                    logEvent.toString().contains("downstream unavailable") shouldBe false
+                }
+
+                val errorLogs = logEvents.filter { it.level == Level.ERROR }.map { it.serializedJson() }
+                errorLogs.size shouldBe 1
+                errorLogs.single().value("event_type") shouldBe OUTBOX_BATCH_ABORTED_EVENT
+                errorLogs.single().value("error_code") shouldBe "CONSECUTIVE_FAILURE_LIMIT_REACHED"
+                errorLogs.single().value("operation") shouldBe PROCESS_OUTBOX_BATCH_OPERATION
+                errorLogs.single().value("message_type") shouldBe TEST_IMMEDIATE_MESSAGE.value
+                errorLogs.single().value("consecutive_failure_count") shouldBe "3"
             }
 
             it("leaves a cancelled worker claim for recovery after its lease expires") {
@@ -309,3 +362,48 @@ class OutboxWorkerTest :
             }
         }
     })
+
+private suspend fun <T> captureOutboxWorkerLogs(block: suspend () -> T): Pair<T, List<ILoggingEvent>> {
+    val logger = LoggerFactory.getLogger(OutboxWorker::class.java) as Logger
+    val appender = ListAppender<ILoggingEvent>().apply { start() }
+    logger.addAppender(appender)
+    return try {
+        block() to appender.list.toList()
+    } finally {
+        logger.detachAppender(appender)
+        appender.stop()
+    }
+}
+
+private fun ILoggingEvent.serializedJson(): JsonObject {
+    val encoder = LogstashEncoder().apply {
+        context = LoggerFactory.getILoggerFactory() as LoggerContext
+        start()
+    }
+    return try {
+        Json.parseToJsonElement(encoder.encode(this).decodeToString()).jsonObject
+    } finally {
+        encoder.stop()
+    }
+}
+
+private fun JsonObject.value(field: String): String = getValue(field).jsonPrimitive.content
+
+private class FailOnceClock(
+    private val currentInstant: Instant,
+    private val failOnInvocation: Int,
+) : Clock() {
+    private var invocation = 0
+
+    override fun getZone(): ZoneId = ZoneOffset.UTC
+
+    override fun withZone(zone: ZoneId): Clock = this
+
+    override fun instant(): Instant {
+        invocation++
+        if (invocation == failOnInvocation) {
+            error("synthetic clock failure")
+        }
+        return currentInstant
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/varsel/budstikka/BudstikkaProducerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/varsel/budstikka/BudstikkaProducerTest.kt
@@ -18,6 +18,7 @@ import no.nav.budstikka.contract.Orgnummer
 import no.nav.budstikka.contract.PersonIdentifier
 import no.nav.budstikka.contract.SendingWindow
 import no.nav.budstikka.contract.Varseltype
+import no.nav.syfo.application.kafka.BUDSTIKKA_SEND_TIMEOUT_MILLIS
 import no.nav.syfo.varsel.budstikka.infrastructure.BudstikkaProducer
 import no.nav.syfo.varsel.budstikka.infrastructure.EVALUERINGS_PAAMINNELSE_EMAIL_HTML
 import no.nav.syfo.varsel.budstikka.infrastructure.EVALUERINGS_PAAMINNELSE_EMAIL_TITLE
@@ -33,9 +34,11 @@ import org.apache.kafka.common.TopicPartition
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.util.UUID
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import org.apache.kafka.common.errors.TimeoutException as KafkaTimeoutException
 
 class BudstikkaProducerTest :
     DescribeSpec({
@@ -57,7 +60,9 @@ class BudstikkaProducerTest :
             publish: suspend () -> Unit,
         ) {
             val future = mockk<Future<RecordMetadata>>()
-            every { future.get(250, TimeUnit.MILLISECONDS) } returns createRecordMetadata()
+            every {
+                future.get(BUDSTIKKA_SEND_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+            } returns createRecordMetadata()
             every { kafkaProducerMock.send(any<ProducerRecord<String, String>>()) } returns future
 
             publish()
@@ -90,7 +95,9 @@ class BudstikkaProducerTest :
                     link = budstikkaOppfolgingsplanSykmeldtUrl,
                     sendingWindow = SendingWindow.BUDSTIKKA_OPENING_HOURS,
                 )
-                every { future.get(250, TimeUnit.MILLISECONDS) } returns createRecordMetadata()
+                every {
+                    future.get(BUDSTIKKA_SEND_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+                } returns createRecordMetadata()
                 every { kafkaProducerMock.send(any<ProducerRecord<String, String>>()) } returns future
 
                 producer.publishOppfolgingsplanCreated(
@@ -116,13 +123,17 @@ class BudstikkaProducerTest :
                         },
                     )
                 }
-                verify(exactly = 1) { future.get(250, TimeUnit.MILLISECONDS) }
+                verify(exactly = 1) {
+                    future.get(BUDSTIKKA_SEND_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+                }
             }
 
             it("rethrows exception when send confirmation times out") {
                 val failedFuture = mockk<Future<RecordMetadata>>()
                 val eventId = UUID.fromString("5fbc039e-b104-4554-809f-337d7ef804d0")
-                every { failedFuture.get(250, TimeUnit.MILLISECONDS) } throws TimeoutException("Forced")
+                every {
+                    failedFuture.get(BUDSTIKKA_SEND_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+                } throws TimeoutException("Forced")
                 every { kafkaProducerMock.send(any<ProducerRecord<String, String>>()) } returns failedFuture
 
                 val error = shouldThrow<Exception> {
@@ -134,7 +145,47 @@ class BudstikkaProducerTest :
                 }
 
                 error.message shouldContain "Forced"
-                verify(exactly = 1) { failedFuture.get(250, TimeUnit.MILLISECONDS) }
+                verify(exactly = 1) {
+                    failedFuture.get(BUDSTIKKA_SEND_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+                }
+            }
+
+            it("rethrows the Kafka cause when delivery times out asynchronously") {
+                val failedFuture = mockk<Future<RecordMetadata>>()
+                val eventId = UUID.fromString("5fbc039e-b104-4554-809f-337d7ef804d0")
+                val kafkaTimeout = KafkaTimeoutException("Delivery timed out")
+                every {
+                    failedFuture.get(BUDSTIKKA_SEND_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+                } throws ExecutionException(kafkaTimeout)
+                every { kafkaProducerMock.send(any<ProducerRecord<String, String>>()) } returns failedFuture
+
+                val error = shouldThrow<KafkaTimeoutException> {
+                    producer.publishOppfolgingsplanCreated(
+                        oppfolgingsplanUuid = UUID.fromString("0a5c80b8-2350-4f2a-b0e7-d1b796c6c8d4"),
+                        sykmeldtFnr = "12345678901",
+                        eventId = eventId,
+                    )
+                }
+
+                error shouldBe kafkaTimeout
+            }
+
+            it("rethrows a synchronous Kafka timeout from send") {
+                val eventId = UUID.fromString("5fbc039e-b104-4554-809f-337d7ef804d0")
+                val kafkaTimeout = KafkaTimeoutException("Metadata unavailable")
+                every {
+                    kafkaProducerMock.send(any<ProducerRecord<String, String>>())
+                } throws kafkaTimeout
+
+                val error = shouldThrow<KafkaTimeoutException> {
+                    producer.publishOppfolgingsplanCreated(
+                        oppfolgingsplanUuid = UUID.fromString("0a5c80b8-2350-4f2a-b0e7-d1b796c6c8d4"),
+                        sykmeldtFnr = "12345678901",
+                        eventId = eventId,
+                    )
+                }
+
+                error shouldBe kafkaTimeout
             }
         }
 
@@ -154,7 +205,9 @@ class BudstikkaProducerTest :
                     text = EVALUERINGS_PAAMINNELSE_TEXT,
                     sendingWindow = SendingWindow.ONGOING,
                 )
-                every { future.get(250, TimeUnit.MILLISECONDS) } returns createRecordMetadata()
+                every {
+                    future.get(BUDSTIKKA_SEND_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+                } returns createRecordMetadata()
                 every { kafkaProducerMock.send(any<ProducerRecord<String, String>>()) } returns future
 
                 producer.publishDineSykmeldteEvalueringspaaminnelse(
@@ -182,7 +235,9 @@ class BudstikkaProducerTest :
                         },
                     )
                 }
-                verify(exactly = 1) { future.get(250, TimeUnit.MILLISECONDS) }
+                verify(exactly = 1) {
+                    future.get(BUDSTIKKA_SEND_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+                }
             }
         }
 
@@ -210,7 +265,9 @@ class BudstikkaProducerTest :
                     messageType = Arbeidsgivervarsel.MessageType.BESKJED,
                     sendingWindow = SendingWindow.BUDSTIKKA_OPENING_HOURS,
                 )
-                every { future.get(250, TimeUnit.MILLISECONDS) } returns createRecordMetadata()
+                every {
+                    future.get(BUDSTIKKA_SEND_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+                } returns createRecordMetadata()
                 every { kafkaProducerMock.send(any<ProducerRecord<String, String>>()) } returns future
 
                 producer.publishMinSideArbeidsgiverEvalueringspaaminnelse(
@@ -234,7 +291,9 @@ class BudstikkaProducerTest :
                         },
                     )
                 }
-                verify(exactly = 1) { future.get(250, TimeUnit.MILLISECONDS) }
+                verify(exactly = 1) {
+                    future.get(BUDSTIKKA_SEND_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+                }
             }
         }
 


### PR DESCRIPTION
## Beskrivelse

Reduserer falske feil og unødvendige outbox-retries ved publisering av varsler til Budstikka. `KafkaProducer.send(...).get(250 ms)` ga opp lenge før Kafka-producerens egen leveringstimeout, mens sendingen fortsatte i bakgrunnen.

Loki-analysen viste 85 timeouts fordelt på 32 eventer og 11 avbrutte outbox-batcher. Alle 32 eventene ble mottatt av Budstikka og levert videre nøyaktig én gang, men retryene opprettet duplikate Kafka-records som Budstikka dedupliserte på `event_id`.

Ukjent utfall kaster fortsatt exception og går til outbox-retry. En rad markeres dermed ikke som `SENT` uten positiv Kafka-bekreftelse.

## Endringer

- `KafkaConfig`: legger til en egen Budstikka-konfigurasjon med `max.block.ms=5s`, `request.timeout.ms=10s`, `delivery.timeout.ms=20s` og eksplisitt `enable.idempotence=true`.
  - Idempotensinnstillingen håndhever deduplisering av Kafka-klientens interne retries i én producer-session og gjør fremtidige konfliktende innstillinger til konfigurasjonsfeil.
  - Den dedupliserer ikke separate outbox-forsøk eller forsøk etter restart; stabil `event_id` og Budstikkas deduplisering er fortsatt nødvendig.
- `BudstikkaProducer`: venter opptil 25 sekunder på Kafka-resultatet og pakker ut asynkrone Kafka-feil fra `ExecutionException`.
- `OutboxWorker`: eier loggingen av retry- og batchutfall for å unngå at samme feil blir `ERROR`-logget både i producer- og retrylaget.
  - retry som kan lykkes senere logges som `WARN` med `event_type=outbox_message_retry_scheduled`
  - uventet meldingsprosessering logges med `event_type=outbox_message_processing_failed`
  - batchavbrudd er den kanoniske terminale `ERROR`-hendelsen med `event_type=outbox_batch_aborted`, `error_code=CONSECUTIVE_FAILURE_LIMIT_REACHED` og `operation=process_outbox_batch`
  - dynamiske exception-meldinger og stacktraces legges ikke i disse loggene; `exception_type` kommer fra en lukket normalisering
- `DependencyInjection`: bruker den nye producer-konfigurasjonen kun for Budstikka.
- Tester: dekker timeoutrelasjonene, synkron timeout, asynkron delivery-timeout, fortsatt retry ved ukjent utfall og faktisk serialisert Logstash-JSON for de nye logghendelsene.

Loggingen følger runtime-feilkontrakten etablert i navikt/team-esyfo#248. Tre sammenhengende feil kan maksimalt bruke omtrent `(5s + 25s) × 3 = 90s`, som er innenfor outbox-workerens arbeidsbudsjett på 240 sekunder.

To uavhengige kode-reviewer fant ingen konkrete feil.

## Issue

Ingen issue. Endringen følger opp en produksjonsincident observert i Grafana/Loki.

## Sjekkliste

- [ ] Koden kompilerer og linter uten feil
  - Lokal `./gradlew build` stopper på eksisterende importrekkefølgefeil i to urørte testfiler på `main`: `OppfolgingsplanApiV1Test.kt` og `SoftDeleteUnntaksvurderingerTaskTest.kt`.
- [x] Endringene er testet automatisk
  - full `./gradlew test`
  - `BudstikkaProducerTest`
  - `KafkaConfigTest`
  - `OutboxWorkerTest`
  - `ktlintMainSourceSetCheck`
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
